### PR TITLE
Live project configuration in clients

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,11 +7,10 @@ import { GetStartedBlankslate } from "./GetStartedBlankslate";
 import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Gutter } from "./Gutter";
-import { getDefaultMethod, Method, Project } from "./project";
+import { createProjectRef, getDefaultMethod, Method, Project, updateProjectRef } from "./project";
 import { Sidebar } from "./Sidebar";
 import { ProjectForm } from "./ProjectForm";
 import { remapEditorCode, remapSourcesToNewName } from "./sources";
-import { createClients } from "./projectLoader";
 import { Configuration, ConfigurationProject } from "./server/api";
 import { getApiClient } from "./server/connection";
 import { addDefinitionTab, addProjectFormTab, addTaskTab, getProjectFormTabIndex, getProjectFormTabLabel, getTabLabel, markInteraction, TabModel, updateProjectFormTab } from "./tabModel";
@@ -25,6 +24,7 @@ import { WindowSetTitle } from "./wailsjs/runtime";
 function createPendingProject(config: ConfigurationProject): Project {
   return {
     configuration: config,
+    projectRef: createProjectRef(config),
     compilation: { status: "pending", logs: [] },
     services: [],
     clients: {},
@@ -44,6 +44,8 @@ function applyProjectRename(project: Project, newConfig: ConfigurationProject): 
       editorCode: remapEditorCode(method.editorCode, originalName, newConfig.name),
     })),
   }));
+  // Update the existing projectRef in place so clients use new values
+  updateProjectRef(project.projectRef, newConfig);
   return {
     ...project,
     configuration: newConfig,
@@ -166,20 +168,14 @@ export function App() {
       const prev = existingProject.configuration;
       const protoDirChanged = prev.protoDir !== newConfig.protoDir;
       const useReflectionChanged = prev.useReflection !== newConfig.useReflection;
-      const urlChanged = prev.url !== newConfig.url;
-      const protocolChanged = prev.protocol !== newConfig.protocol;
-      const headersChanged = JSON.stringify(prev.headers || {}) !== JSON.stringify(newConfig.headers || {});
 
       if (protoDirChanged || useReflectionChanged) {
         // Needs recompilation
         disposeMonacoModelsForProject(existingProject.configuration.name);
         updatedProjects.push(createPendingProject(newConfig));
-      } else if (urlChanged || protocolChanged || headersChanged) {
-        // Recreate clients only
-        const newClients = createClients(existingProject.services, existingProject.stub, newConfig);
-        updatedProjects.push({ ...existingProject, configuration: newConfig, clients: newClients });
       } else {
-        // Just update configuration
+        // Update the projectRef in place - clients will pick up new URL/headers dynamically
+        updateProjectRef(existingProject.projectRef, newConfig);
         updatedProjects.push({ ...existingProject, configuration: newConfig });
       }
     }

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -1,8 +1,25 @@
 import { Kaja } from "./kaja";
 import { Sources, Stub } from "./sources";
 import { ConfigurationProject, Log } from "./server/api";
+
+// Mutable reference that clients read at request time for dynamic access to project properties
+export interface ProjectRef {
+  configuration: ConfigurationProject;
+}
+
+export function createProjectRef(configuration: ConfigurationProject): ProjectRef {
+  return {
+    configuration: { ...configuration, headers: { ...(configuration.headers || {}) } },
+  };
+}
+
+export function updateProjectRef(projectRef: ProjectRef, configuration: ConfigurationProject): void {
+  projectRef.configuration = { ...configuration, headers: { ...(configuration.headers || {}) } };
+}
+
 export interface Project {
   configuration: ConfigurationProject;
+  projectRef: ProjectRef;
   compilation: Compilation;
   services: Service[];
   clients: Clients;

--- a/ui/src/projectLoader.ts
+++ b/ui/src/projectLoader.ts
@@ -2,7 +2,7 @@ import { MethodInfo, ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import ts from "typescript";
 import { createClient } from "./client";
 import { addImport, defaultMessage } from "./defaultInput";
-import { Clients, Method, Project, Service } from "./project";
+import { Clients, createProjectRef, Method, Project, ProjectRef, Service } from "./project";
 import { Source as ApiSource, ConfigurationProject } from "./server/api";
 import { findInStub, findInterface, loadSources, parseStub, Source, Sources, Stub } from "./sources";
 
@@ -66,24 +66,27 @@ export async function loadProject(apiSources: ApiSource[], stubCode: string, con
     });
   });
 
+  const projectRef = createProjectRef(configuration);
+
   return {
     compilation: {
       status: "pending",
       logs: [],
     },
     configuration,
+    projectRef,
     services,
-    clients: createClients(services, stub, configuration),
+    clients: createClients(services, stub, projectRef),
     sources: kajaSources,
     stub,
   };
 }
 
-export function createClients(services: Service[], stub: Stub, configuration: ConfigurationProject): Clients {
+export function createClients(services: Service[], stub: Stub, projectRef: ProjectRef): Clients {
   const clients: Clients = {};
 
   for (const service of services) {
-    clients[service.name] = createClient(service, stub, configuration);
+    clients[service.name] = createClient(service, stub, projectRef);
   }
 
   return clients;


### PR DESCRIPTION
Dynamically respond to `kaja.json` changes.



<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-193/demo.gif)

### Home
![Home](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-193/home.png)

### Call
![Call](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-193/call.png)

### Compiler
![Compiler](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-193/compiler.png)

### New Project
![New Project](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-193/newproject.png)

</details>
