### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   demo:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wham/kaja/security/code-scanning/2](https://github.com/wham/kaja/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (or job level) with only the scopes required by current steps:

- `contents: write` (needed for GitHub Release create/upload/delete asset operations)
- `pull-requests: write` (needed for editing PR description)
- `actions: read` (safe minimal read for actions metadata; optional but commonly included)
  
The single best fix without changing functionality is to add this block near the top of `.github/workflows/demo.yml`, directly under `on:` (or under `name:` before `on:`), so all jobs inherit it. Since there is only one job, root-level is clean and future-proof.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-276-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-276-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-276-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-276-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-276-newproject.png)

</details>
