### PR TITLE
Update desktop build to use create-dmg installer

### DIFF
--- a/scripts/desktop
+++ b/scripts/desktop
@@ -39,6 +39,22 @@ then
     fi
 fi
 
+# Check if create-dmg is installed, if not ask for user confirmation to install it using Homebrew
+if ! command -v create-dmg &> /dev/null
+then
+    echo "create-dmg is not installed."
+    read -p "Would you like to install create-dmg using Homebrew? (y/n) " -n 1 -r
+    echo    # Move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Installing create-dmg using Homebrew..."
+        brew install create-dmg
+    else
+        echo "create-dmg installation skipped. Exiting script."
+        exit 1
+    fi
+fi
+
 setup_trap
 
 cd "$(dirname "$0")/.."
@@ -139,19 +155,15 @@ if [ -n "$BUILD_MODE" ]; then
             DMG_PATH="./build/bin/kaja.dmg"
             rm -f "$DMG_PATH"
 
-            if command -v create-dmg &> /dev/null; then
-                create-dmg \
-                    --volname "kaja" \
-                    --window-size 600 400 \
-                    --icon-size 100 \
-                    --icon "kaja.app" 150 200 \
-                    --app-drop-link 450 200 \
-                    "$DMG_PATH" \
-                    "$APP_BUNDLE"
-            else
-                echo "create-dmg not found, using hdiutil..."
-                hdiutil create -volname "kaja" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG_PATH"
-            fi
+            create-dmg \
+                --volname "kaja" \
+                --volicon "./build/appicon.png" \
+                --window-size 600 400 \
+                --icon-size 100 \
+                --icon "kaja.app" 150 200 \
+                --app-drop-link 450 200 \
+                "$DMG_PATH" \
+                "$APP_BUNDLE"
 
             # Notarize DMG
             echo ""


### PR DESCRIPTION
- Add homebrew installation check for create-dmg (like Wails)
- Remove hdiutil fallback - create-dmg is now required
- Add --volicon flag to use appicon.png for nicer installer