### PR TITLE
Removed unused network.server entitlement

### DIFF
--- a/desktop/build/darwin/entitlements.plist
+++ b/desktop/build/darwin/entitlements.plist
@@ -14,9 +14,6 @@
     <key>com.apple.security.network.client</key>
     <true/>
 
-    <key>com.apple.security.network.server</key>
-    <true/>
-
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
 

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -5,7 +5,7 @@
   "wailsjsdir": "../ui/src",
   "info": {
     "productName": "Kaja",
-    "productVersion": "0.8.2",
+    "productVersion": "0.8.3",
     "copyright": "2026 Tomas Vesely"
   },
   "author": {


### PR DESCRIPTION
Removed `com.apple.security.network.server` entitlement to fix App Store review rejection (guideline 2.4.5(i)). The desktop app doesn't accept incoming connections.

https://claude.ai/code/session_01Tbq49ySQ8wcYACHKiSY5HV


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-269-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-269-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-269-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-269-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-269-newproject.png)

</details>
