### PR TITLE
Add relative timestamps to console method calls

### DIFF
--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -75,6 +75,7 @@ export function createClient(service: Service, stub: Stub, projectRef: ProjectRe
         input,
         requestHeaders,
         url: isTwirp ? `${projectRef.configuration.url.replace(/\/$/, "")}/twirp/${serviceId(service)}/${method.name}` : undefined,
+        timestamp: Date.now(),
       };
       client.kaja?._internal.methodCallUpdate(methodCall);
 

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -28,6 +28,7 @@ export interface MethodCall {
   requestHeaders?: MethodCallHeaders;
   responseHeaders?: MethodCallHeaders;
   url?: string;
+  timestamp: number;
 }
 
 export interface MethodCallUpdate {


### PR DESCRIPTION
Inspired by Bruno. Thanks @barehands-io for the idea.

<img width="292" height="272" alt="image" src="https://github.com/user-attachments/assets/04966df6-0b02-4fd0-936f-cc8bf397ae62" />

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-216/demo.gif)

### Home
![Home](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-216/home.png)

### Call
![Call](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-216/call.png)

### Compiler
![Compiler](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-216/compiler.png)

### New Project
![New Project](https://raw.githubusercontent.com/wham/kaja/demo-assets/pr-216/newproject.png)

</details>
