### PR TITLE
Added Wails skill and updated dependency to v2.12.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "enabledPlugins": {
-    "chrome-devtools-mcp@chrome-devtools-plugins": true
-  },
   "hooks": {
     "PostToolUse": [
       {
@@ -14,5 +11,9 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "chrome-devtools-mcp@chrome-devtools-plugins": true,
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/.claude/skills/wails/SKILL.md
+++ b/.claude/skills/wails/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: wails
+description: Quick reference for Wails v2, the Go + native-webview desktop framework. Use whenever the task touches a Wails project — `wails.json`, `wails.Run`, `options.App`, `assetserver`, the Go ↔ JS bindings under `frontend/wailsjs/`, the runtime API (`runtime.WindowSetTitle`, `runtime.EventsEmit`, `window.runtime.*`), `wails build` / `wails dev` / `wails generate`, embedded `frontend/dist`, dev-server hot reload, code signing, or anything in `desktop/main.go` that wires up a Wails app. Also use when the user mentions WebView2, WebKitGTK, or "the desktop build."
+---
+
+# Wails v2
+
+Wails builds desktop apps from a Go backend and a web frontend that runs inside the platform's **native webview** — WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux. There is no embedded Chromium. The Go process and the webview talk via generated JS wrappers and an IPC runtime.
+
+## Mental model
+
+```
+┌─────────────── Go process ───────────────┐
+│  main.go: wails.Run(&options.App{...})   │
+│  Bind: []interface{}{ app }              │
+│  AssetServer.Assets: embed.FS            │
+│                                          │
+│  context.Context  ──► runtime.* (Go)     │
+│        ▲                                 │
+└────────┼─────────────────────────────────┘
+         │  IPC bridge (custom URL scheme)
+┌────────┼─────────────────────────────────┐
+│  webview                                 │
+│   import { Method } from                 │
+│     "../wailsjs/go/<pkg>/<Struct>";      │
+│   import { EventsOn } from               │
+│     "../wailsjs/runtime";                │
+│   // also window.runtime.*               │
+└──────────────────────────────────────────┘
+```
+
+Two key auto-generated trees inside the frontend:
+
+- `frontend/wailsjs/go/<pkg>/<Struct>.{js,d.ts}` — JS wrappers for every exported method of every value in `Bind`. Calls return Promises.
+- `frontend/wailsjs/runtime/runtime.{js,d.ts}` — the JS side of the runtime (window, dialog, events, log, browser, screen, clipboard, drag-drop). Also reachable via `window.runtime.*`.
+
+Both regenerate on `wails dev` / `wails build`. Don't hand-edit them, don't commit them.
+
+> Note: `wailsjsdir` in `wails.json` can relocate that tree. In this repo it points to `../ui/src`, so generated bindings land at `ui/src/wailsjs/`.
+
+## Project layout (template default)
+
+```
+.
+├── app.go            # bound App struct (NewApp, methods, ctx capture)
+├── main.go           # wails.Run + //go:embed all:frontend/dist
+├── wails.json        # project config
+├── go.mod
+├── build/
+│   ├── appicon.png   # source icon
+│   ├── darwin/       # Info.plist (+ Info.dev.plist for `wails dev`)
+│   └── windows/      # icon.ico, info.json, manifest, NSIS templates
+└── frontend/
+    ├── package.json
+    ├── src/
+    ├── dist/         # build output, embedded by go:embed
+    └── wailsjs/      # generated; gitignored
+```
+
+Production binary lands in `build/bin/<name>[.exe|.app]`.
+
+## The cheatsheet
+
+```bash
+# Install / update CLI
+go install github.com/wailsapp/wails/v2/cmd/wails@latest
+wails doctor                       # diagnose toolchain & system deps
+
+# New project
+wails init -n MyApp -t react-ts    # templates: vanilla|svelte|react|vue|preact|lit (+ -ts)
+
+# Develop (hot reload, dev server on :34115)
+wails dev
+wails dev -assetdir ./frontend/dist          # serve assets from disk
+wails dev -frontenddevserverurl auto         # hand off to Vite (auto-detect port)
+wails dev -tags webkit2_41                   # Ubuntu 24.04+
+
+# Build
+wails build
+wails build -platform darwin/universal,windows/amd64
+wails build -clean -trimpath -ldflags "-X main.GitRef=$(git rev-parse HEAD)"
+wails build -nsis -webview2 embed            # Windows installer w/ embedded WebView2
+wails build -debug -devtools                 # devtools in production binary
+
+# Regenerate JS bindings only (rare; dev/build do it automatically)
+wails generate module
+```
+
+`wails dev` watches Go files (`-extensions go`) for rebuilds and asset files (`-reloaddirs`, `-debounce`) for frontend reload. It also exposes the running app on `http://localhost:34115` so you can use real browser devtools.
+
+## Where to read deeper
+
+Pull these in only when the task actually needs them:
+
+- **CLI flags** — every flag for `init`, `build`, `dev`, `generate`, `doctor`, `update`. → `references/cli.md`
+- **`wails.json`** — every field, hooks, `${platform}` substitution, file associations, NSIS type. → `references/config.md`
+- **`options.App`** — window/lifecycle/asset-server/menu/bind/error-formatter, plus per-platform `mac.Options`, `windows.Options`, `linux.Options`. → `references/options.md`
+- **Bindings** — how Go methods become JS, JSON tags, `context.Context` injection, error/Promise mapping, enum binding. → `references/bindings.md`
+- **Runtime API** — full Go + JS surface for window, dialog, events, log, browser, screen, menu, clipboard, drag-drop, notifications. → `references/runtime.md`
+- **Gotchas** — WebView2/WebKitGTK quirks, vite-5 incompat, OnStartup vs OnDomReady, single-instance lock, panic recovery, Linux signal handlers. → `references/gotchas.md`
+
+## Working rules
+
+- **Don't run `wails build` to "check it compiles"** — it builds the frontend too and is slow. Use `go build -tags desktop` or whatever the project's dev script is. In this repo, prefer `scripts/desktop`.
+- **Bind takes instances, not types**: `Bind: []interface{}{app}`, with `app := NewApp()`.
+- **Capture `ctx` in `OnStartup`** and store it on the bound struct — runtime calls need it. `OnDomReady` is the safe place for runtime calls that touch the window.
+- **Struct fields without `json` tags are invisible** to the generated TS. Anonymous nested structs aren't supported.
+- **First `context.Context` parameter is auto-injected** — the JS-facing signature drops it.
+- **Errors propagate as Promise rejections.** Customise the JSON shape with `options.ErrorFormatter`.
+- **`wailsjs/` is generated.** If types look wrong, regenerate (`wails generate module`) before debugging.
+- **Production assets are embedded** via `//go:embed all:frontend/dist`. The `all:` prefix is required to include dotfiles.
+- **Cross-compilation** through `-platform a,b,c` works for Windows/Linux/Mac — but not all combinations (no Linux→macOS without extra toolchain). `darwin/universal` produces a fat binary.
+- **Code signing & notarisation** are outside Wails — run `codesign` / `notarytool` on the produced `.app`.

--- a/.claude/skills/wails/references/bindings.md
+++ b/.claude/skills/wails/references/bindings.md
@@ -1,0 +1,137 @@
+# Bindings (Go ↔ JS)
+
+`Bind: []interface{}{ app, &otherStruct{} }` in `options.App` exposes **instances** to JS. Wails reflects over each value, picks up exported methods, and emits JS wrappers + TypeScript declarations.
+
+## Generated tree
+
+```
+frontend/wailsjs/                    # or wherever wailsjsdir points
+├── go/
+│   ├── <pkg>/<Struct>.js            # function wrappers
+│   ├── <pkg>/<Struct>.d.ts          # TS declarations
+│   └── models.ts                    # Go struct → TS class/interface
+└── runtime/
+    ├── runtime.js
+    └── runtime.d.ts
+```
+
+Regeneration is automatic on `wails dev` and `wails build`. Manual: `wails generate module`. Don't commit this tree.
+
+## Method conventions
+
+- Methods must be **exported** (uppercase first letter).
+- If the first parameter is `context.Context`, Wails injects the app context — the JS-facing signature drops it.
+- Return shapes Wails understands: `(T)`, `(T, error)`, `error`. Errors → JS `Promise` reject; success values → resolve.
+- Argument and return types: scalars, slices, maps, structs.
+- Struct fields **must have a `json` tag** to appear in generated TS.
+- Anonymous nested structs are not supported.
+- Pointers to structs are fine.
+
+```go
+type Person struct {
+    Name string `json:"name"`
+    Age  int    `json:"age"`
+}
+
+type App struct{ ctx context.Context }
+
+func (a *App) startup(ctx context.Context) { a.ctx = ctx }
+
+// JS: Greet(p: main.Person): Promise<string>
+func (a *App) Greet(p Person) (string, error) {
+    if p.Name == "" {
+        return "", fmt.Errorf("missing name")
+    }
+    return "Hello " + p.Name, nil
+}
+
+// JS: TouchedAt(): Promise<string>      // ctx auto-injected
+func (a *App) TouchedAt(ctx context.Context) string {
+    return time.Now().Format(time.RFC3339)
+}
+```
+
+## JS usage
+
+```js
+import { Greet } from "../wailsjs/go/main/App";
+import { main } from "../wailsjs/go/models";
+
+const p = new main.Person();
+p.name = "Ada"; p.age = 36;
+
+Greet(p)
+  .then(console.log)
+  .catch(err => console.error(err));   // err is whatever ErrorFormatter returned
+```
+
+Internally the wrapper calls `window.go.<pkg>.<Struct>.<Method>(...)` — the global is also there if you need to call by name.
+
+## Custom error format
+
+```go
+options.App{
+    ErrorFormatter: func(err error) any {
+        var c *MyCodedError
+        if errors.As(err, &c) {
+            return map[string]any{"code": c.Code, "message": c.Message}
+        }
+        return err.Error()
+    },
+}
+```
+
+The returned value is JSON-marshalled and becomes the JS rejection.
+
+## Enum binding
+
+Wails can emit TS string-union or class enums for Go-defined enums when you supply metadata.
+
+```go
+type Status int
+const (
+    StatusActive Status = iota
+    StatusPaused
+    StatusArchived
+)
+
+var AllStatuses = []struct {
+    Value  Status
+    TSName string
+}{
+    {StatusActive, "ACTIVE"},
+    {StatusPaused, "PAUSED"},
+    {StatusArchived, "ARCHIVED"},
+}
+
+options.App{
+    EnumBind: []interface{}{ AllStatuses },
+}
+```
+
+The metadata appears in `models.ts`.
+
+## TS output style
+
+`wails.json`:
+
+```json
+{
+  "bindings": {
+    "ts_generation": {
+      "prefix": "",
+      "suffix": "",
+      "outputType": "classes"   // or "interfaces"
+    }
+  }
+}
+```
+
+`classes` (default) emits constructable wrappers: `new main.Person()`. `interfaces` emits plain `export interface` types — pair with frontend code that builds objects via spread/literal.
+
+## When bindings look stale
+
+- Run `wails generate module` to force regen
+- Confirm `wailsjsdir` in `wails.json` is pointing where the frontend imports from
+- A method without `json` tags on its struct types will silently produce empty TS
+- A method whose only return is a non-error type other than `(T)` or `(T, error)` won't be exposed

--- a/.claude/skills/wails/references/cli.md
+++ b/.claude/skills/wails/references/cli.md
@@ -1,0 +1,112 @@
+# Wails CLI
+
+All commands: `wails <command> [flags]`.
+
+## `wails init` — scaffold a new project
+
+| Flag | Description | Default |
+|---|---|---|
+| `-n "name"` | Project name (required) | — |
+| `-d "dir"` | Project directory | name |
+| `-t "template"` | Template name or remote URL | `vanilla` |
+| `-g` | Init git repo | |
+| `-l` | List built-in templates | |
+| `-q` | Quiet | |
+| `-ide vscode\|goland` | Generate IDE files | |
+| `-f` | Overwrite if dir exists | false |
+
+Built-in templates: `vanilla`, `svelte`, `react`, `vue`, `preact`, `lit` — each also as `-ts` (e.g. `react-ts`).
+
+Remote: `wails init -n test -t https://github.com/leaanthony/testtemplate@v1.0.0`.
+
+## `wails build` — production build
+
+Outputs to `build/bin/`.
+
+| Flag | Description |
+|---|---|
+| `-platform list` | `darwin`, `darwin/amd64`, `darwin/arm64`, `darwin/universal`, `windows`, `windows/amd64`, `windows/arm64`, `linux/amd64`, `linux/arm64`. Comma-separated. |
+| `-clean` | Wipe `build/bin` first |
+| `-debug` | Keep debug info, show debug console, enable devtools |
+| `-devtools` | Enable devtools in production (Mac App Store reject risk) |
+| `-dryrun` | Print build command without running |
+| `-f` | Force rebuild |
+| `-ldflags "..."` | Extra `-ldflags` for Go |
+| `-tags "..."` | Build tags. Quoted; space- or comma-separated, not both |
+| `-trimpath` | `go build -trimpath` |
+| `-race` | Race detector |
+| `-o filename` | Output binary name |
+| `-nopackage` | No `.app` / installer wrapping |
+| `-nsis` | Generate NSIS installer (Windows) |
+| `-webview2 strategy` | Installer behaviour: `download` (default), `embed`, `browser`, `error` |
+| `-windowsconsole` | Keep Windows console window |
+| `-upx` | Compress binary with UPX |
+| `-upxflags "..."` | Args for UPX |
+| `-obfuscated` | Obfuscate via [garble](https://github.com/burrowers/garble) |
+| `-garbleargs "..."` | Args for garble (default `-literals -tiny -seed=random`) |
+| `-s` | Skip frontend build |
+| `-skipbindings` | Skip `wailsjs/go/...` regeneration |
+| `-skipembedcreate` | Don't auto-create missing embed dirs / `.gitkeep` files |
+| `-m` | Skip `go mod tidy` |
+| `-u` | Update `go.mod` to match CLI's Wails version |
+| `-nosyncgomod` | Don't touch `go.mod` Wails version |
+| `-compiler "go"` | Alternative go compiler |
+| `-nocolour` | Disable coloured output |
+| `-v 0\|1\|2` | Verbosity (default 1) |
+
+Override macOS minimum target:
+```bash
+CGO_CFLAGS=-mmacosx-version-min=10.15.0 \
+CGO_LDFLAGS=-mmacosx-version-min=10.15.0 \
+wails build
+```
+
+## `wails dev` — development with hot reload
+
+Compiles, runs the binary, watches files. Exposes the app on `http://localhost:34115` (any browser can connect — useful for browser devtools).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-assetdir "./path"` | Serve assets from disk instead of embed.FS | from `wails.json` |
+| `-extensions "go,..."` | File extensions that trigger Go rebuild | `go` |
+| `-reloaddirs "a,b"` | Extra dirs to watch for asset reload | from `wails.json` |
+| `-debounce N` | Debounce ms for asset reload | 100 |
+| `-devserver "host:port"` | Dev server bind address | `localhost:34115` |
+| `-frontenddevserverurl url\|auto` | Hand off to a 3rd-party dev server (Vite, etc.). `auto` parses Vite's stdout. | `""` |
+| `-viteservertimeout N` | Seconds to wait for Vite when `auto` | 10 |
+| `-browser` | Open `http://localhost:34115` on start | |
+| `-noreload` | Disable auto-reload on asset change | |
+| `-loglevel "Debug"` | Trace, Debug, Info, Warning, Error | Debug |
+| `-appargs "..."` | Args passed to your app (shell-quoted) | |
+| `-tags "..."` | Build tags | |
+| `-ldflags "..."` | Extra ldflags | |
+| `-race` | Race detector | false |
+| `-s` | Skip frontend build | |
+| `-skipbindings` | Skip `wailsjs/go/...` regeneration | |
+| `-skipembedcreate` | Skip embed dir creation | |
+| `-forcebuild` | Force build | |
+| `-wailsjsdir` | Where to emit JS modules | from `wails.json` |
+| `-save` | Persist `assetdir`/`reloaddirs`/`wailsjsdir`/`debounce`/`devserver`/`frontenddevserverurl`/`viteservertimeout` to `wails.json` | |
+| `-nosyncgomod` | Don't sync `go.mod` | false |
+| `-compiler "go"` | Alternative compiler | go |
+| `-v 0\|1\|2` | Verbosity | 1 |
+
+## `wails generate`
+
+- `wails generate module [-compiler go] [-tags "..."]` — manually regenerate `frontend/wailsjs/`. `dev`/`build` do it automatically.
+- `wails generate template -name <name> [-frontend <path>]` — scaffold a new template from an existing frontend project.
+
+## `wails doctor`
+
+Checks Go, Node, npm, pkg-config, gcc, libgtk, libwebkit, WebView2, NSIS, UPX, etc. Run when something feels off.
+
+## `wails update`
+
+| Flag | Description |
+|---|---|
+| `-pre` | Update to latest pre-release |
+| `-version <ver>` | Pin to a specific version |
+
+## `wails version`
+
+Prints the CLI version. Combine with `go list -m github.com/wailsapp/wails/v2` to confirm CLI ≈ library version.

--- a/.claude/skills/wails/references/config.md
+++ b/.claude/skills/wails/references/config.md
@@ -1,0 +1,129 @@
+# `wails.json`
+
+Project config consumed by `wails dev` and `wails build`. JSON schema: `https://wails.io/schemas/config.v2.json`.
+
+## Full field list
+
+```json5
+{
+  "$schema": "https://wails.io/schemas/config.v2.json",
+  "version": "",
+  "name": "",                          // app/project name
+  "outputfilename": "",                // resulting binary name (no extension)
+
+  // Dirs
+  "build:dir": "",                     // default: "build"
+  "frontend:dir": "",                  // default: "frontend"
+  "wailsjsdir": "",                    // where generated JS modules go (default: frontend/)
+  "assetdir": "",                      // compiled-assets dir (auto-detected if empty)
+
+  // Frontend hooks
+  "frontend:install": "",              // e.g. "npm install"
+  "frontend:build": "",                // e.g. "npm run build"
+  "frontend:dev": "",                  // legacy; falls back to frontend:build
+  "frontend:dev:install": "",          // dev counterpart of frontend:install
+  "frontend:dev:build": "",            // dev counterpart of frontend:build
+  "frontend:dev:watcher": "",          // long-running process during `wails dev` (e.g. "npm run dev")
+  "frontend:dev:serverUrl": "",        // 3rd-party dev server URL, or "auto" (Vite)
+  "viteServerTimeout": 10,
+
+  // Watch / dev
+  "reloaddirs": "",                    // extra dirs that trigger reload (comma)
+  "debounceMS": 100,
+  "devServer": "",                     // default: "localhost:34115"
+  "appargs": "",                       // args for the app in dev mode
+
+  // Build hooks. Keys are GOOS/GOARCH; "*" matches anything
+  "runNonNativeBuildHooks": false,
+  "preBuildHooks":  { "GOOS/GOARCH": "", "GOOS/*": "", "*/*": "" },
+  "postBuildHooks": { "GOOS/GOARCH": "", "GOOS/*": "", "*/*": "" },
+
+  // Build flags / metadata
+  "build:tags": "",                    // tags applied to all builds
+  "obfuscated": "",
+  "garbleargs": "",
+  "nsisType": "",                      // "multiple" (per-arch) | "single" (universal)
+
+  // App info
+  "info": {
+    "companyName": "",
+    "productName": "",
+    "productVersion": "",
+    "copyright": "",
+    "comments": "",
+    "fileAssociations": [
+      {
+        "ext": "wails",
+        "name": "Wails",
+        "description": "Wails File",
+        "iconName": "fileIcon",
+        "role": "Editor"
+      }
+    ],
+    "protocols": [
+      { "scheme": "myapp", "description": "MyApp Protocol", "role": "Editor" }
+    ]
+  },
+
+  "author": { "name": "", "email": "" },
+
+  // Bindings codegen
+  "bindings": {
+    "ts_generation": {
+      "prefix": "",
+      "suffix": "",
+      "outputType": "classes"          // "classes" | "interfaces"
+    }
+  }
+}
+```
+
+## Hook substitution
+
+In `preBuildHooks` / `postBuildHooks`:
+
+- `${platform}` → `GOOS/GOARCH` (e.g. `darwin/arm64`)
+- `${bin}` → path to compiled binary (post hooks only)
+
+Hook resolution order: `GOOS/GOARCH` runs first, then `GOOS/*`, then `*/*`. Non-matching hooks are skipped. Set `runNonNativeBuildHooks: true` to also run hooks for non-host platforms.
+
+## `wails dev` `-save` behaviour
+
+The `-save` flag persists the following dev-only flags into `wails.json`:
+
+- `assetdir`
+- `reloaddirs`
+- `wailsjsdir`
+- `debounceMS`
+- `devServer`
+- `frontenddevserverurl`
+- `viteServerTimeout`
+
+## File / protocol associations
+
+`info.fileAssociations` and `info.protocols` populate platform metadata: `Info.plist` on macOS, NSIS installer on Windows, `.desktop` files on Linux. The corresponding open events come back through `mac.Options.OnFileOpen` / `OnUrlOpen` (or the `runtime.OnFileDrop` event for drops).
+
+## Custom bindings prefix/suffix
+
+`bindings.ts_generation.prefix`/`suffix` wrap every generated TS type in `models.ts`. `outputType: "interfaces"` emits `export interface` instead of class wrappers — useful when the frontend uses its own constructors.
+
+## Sample (this repo)
+
+`/Users/wham/code/kaja/desktop/wails.json`:
+
+```json
+{
+  "$schema": "https://wails.io/schemas/config.v2.json",
+  "name": "Kaja",
+  "outputfilename": "Kaja",
+  "wailsjsdir": "../ui/src",
+  "info": {
+    "productName": "Kaja",
+    "productVersion": "0.10.0",
+    "copyright": "2026 Tomas Vesely"
+  },
+  "author": { "name": "Tomas Vesely", "email": "..." }
+}
+```
+
+`wailsjsdir: "../ui/src"` is relative to `desktop/`, so generated bindings land under `ui/src/wailsjs/`.

--- a/.claude/skills/wails/references/gotchas.md
+++ b/.claude/skills/wails/references/gotchas.md
@@ -1,0 +1,93 @@
+# Common Gotchas
+
+Things that bite repeatedly. If something feels wrong, scan this list before deep-diving.
+
+## Webview platform deps
+
+- **WebView2 (Windows)** is required at runtime. Distribute it via `wails build -webview2 download` (default), `embed` (fixed-version, larger binary), `browser` (assume installed), or `error` (refuse to launch without it). Verify locally with `wails doctor`.
+- **WebKitGTK (Linux)** — Ubuntu 24.04+ ships only `libwebkit2gtk-4.1`. Build with `-tags webkit2_41`. For full asset-server features, also `webkit2_36` (non-GET methods/headers/status) and `webkit2_40` (request bodies). WebSockets through the asset server are unsupported on all platforms.
+- **macOS minimum target** — `wails build` defaults can be too low for newer SDKs. Override:
+  ```bash
+  CGO_CFLAGS=-mmacosx-version-min=10.15.0 \
+  CGO_LDFLAGS=-mmacosx-version-min=10.15.0 \
+  wails build
+  ```
+  macOS 15+ requires Go 1.23.3+.
+
+## Lifecycle ordering
+
+- `OnStartup` fires **before** `index.html` loads. Runtime calls that touch the window (e.g. `WindowShow`, dialogs) may fail. Capture `ctx` here, do real work in `OnDomReady`.
+- `OnBeforeClose` returning `true` cancels the close. Use this for "quit anyway?" prompts.
+- `Quit(ctx)` does **not** trigger `OnBeforeClose` — it's a direct exit. If you need confirmation everywhere, route everything through a single `requestClose()` helper.
+
+## Bindings
+
+- `Bind` takes **instances**, not types: `Bind: []interface{}{ app }` with `app := &App{}`. Passing `App{}` as a value works but the methods need value receivers.
+- Methods must be **exported** — lowercase first letter is invisible to JS.
+- Struct fields without `json` tags are silently dropped from `models.ts`. If TS types look anaemic, check tags first.
+- Anonymous nested structs aren't supported. Name the inner type.
+- `context.Context` first-arg → auto-injected, JS signature drops it.
+- After changing a Go method signature, `frontend/wailsjs/` regenerates on next `wails dev`/`wails build`. If you import from a stale path or a different `wailsjsdir`, you'll see ghost types — `wails generate module` to force.
+
+## `wails dev` quirks
+
+- Default dev server: `http://localhost:34115`. Open it in a real browser for proper devtools (the embedded webview's devtools are limited). Override with `-devserver host:port`.
+- `frontend:dev:watcher` runs a sibling process (e.g. `npm run dev`). Output is interleaved with Wails' own log — set a unique prefix in your watcher script if it gets noisy.
+- `frontend:dev:serverUrl: "auto"` parses Vite's stdout to find the port; `-viteservertimeout` is in seconds.
+- **Vite ≥ 5.0.0 + `assetserver.Handler`** is broken in Wails v2 (issue #3240). If you depend on the Handler fallback during dev with Vite, pin to v4 or work around it.
+- `-assetdir ./frontend/dist` reads assets from disk instead of `embed.FS` — useful when iterating without rebuilding the Go binary.
+
+## Embedded vs filesystem assets
+
+- `//go:embed all:frontend/dist` requires the **`all:`** prefix to include dotfiles (e.g. `.well-known/`).
+- The embed dir must exist at build time. `wails build` creates `frontend/dist/.gitkeep` automatically; turn it off with `-skipembedcreate`.
+- The asset server resolves the directory containing `index.html` inside the FS — don't nest `index.html` deeper than the embed root unless you point `Assets` at a subFS.
+
+## Single instance
+
+```go
+SingleInstanceLock: &options.SingleInstanceLock{
+    UniqueId: "dc9a36e3-...-uuid",
+    OnSecondInstanceLaunch: func(secondInstanceData options.SecondInstanceData) {
+        // Re-focus existing window, handle CLI args from the second launch
+    },
+},
+```
+
+Without this, multiple launches each get their own window.
+
+## Panic recovery
+
+- Wails recovers from panics in IPC handlers by default and logs them. Disable with `DisablePanicRecovery: true` if you want the process to die.
+- On Linux, WebKit installs signal handlers without `SA_ONSTACK`, which can clash with Go's panic recovery in goroutines. Call `runtime.ResetSignalHandlers()` from a goroutine that needs reliable Go panic recovery.
+
+## Dialogs & file paths
+
+- `MessageDialog` button strings differ per platform — see `references/runtime.md`. Don't hard-code `"OK"` (case-sensitive) when comparing returns.
+- macOS `OpenDialogOptions.ResolvesAliases: true` returns the resolved path; with `false` you get the alias path.
+
+## Drag-and-Drop
+
+- `DragAndDrop.EnableFileDrop: true` is opt-in.
+- Two ways to receive drops: `runtime.OnFileDrop(ctx, cb)` in Go, or `EventsOn("wails:file-drop", cb)` in JS. Pick one.
+- The CSS-target mode (`OnFileDrop(cb, true)` in JS) toggles a `wails-drop-target-active` class on elements whose CSS sets the configured drop property.
+
+## File / URL associations
+
+- Declared in `wails.json` `info.fileAssociations` / `info.protocols`.
+- macOS callbacks: `mac.Options.OnFileOpen` / `OnUrlOpen`. These fire even on cold launch — be ready to defer work until `OnDomReady`.
+- Windows associations are wired through the NSIS installer.
+
+## Build hygiene
+
+- `wails build` runs `frontend:install` then `frontend:build`. To skip both: `-s`. To skip `go mod tidy`: `-m`. To skip bindings regen: `-skipbindings`.
+- `-trimpath` and `-ldflags "-s -w"` are recommended for release builds. Combine with `-X main.Version=$(git describe --tags)` to embed a version.
+- UPX has known issues on Apple Silicon and triggers Windows AV false-positives. Don't enable it by default.
+- Don't commit `frontend/wailsjs/`, `frontend/dist/`, or `desktop/build/bin/` — all regenerated.
+
+## Project conventions in this repo
+
+- Use `scripts/desktop` rather than `wails dev` directly — it sets up `wailsjsdir` redirection (`../ui/src`), embeds the bundled UI, and wires the dev hot-reload.
+- The frontend pipeline is integrated through Wails project hooks (see recent commits) — don't run `scripts/build-ui` separately.
+- `cmd+R` rebuilds the desktop UI in dev (`8e679f5`).
+- Generated code under `ui/src/wailsjs/**` is **not** edited by hand and is regenerated by `wails dev`/`wails build`.

--- a/.claude/skills/wails/references/options.md
+++ b/.claude/skills/wails/references/options.md
@@ -1,0 +1,134 @@
+# Application Options (`options.App`)
+
+Passed to `wails.Run(&options.App{...})` from `main.go`.
+
+```go
+import (
+    "github.com/wailsapp/wails/v2"
+    "github.com/wailsapp/wails/v2/pkg/options"
+    "github.com/wailsapp/wails/v2/pkg/options/assetserver"
+    "github.com/wailsapp/wails/v2/pkg/options/linux"
+    "github.com/wailsapp/wails/v2/pkg/options/mac"
+    "github.com/wailsapp/wails/v2/pkg/options/windows"
+)
+```
+
+## Top-level fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `Title` | `string` | Window title |
+| `Width`, `Height` | `int` | Default 1024×768 |
+| `MinWidth`, `MinHeight`, `MaxWidth`, `MaxHeight` | `int` | Resize constraints |
+| `DisableResize` | `bool` | Fixed-size window |
+| `WindowStartState` | `options.WindowStartState` | `Fullscreen`, `Maximised`, `Minimised` (Minimised: not on macOS) |
+| `Frameless` | `bool` | No borders / title bar |
+| `StartHidden` | `bool` | Hide until `runtime.WindowShow` |
+| `HideWindowOnClose` | `bool` | Close button hides instead of quits |
+| `BackgroundColour` | `*options.RGBA` | `options.NewRGBA(r,g,b,a)` |
+| `AlwaysOnTop` | `bool` | |
+| `AssetServer` | `*assetserver.Options` | See below |
+| `Menu` | `*menu.Menu` | App menu (default macOS menu auto-generated if nil) |
+| `Logger` | `logger.Logger` | Default: stdout |
+| `LogLevel` | `logger.LogLevel` | Default `Info` (dev) |
+| `LogLevelProduction` | `logger.LogLevel` | Default `Error` |
+| `OnStartup` | `func(ctx context.Context)` | Pre-`index.html` load. **Capture `ctx` here.** |
+| `OnDomReady` | `func(ctx context.Context)` | After body onload. Safe for runtime calls touching the window. |
+| `OnShutdown` | `func(ctx context.Context)` | Just before exit |
+| `OnBeforeClose` | `func(ctx context.Context) bool` | Return `true` to prevent close |
+| `CSSDragProperty` | `string` | Default `--wails-draggable` |
+| `CSSDragValue` | `string` | Default `drag` |
+| `EnableDefaultContextMenu` | `bool` | Browser right-click menu in production |
+| `EnableFraudulentWebsiteDetection` | `bool` | |
+| `DisablePanicRecovery` | `bool` | Default false |
+| `Bind` | `[]interface{}` | **Instances** to expose to JS |
+| `EnumBind` | `[]interface{}` | Enum metadata arrays — see `references/bindings.md` |
+| `ErrorFormatter` | `func(error) any` | JSON-marshalled and returned to JS reject |
+| `SingleInstanceLock` | `*options.SingleInstanceLock` | `{UniqueId, OnSecondInstanceLaunch}` |
+| `DragAndDrop` | `*options.DragAndDrop` | `{EnableFileDrop, DisableWebViewDrop, CSSDropProperty, CSSDropValue}` |
+| `Windows` | `*windows.Options` | Per-platform |
+| `Mac` | `*mac.Options` | Per-platform |
+| `Linux` | `*linux.Options` | Per-platform |
+| `Debug` | `options.Debug` | `{OpenInspectorOnStartup}` |
+| `BindingsAllowedOrigins` | `string` | Comma-separated; `*` wildcard allowed |
+
+## `assetserver.Options`
+
+| Field | Type | Notes |
+|---|---|---|
+| `Assets` | `fs.FS` (typically `embed.FS`) | Static assets. Wails finds the dir containing `index.html`. |
+| `Handler` | `http.Handler` | Fallback for GETs not in `Assets` (returns `os.ErrNotExist`); always called for non-GET requests. |
+| `Middleware` | `assetserver.Middleware` | `func(next http.Handler) http.Handler` |
+
+Linux feature matrix (build tags):
+- `webkit2_36` — non-GET request methods/headers/status
+- `webkit2_40` — request bodies
+- WebSockets unsupported on all platforms
+
+## `windows.Options`
+
+- `WebviewIsTransparent`, `WindowIsTranslucent` — translucency
+- `BackdropType`: `windows.Auto | None | Acrylic | Mica | Tabbed` (Win 11 22621+)
+- `ContentProtection`, `DisablePinchZoom`, `DisableWindowIcon`, `DisableFramelessWindowDecorations`
+- `WebviewUserDataPath`, `WebviewBrowserPath` — fixed-version WebView2
+- `Theme`: `windows.SystemDefault | Dark | Light`
+- `CustomTheme: *windows.ThemeSettings` — `DarkModeTitleBar`, `DarkModeTitleText`, `DarkModeBorder`, `LightMode*`, `*Inactive` variants. Helper: `windows.RGB(r,g,b)`
+- `Messages: *windows.Messages` — WebView2 installer strings
+- `ZoomFactor float64`, `IsZoomControlEnabled bool`
+- `ResizeDebounceMS uint16`
+- `OnSuspend func()`, `OnResume func()`
+- `WebviewGpuIsDisabled bool`, `EnableSwipeGestures bool`
+- `WindowClassName string` (default `wailsWindow`)
+
+## `mac.Options`
+
+- `TitleBar *mac.TitleBar` — `{TitlebarAppearsTransparent, HideTitle, HideTitleBar, FullSizeContent, UseToolbar, HideToolbarSeparator}`. Presets: `mac.TitleBarDefault()`, `mac.TitleBarHidden()`, `mac.TitleBarHiddenInset()`
+- `Appearance mac.AppearanceType`: `DefaultAppearance`, `NSAppearanceNameAqua`, `NSAppearanceNameDarkAqua`, `NSAppearanceNameVibrantLight`, plus accessibility variants
+- `WebviewIsTransparent`, `WindowIsTranslucent`, `ContentProtection`
+- `OnFileOpen func(path string)`, `OnUrlOpen func(url string)` — paired with `wails.json` `info.fileAssociations` / `info.protocols`
+- `Preferences *mac.Preferences`: `TabFocusesLinks`, `TextInteractionEnabled`, `FullscreenEnabled` — values `mac.Enabled` / `mac.Disabled`
+- `About *mac.AboutInfo`: `{Title, Message, Icon []byte}`
+
+## `linux.Options`
+
+- `Icon []byte` — window/iconified icon
+- `WindowIsTranslucent bool`
+- `WebviewGpuPolicy`: `WebviewGpuPolicyAlways` (default), `WebviewGpuPolicyOnDemand`, `WebviewGpuPolicyNever`
+- `ProgramName string` — passed to GTK `g_set_prgname()`
+
+## Minimal `main.go` skeleton
+
+```go
+package main
+
+import (
+    "context"
+    "embed"
+    "github.com/wailsapp/wails/v2"
+    "github.com/wailsapp/wails/v2/pkg/options"
+    "github.com/wailsapp/wails/v2/pkg/options/assetserver"
+)
+
+//go:embed all:frontend/dist
+var assets embed.FS
+
+type App struct{ ctx context.Context }
+
+func (a *App) startup(ctx context.Context) { a.ctx = ctx }
+func (a *App) Greet(name string) string    { return "Hello " + name }
+
+func main() {
+    app := &App{}
+    err := wails.Run(&options.App{
+        Title:     "MyApp",
+        Width:     1024,
+        Height:    768,
+        OnStartup: app.startup,
+        AssetServer: &assetserver.Options{Assets: assets},
+        Bind:      []interface{}{app},
+    })
+    if err != nil {
+        println("Error:", err.Error())
+    }
+}
+```

--- a/.claude/skills/wails/references/runtime.md
+++ b/.claude/skills/wails/references/runtime.md
@@ -1,0 +1,209 @@
+# Runtime API
+
+The runtime is mirrored on both sides:
+
+- **Go**: `import "github.com/wailsapp/wails/v2/pkg/runtime"`. Every function takes `ctx context.Context` (capture from `OnStartup` / `OnDomReady`).
+- **JS**: `import {...} from "../wailsjs/runtime"` (typed) or `window.runtime.*` (untyped, always available).
+
+Many APIs return `Promise<T>` on the JS side because they cross the IPC bridge.
+
+## App-level
+
+| Go | JS | Notes |
+|---|---|---|
+| `Hide(ctx)` | `Hide()` | macOS: NSApp hide. Win/Linux: same as `WindowHide` |
+| `Show(ctx)` | `Show()` | |
+| `Quit(ctx)` | `Quit()` | |
+| `Environment(ctx) EnvironmentInfo` | `Environment()` | `{BuildType, Platform, Arch}` (Go) / lowercase (JS) |
+| `ResetSignalHandlers()` | — | Linux only; reinstalls signal handlers with `SA_ONSTACK` for Go panic recovery in goroutines |
+
+## Window
+
+| Go | JS |
+|---|---|
+| `WindowSetTitle(ctx, string)` | `WindowSetTitle(title)` |
+| `WindowFullscreen(ctx)` / `WindowUnfullscreen(ctx)` / `WindowIsFullscreen(ctx) bool` | same |
+| `WindowCenter(ctx)` | `WindowCenter()` |
+| `WindowReload(ctx)` / `WindowReloadApp(ctx)` | same |
+| `WindowExecJS(ctx, js string)` | — (Go only; async, no return) |
+| `WindowSetSystemDefaultTheme/SetLightTheme/SetDarkTheme(ctx)` | same (Windows only) |
+| `WindowShow(ctx)` / `WindowHide(ctx)` | same |
+| `WindowIsNormal(ctx) bool` | `WindowIsNormal(): Promise<boolean>` |
+| `WindowSetSize(ctx, w, h int)` / `WindowGetSize(ctx) (int,int)` | `WindowSetSize(w,h)` / `WindowGetSize(): Promise<Size>` |
+| `WindowSetMinSize(ctx, w, h)` / `WindowSetMaxSize(ctx, w, h)` | same. `(0,0)` to disable |
+| `WindowSetAlwaysOnTop(ctx, bool)` | same |
+| `WindowSetPosition(ctx, x, y)` / `WindowGetPosition(ctx) (int,int)` | same |
+| `WindowMaximise` / `WindowUnmaximise` / `WindowIsMaximised` / `WindowToggleMaximise` | same |
+| `WindowMinimise` / `WindowUnminimise` / `WindowIsMinimised` | same |
+| `WindowSetBackgroundColour(ctx, R,G,B,A uint8)` | same. Windows: alpha must be 0 or 255 |
+| `WindowPrint(ctx)` | `WindowPrint()` |
+
+JS types: `interface Position { x: number; y: number }`, `interface Size { w: number; h: number }`.
+
+## Dialog (Go only)
+
+```go
+runtime.OpenDirectoryDialog(ctx, OpenDialogOptions) (string, error)
+runtime.OpenFileDialog(ctx, OpenDialogOptions) (string, error)
+runtime.OpenMultipleFilesDialog(ctx, OpenDialogOptions) ([]string, error)
+runtime.SaveFileDialog(ctx, SaveDialogOptions) (string, error)
+runtime.MessageDialog(ctx, MessageDialogOptions) (string, error)
+```
+
+```go
+type OpenDialogOptions struct {
+    DefaultDirectory           string
+    DefaultFilename            string
+    Title                      string
+    Filters                    []FileFilter
+    ShowHiddenFiles            bool   // mac/lin
+    CanCreateDirectories       bool   // mac
+    ResolvesAliases            bool   // mac
+    TreatPackagesAsDirectories bool   // mac
+}
+
+type FileFilter struct {
+    DisplayName string  // "Image Files (*.jpg, *.png)"
+    Pattern     string  // "*.jpg;*.png"   (semicolons)
+}
+
+type MessageDialogOptions struct {
+    Type          DialogType  // InfoDialog | WarningDialog | ErrorDialog | QuestionDialog
+    Title         string
+    Message       string
+    Buttons       []string    // mac only; up to 4
+    DefaultButton string
+    CancelButton  string      // mac only
+}
+```
+
+Return strings on Windows: `"Ok"`, `"Cancel"`, `"Abort"`, `"Retry"`, `"Ignore"`, `"Yes"`, `"No"`, `"Try Again"`, `"Continue"`. Linux: `"Ok"`, `"Cancel"`, `"Yes"`, `"No"`. Question on Windows defaults to `"Yes"` — set `DefaultButton: "No"` to flip.
+
+`SaveDialogOptions` is the same as `OpenDialogOptions` minus `ResolvesAliases`.
+
+## Events
+
+| Go | JS |
+|---|---|
+| `EventsOn(ctx, name, cb func(...interface{})) func()` | `EventsOn(name, cb): () => void` |
+| `EventsOnce(ctx, name, cb) func()` | `EventsOnce(name, cb): () => void` |
+| `EventsOnMultiple(ctx, name, cb, counter int) func()` | `EventsOnMultiple(name, cb, counter): () => void` |
+| `EventsOff(ctx, name, ...additional)` | `EventsOff(name, ...additional)` |
+| `EventsOffAll(ctx)` | `EventsOffAll()` |
+| `EventsEmit(ctx, name, ...optionalData)` | `EventsEmit(name, ...optionalData)` |
+
+Cross-language: a JS `EventsEmit` reaches Go listeners and vice versa. The `On*` functions return an unsubscribe.
+
+Built-in: `wails:file-drop` fires when `DragAndDrop.EnableFileDrop` is true. Payload: `(x, y, paths []string)`.
+
+## Log
+
+Levels low → high: Trace, Debug, Info, Warning, Error, Fatal. JS numeric: 1 Trace, 2 Debug, 3 Info, 4 Warning, 5 Error.
+
+| Go | JS |
+|---|---|
+| `LogPrint(ctx, msg)` / `LogPrintf(ctx, fmt, ...)` | `LogPrint(msg)` |
+| `LogTrace`/`LogDebug`/`LogInfo`/`LogWarning`/`LogError`/`LogFatal` (each with `*f` variant) | `LogTrace`/`LogDebug`/`LogInfo`/`LogWarning`/`LogError`/`LogFatal` |
+| `LogSetLogLevel(ctx, logger.LogLevel)` | `LogSetLogLevel(n)` |
+
+Custom logger (`github.com/wailsapp/wails/v2/pkg/logger`):
+
+```go
+type Logger interface {
+    Print(message string)
+    Trace(message string)
+    Debug(message string)
+    Info(message string)
+    Warning(message string)
+    Error(message string)
+    Fatal(message string)
+}
+```
+
+## Browser
+
+`BrowserOpenURL(ctx, url string)` / `BrowserOpenURL(url)` — opens in the user's default browser.
+
+## Screen
+
+`ScreenGetAll(ctx) []Screen` / `ScreenGetAll(): Promise<Screen[]>`:
+
+```go
+type Screen struct {
+    IsCurrent bool
+    IsPrimary bool
+    Width     int
+    Height    int
+}
+```
+
+## Menu (Go only)
+
+```go
+runtime.MenuSetApplicationMenu(ctx, *menu.Menu)
+runtime.MenuUpdateApplicationMenu(ctx)
+```
+
+Building menus (`github.com/wailsapp/wails/v2/pkg/menu` + `pkg/menu/keys`):
+
+```go
+m := menu.NewMenu()
+file := m.AddSubmenu("File")
+file.AddText("Open", keys.CmdOrCtrl("o"), func(cd *menu.CallbackData) { /* ... */ })
+file.AddSeparator()
+file.AddText("Quit", keys.CmdOrCtrl("q"), func(cd *menu.CallbackData) { runtime.Quit(ctx) })
+
+// macOS standard menus
+m.Append(menu.AppMenu())
+m.Append(menu.EditMenu())   // Cmd+C/V/Z
+
+runtime.MenuSetApplicationMenu(ctx, m)
+```
+
+`MenuItem`:
+```go
+type MenuItem struct {
+    Label       string
+    Role        Role               // macOS roles
+    Accelerator *keys.Accelerator
+    Type        Type
+    Disabled    bool
+    Hidden      bool
+    Checked     bool
+    SubMenu     *Menu
+    Click       Callback           // func(*menu.CallbackData)
+}
+```
+
+## Clipboard
+
+| Go | JS |
+|---|---|
+| `ClipboardGetText(ctx) (string, error)` | `ClipboardGetText(): Promise<string>` |
+| `ClipboardSetText(ctx, text string) error` | `ClipboardSetText(text): Promise<boolean>` |
+
+Text only.
+
+## Drag-and-Drop
+
+Enable in `options.App`:
+
+```go
+DragAndDrop: &options.DragAndDrop{
+    EnableFileDrop:     true,
+    DisableWebViewDrop: false,
+    CSSDropProperty:    "--wails-drop-target",
+    CSSDropValue:       "drop",
+},
+```
+
+| Go | JS |
+|---|---|
+| `OnFileDrop(ctx, func(x,y int, paths []string))` | `OnFileDrop(cb, useDropTarget: boolean)` |
+| `OnFileDropOff(ctx)` | `OnFileDropOff()` |
+
+When `useDropTarget` is true, JS auto-toggles a `wails-drop-target-active` class on elements whose CSS sets `CSSDropProperty: CSSDropValue`. Alternative: subscribe to the `wails:file-drop` event via `EventsOn`.
+
+## Notifications
+
+`InitializeNotifications(ctx) error`, `IsNotificationAvailable(ctx) bool`, plus send/dismiss with action buttons and reply text fields. Available in both Go and JS runtimes — see `website/docs/reference/runtime/notification.mdx` upstream for the full options struct.

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/wailsapp/wails/v2 v2.11.0
+	github.com/wailsapp/wails/v2 v2.12.0
 	github.com/wham/kaja/v2 v2.0.0-20240101000000-000000000000
 )
 
@@ -15,6 +15,7 @@ replace (
 )
 
 require (
+	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/evanw/esbuild v0.27.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -1,3 +1,5 @@
+git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 h1:N3IGoHHp9pb6mj1cbXbuaSXV/UMKwmbKLf53nQmtqMA=
+git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3/go.mod h1:QtOLZGz8olr4qH2vWK0QH0w0O4T9fEIjMuWpKUsH7nc=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -70,8 +72,8 @@ github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+
 github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSBtqQ=
-github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
+github.com/wailsapp/wails/v2 v2.12.0 h1:BHO/kLNWFHYjCzucxbzAYZWUjub1Tvb4cSguQozHn5c=
+github.com/wailsapp/wails/v2 v2.12.0/go.mod h1:mo1bzK1DEJrobt7YrBjgxvb5Sihb1mhAY09hppbibQg=
 github.com/wham/protoc-go v0.0.0-20260410000912-cb20922cf784 h1:lzw9qAHTOyTxnfDCURB7KWDb81iyMCC4ZMYkiRp5Bmo=
 github.com/wham/protoc-go v0.0.0-20260410000912-cb20922cf784/go.mod h1:X+cjaeMbBlhWPs1huMPwDLV5sPn56DUadkqrRj+ErDA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/ui/src/wailsjs/runtime/runtime.d.ts
+++ b/ui/src/wailsjs/runtime/runtime.d.ts
@@ -247,3 +247,84 @@ export function CanResolveFilePaths(): boolean;
 
 // Resolves file paths for an array of files
 export function ResolveFilePaths(files: File[]): void
+
+// Notification types
+export interface NotificationOptions {
+    id: string;
+    title: string;
+    subtitle?: string; // macOS and Linux only
+    body?: string;
+    categoryId?: string;
+    data?: { [key: string]: any };
+}
+
+export interface NotificationAction {
+    id?: string;
+    title?: string;
+    destructive?: boolean; // macOS-specific
+}
+
+export interface NotificationCategory {
+    id?: string;
+    actions?: NotificationAction[];
+    hasReplyField?: boolean;
+    replyPlaceholder?: string;
+    replyButtonTitle?: string;
+}
+
+// [InitializeNotifications](https://wails.io/docs/reference/runtime/notification#initializenotifications)
+// Initializes the notification service for the application.
+// This must be called before sending any notifications.
+export function InitializeNotifications(): Promise<void>;
+
+// [CleanupNotifications](https://wails.io/docs/reference/runtime/notification#cleanupnotifications)
+// Cleans up notification resources and releases any held connections.
+export function CleanupNotifications(): Promise<void>;
+
+// [IsNotificationAvailable](https://wails.io/docs/reference/runtime/notification#isnotificationavailable)
+// Checks if notifications are available on the current platform.
+export function IsNotificationAvailable(): Promise<boolean>;
+
+// [RequestNotificationAuthorization](https://wails.io/docs/reference/runtime/notification#requestnotificationauthorization)
+// Requests notification authorization from the user (macOS only).
+export function RequestNotificationAuthorization(): Promise<boolean>;
+
+// [CheckNotificationAuthorization](https://wails.io/docs/reference/runtime/notification#checknotificationauthorization)
+// Checks the current notification authorization status (macOS only).
+export function CheckNotificationAuthorization(): Promise<boolean>;
+
+// [SendNotification](https://wails.io/docs/reference/runtime/notification#sendnotification)
+// Sends a basic notification with the given options.
+export function SendNotification(options: NotificationOptions): Promise<void>;
+
+// [SendNotificationWithActions](https://wails.io/docs/reference/runtime/notification#sendnotificationwithactions)
+// Sends a notification with action buttons. Requires a registered category.
+export function SendNotificationWithActions(options: NotificationOptions): Promise<void>;
+
+// [RegisterNotificationCategory](https://wails.io/docs/reference/runtime/notification#registernotificationcategory)
+// Registers a notification category that can be used with SendNotificationWithActions.
+export function RegisterNotificationCategory(category: NotificationCategory): Promise<void>;
+
+// [RemoveNotificationCategory](https://wails.io/docs/reference/runtime/notification#removenotificationcategory)
+// Removes a previously registered notification category.
+export function RemoveNotificationCategory(categoryId: string): Promise<void>;
+
+// [RemoveAllPendingNotifications](https://wails.io/docs/reference/runtime/notification#removeallpendingnotifications)
+// Removes all pending notifications from the notification center.
+export function RemoveAllPendingNotifications(): Promise<void>;
+
+// [RemovePendingNotification](https://wails.io/docs/reference/runtime/notification#removependingnotification)
+// Removes a specific pending notification by its identifier.
+export function RemovePendingNotification(identifier: string): Promise<void>;
+
+// [RemoveAllDeliveredNotifications](https://wails.io/docs/reference/runtime/notification#removealldeliverednotifications)
+// Removes all delivered notifications from the notification center.
+export function RemoveAllDeliveredNotifications(): Promise<void>;
+
+// [RemoveDeliveredNotification](https://wails.io/docs/reference/runtime/notification#removedeliverednotification)
+// Removes a specific delivered notification by its identifier.
+export function RemoveDeliveredNotification(identifier: string): Promise<void>;
+
+// [RemoveNotification](https://wails.io/docs/reference/runtime/notification#removenotification)
+// Removes a notification by its identifier (cross-platform convenience function).
+export function RemoveNotification(identifier: string): Promise<void>;

--- a/ui/src/wailsjs/runtime/runtime.js
+++ b/ui/src/wailsjs/runtime/runtime.js
@@ -240,3 +240,59 @@ export function CanResolveFilePaths() {
 export function ResolveFilePaths(files) {
     return window.runtime.ResolveFilePaths(files);
 }
+
+export function InitializeNotifications() {
+    return window.runtime.InitializeNotifications();
+}
+
+export function CleanupNotifications() {
+    return window.runtime.CleanupNotifications();
+}
+
+export function IsNotificationAvailable() {
+    return window.runtime.IsNotificationAvailable();
+}
+
+export function RequestNotificationAuthorization() {
+    return window.runtime.RequestNotificationAuthorization();
+}
+
+export function CheckNotificationAuthorization() {
+    return window.runtime.CheckNotificationAuthorization();
+}
+
+export function SendNotification(options) {
+    return window.runtime.SendNotification(options);
+}
+
+export function SendNotificationWithActions(options) {
+    return window.runtime.SendNotificationWithActions(options);
+}
+
+export function RegisterNotificationCategory(category) {
+    return window.runtime.RegisterNotificationCategory(category);
+}
+
+export function RemoveNotificationCategory(categoryId) {
+    return window.runtime.RemoveNotificationCategory(categoryId);
+}
+
+export function RemoveAllPendingNotifications() {
+    return window.runtime.RemoveAllPendingNotifications();
+}
+
+export function RemovePendingNotification(identifier) {
+    return window.runtime.RemovePendingNotification(identifier);
+}
+
+export function RemoveAllDeliveredNotifications() {
+    return window.runtime.RemoveAllDeliveredNotifications();
+}
+
+export function RemoveDeliveredNotification(identifier) {
+    return window.runtime.RemoveDeliveredNotification(identifier);
+}
+
+export function RemoveNotification(identifier) {
+    return window.runtime.RemoveNotification(identifier);
+}


### PR DESCRIPTION
Added a `.claude/skills/wails/` reference skill (SKILL.md + per-topic references) so the agent has a quick lookup for Wails v2 concepts, and bumped `desktop/go.mod` from Wails v2.11.0 to v2.12.0 (bug-fix release; notable: macOS Tahoe webview crash, Linux panic-handler fix, clipboard mojibake).

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-278-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-278-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-278-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-278-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-278-newproject.png)

</details>
