### PR TITLE
Add headers tab to console for viewing request/response headers

### DIFF
--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -8,12 +8,18 @@ export class Kaja {
   }
 }
 
+export interface MethodCallHeaders {
+  [key: string]: string;
+}
+
 export interface MethodCall {
   service: Service;
   method: Method;
   input: any;
   output?: any;
   error?: any;
+  requestHeaders?: MethodCallHeaders;
+  responseHeaders?: MethodCallHeaders;
 }
 
 export interface MethodCallUpdate {


### PR DESCRIPTION

<img width="729" height="281" alt="image" src="https://github.com/user-attachments/assets/8a985033-e06a-4c8a-b543-7ae46fb53505" />


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-188/demo.gif)

### Home
![Home](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-188/home.png)

### Call
![Call](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-188/call.png)

### Compiler
![Compiler](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-188/compiler.png)

### New Project
![New Project](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-188/newproject.png)

</details>
