### PR TITLE
Rebrand product name to Kaja

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - When I prompt you to make changes that are radically different from what's documented here, please update this file accordingly.
 - Don't commit changes to `kaja.json`
 - Use past tense in pull request titles and commit messages (e.g., "Fix bug" → "Fixed bug").
-- Use lower-case for the product name "kaja" in documentation, UIs, and labels.
+- Use capitalized "Kaja" for user-facing labels (titles, headings, UI text). Keep lowercase "kaja" for code, terminal commands, and file paths.
 
 ## Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Introduction
 
-`kaja` is an experimental, code-based UI for exploring and calling [Twirp](https://github.com/twitchtv/twirp) and [gRPC](https://grpc.io) APIs. Try the [live demo](https://kaja.tools/demo).
+Kaja is an experimental, code-based UI for exploring and calling [Twirp](https://github.com/twitchtv/twirp) and [gRPC](https://grpc.io) APIs. Try the [live demo](https://kaja.tools/demo).
 
 ![](docs/screenshot.png)
 
-You can embed `kaja` into your development workflow as a Docker container. A desktop version is coming later.
+You can embed Kaja into your development workflow as a Docker container. A desktop version is coming later.
 
 ```
 docker run --pull always --name kaja -d -p 41520:41520 \
@@ -18,15 +18,15 @@ docker run --pull always --name kaja -d -p 41520:41520 \
 
 `docker run` arguments explained:
 
-- `--pull always` - Always pull the latest image from Docker Hub. `kaja` is updated frequently.
+- `--pull always` - Always pull the latest image from Docker Hub. Kaja is updated frequently.
 - `--name kaja` - Name the container. Useful for managing multiple containers.
 - `-d` - Run the container in [detached mode](https://docs.docker.com/engine/reference/run/#detached--d).
-- `-p 41520:41520` - Expose the container's port 41520 on the host's port 41520. `kaja` listens on port 41520 by default.
-- `-v /my_app/proto:/workspace/proto` - Mount the `/my_app/proto` directory from the host file system into the container's `/workspace/proto` directory. `kaja` will recursively search for `.proto` files in the `/workspace` directory. `/my_app/proto` should be your application's [--proto_path](https://protobuf.dev/reference/cpp/api-docs/google.protobuf.compiler.command_line_interface/), the directory where your `.proto` files are located.
-- `-v /my_app/kaja.json:/workspace/kaja.json` - Mount the `kaja` [configuration file](#configuration) from the host file system into a predefined location where `kaja` expects it.
-- `--add-host=host.docker.internal:host-gateway` - Make the host's localhost accessible from the container. This is required for `kaja` to call Twirp and gRPC APIs running on the host.
+- `-p 41520:41520` - Expose the container's port 41520 on the host's port 41520. Kaja listens on port 41520 by default.
+- `-v /my_app/proto:/workspace/proto` - Mount the `/my_app/proto` directory from the host file system into the container's `/workspace/proto` directory. Kaja will recursively search for `.proto` files in the `/workspace` directory. `/my_app/proto` should be your application's [--proto_path](https://protobuf.dev/reference/cpp/api-docs/google.protobuf.compiler.command_line_interface/), the directory where your `.proto` files are located.
+- `-v /my_app/kaja.json:/workspace/kaja.json` - Mount the Kaja [configuration file](#configuration) from the host file system into a predefined location where Kaja expects it.
+- `--add-host=host.docker.internal:host-gateway` - Make the host's localhost accessible from the container. This is required for Kaja to call Twirp and gRPC APIs running on the host.
 - `-e AI_API_KEY="*****"` - Some [configuration options](#configuration) can also be provided as environment variables.
-- `kajatools/kaja:latest` - `kaja` is available on [Docker Hub](https://hub.docker.com/r/kajatools/kaja).
+- `kajatools/kaja:latest` - Kaja is available on [Docker Hub](https://hub.docker.com/r/kajatools/kaja).
 
 A minimal `kaja.json` [configuration file](#configuration) looks like this:
 
@@ -48,7 +48,7 @@ A minimal `kaja.json` [configuration file](#configuration) looks like this:
 
 # Configuration
 
-`kaja` is configured with a `kaja.json` file in the `/workspace` directory and/or environment variables.
+Kaja is configured with a `kaja.json` file in the `/workspace` directory and/or environment variables.
 
 Supported configuration options:
 

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -206,7 +206,7 @@ func main() {
 	app := NewApp(twirpHandler)
 
 	err = wails.Run(&options.App{
-		Title:  "kaja",
+		Title:  "Kaja",
 		Width:  1024,
 		Height: 768,
 		AssetServer: &assetserver.Options{

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "kaja",
-  "outputfilename": "kaja",
+  "name": "Kaja",
+  "outputfilename": "Kaja",
   "wailsjsdir": "../ui/src",
   "postBuildHooks": {
     "*/*": "../../../scripts/desktop-post-build ${bin}"
   },
   "info": {
-    "productName": "kaja",
+    "productName": "Kaja",
     "productVersion": "main",
     "copyright": "2026 Tomas Vesely"
   },

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -17,5 +17,5 @@
 
   <text x="90" y="52"
         font-family="Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-        font-size="44" font-weight="600" fill="#FFFFFF">kaja</text>
+        font-size="44" font-weight="600" fill="#FFFFFF">Kaja</text>
 </svg>

--- a/scripts/desktop
+++ b/scripts/desktop
@@ -109,7 +109,7 @@ if [ -n "$BUILD_MODE" ]; then
     echo "Building desktop app ($BUILD_MODE)..."
     wails build
 
-    APP_BUNDLE="./build/bin/kaja.app"
+    APP_BUNDLE="./build/bin/Kaja.app"
     if [ -d "$APP_BUNDLE" ]; then
         # Select signing profile based on build mode
         if [ "$BUILD_MODE" = "distribution" ]; then
@@ -130,7 +130,7 @@ if [ -n "$BUILD_MODE" ]; then
         if [ "$BUILD_MODE" = "distribution" ]; then
             echo ""
             echo "Notarizing app..."
-            APP_ZIP="./build/bin/kaja.zip"
+            APP_ZIP="./build/bin/Kaja.zip"
 
             # Create zip for notarization
             ditto -c -k --keepParent "$APP_BUNDLE" "$APP_ZIP"
@@ -152,15 +152,15 @@ if [ -n "$BUILD_MODE" ]; then
             # Create DMG
             echo ""
             echo "Creating DMG..."
-            DMG_PATH="./build/bin/kaja.dmg"
+            DMG_PATH="./build/bin/Kaja.dmg"
             rm -f "$DMG_PATH"
 
             create-dmg \
-                --volname "kaja" \
+                --volname "Kaja" \
                 --volicon "./build/appicon.png" \
                 --window-size 600 400 \
                 --icon-size 100 \
-                --icon "kaja.app" 150 200 \
+                --icon "Kaja.app" 150 200 \
                 --app-drop-link 450 200 \
                 "$DMG_PATH" \
                 "$APP_BUNDLE"

--- a/scripts/desktop-post-build
+++ b/scripts/desktop-post-build
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR/.."
 SERVER_BUILD="$PROJECT_ROOT/server/build"
 
-# Derive app bundle path from binary path (e.g., ./kaja.app/Contents/MacOS/kaja -> ./kaja.app)
+# Derive app bundle path from binary path (e.g., ./Kaja.app/Contents/MacOS/Kaja -> ./Kaja.app)
 if [[ "$BIN_PATH" == *.app/Contents/MacOS/* ]]; then
     APP_BUNDLE="${BIN_PATH%/Contents/MacOS/*}"
 elif [[ -d "${BIN_PATH}.app" ]]; then

--- a/server/pkg/api/compiler.go
+++ b/server/pkg/api/compiler.go
@@ -65,7 +65,7 @@ func (c *Compiler) start(id string, protoDir string) error {
 	c.stub = string(stub)
 
 	c.status = CompileStatus_STATUS_READY
-	c.logger.info("Compilation completed successfully, kaja is ready to go")
+	c.logger.info("Compilation completed successfully, Kaja is ready to go")
 
 	return nil
 }

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -7,7 +7,7 @@
     <link rel="mask-icon" href="./static/favicon.svg" color="#000000" />
     <link rel="stylesheet" href="./main.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>kaja</title>
+    <title>Kaja</title>
     <script type="importmap">
       {
         "imports": {

--- a/ui/src/GetStartedBlankslate.tsx
+++ b/ui/src/GetStartedBlankslate.tsx
@@ -15,7 +15,7 @@ export function GetStartedBlankslate() {
       <Blankslate.Visual>
         <RocketIcon size="medium" />
       </Blankslate.Visual>
-      <Blankslate.Heading>Welcome to kaja</Blankslate.Heading>
+      <Blankslate.Heading>Welcome to Kaja</Blankslate.Heading>
       <Blankslate.Description>
         Select a method from the sidebar to get started.
       </Blankslate.Description>


### PR DESCRIPTION
Updated user-facing labels to use capitalized "Kaja" while keeping lowercase "kaja" for code, terminal commands, and file paths.