### PR TITLE
Remove .ai_api_key from .dockerignore and .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,3 @@
 /desktop/frontend/dist
 /server/build
 /ui/node_modules
-
-.ai_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 /desktop/frontend/dist
 /server/build
 /ui/node_modules
-
-.ai_api_key


### PR DESCRIPTION
## Summary
Removed the `.ai_api_key` entry from both `.dockerignore` and `.gitignore` files.

## Changes
- Removed `.ai_api_key` line from `.dockerignore`
- Removed `.ai_api_key` line from `.gitignore`
- Removed trailing blank lines from both files

## Notes
This change indicates that `.ai_api_key` files will now be tracked by Git and included in Docker builds. If this file contains sensitive information, please ensure appropriate security measures are in place (such as using environment variables or secrets management) before merging.

https://claude.ai/code/session_01GwjfEtgFx4wLE3TFcTMxas

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-214/demo.gif)

### Home
![Home](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-214/home.png)

### Call
![Call](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-214/call.png)

### Compiler
![Compiler](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-214/compiler.png)

### New Project
![New Project](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-214/newproject.png)

</details>
