### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -2,6 +2,9 @@ name: desktop
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wham/kaja/security/code-scanning/1](https://github.com/wham/kaja/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/desktop.yml` at the workflow root so all jobs inherit least-privilege defaults.  
Best single fix here is:

- Add:
  - `permissions:`
  - `  contents: read`

Place it after the `on:` trigger block (before `jobs:`), so it applies to `macos` and any future jobs unless overridden. This does not change build behavior and satisfies CodeQL’s minimum recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-275-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-275-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-275-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-275-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-275-newproject.png)

</details>
