### PR TITLE
Fixed stub build error for proto files with hyphens in names

### DIFF
--- a/server/internal/ui/builder.go
+++ b/server/internal/ui/builder.go
@@ -113,9 +113,11 @@ func BuildStub(sourcesDir string) ([]byte, error) {
 			relativePath, _ := filepath.Rel(sourcesDir, path)
 			// Use namespace exports to avoid name collisions when multiple packages
 			// define the same enum name (e.g., basics.lib.Position and quirks.lib.Position)
+			relativePath = filepath.ToSlash(relativePath)
 			identifier := strings.TrimSuffix(relativePath, ".ts")
 			identifier = strings.ReplaceAll(identifier, "/", "$")
 			identifier = strings.ReplaceAll(identifier, ".", "$")
+			identifier = strings.ReplaceAll(identifier, "-", "$")
 			stubContent.WriteString("export * as " + identifier + " from \"./" + relativePath + "\";\n")
 		}
 		return nil

--- a/ui/src/sources.ts
+++ b/ui/src/sources.ts
@@ -31,7 +31,7 @@ export async function loadSources(apiSources: ApiSource[], stub: Stub, projectNa
 
     // Convert source path to stub module identifier
     // e.g., "basics/lib/enum.ts" -> "basics$lib$enum"
-    const stubModuleId = apiSource.path.replace(".ts", "").replace(/\//g, "$").replace(/\./g, "$");
+    const stubModuleId = apiSource.path.replace(".ts", "").replace(/\//g, "$").replace(/\./g, "$").replace(/-/g, "$");
     const stubModule = stub[stubModuleId] || {};
 
     const source: Source = {


### PR DESCRIPTION
Replaced hyphens with $ in generated JavaScript identifiers so
esbuild can parse them. Also normalized Windows backslash paths
with filepath.ToSlash.

https://claude.ai/code/session_015FxqCxdPfYRN2PEtZrGttR

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-200/demo.gif)

### Home
![Home](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-200/home.png)

### Call
![Call](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-200/call.png)

### Compiler
![Compiler](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-200/compiler.png)

### New Project
![New Project](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-200/newproject.png)

</details>
