### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - "main"
+permissions:
+  contents: read
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wham/kaja/security/code-scanning/3](https://github.com/wham/kaja/security/code-scanning/3)

Add an explicit `permissions` block to the workflow YAML.  
Best fix without changing functionality: define workflow-level minimal permissions needed by current steps. For this file, `actions/checkout` requires `contents: read`; no other `GITHUB_TOKEN` write scopes are needed for the shown steps (Docker Hub login/push uses secrets). So add:

```yaml
permissions:
  contents: read
```

Place it at the workflow root (after `on:` block and before `jobs:`), so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-274-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-274-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-274-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-274-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-274-newproject.png)

</details>
