### PR TITLE
Added Bun homebrew install prompt

### DIFF
--- a/scripts/desktop
+++ b/scripts/desktop
@@ -74,6 +74,22 @@ then
     brew install create-dmg
 fi
 
+# Check if Bun is installed (wails dev/build invokes it via frontend:install)
+if ! command -v bun &> /dev/null
+then
+    if [ -t 0 ]; then
+        echo "Bun is not installed."
+        read -p "Would you like to install Bun using Homebrew? (y/n) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Bun installation skipped. Exiting script."
+            exit 1
+        fi
+    fi
+    echo "Installing Bun using Homebrew..."
+    brew install oven-sh/bun/bun
+fi
+
 cd "$(dirname "$0")/.."
 
 export GOBIN=$PWD/server/build

--- a/scripts/server
+++ b/scripts/server
@@ -19,6 +19,22 @@ then
     fi
 fi
 
+# Check if Bun is installed, if not ask for user confirmation to install it using Homebrew
+if ! command -v bun &> /dev/null
+then
+    echo "Bun is not installed."
+    read -p "Would you like to install Bun using Homebrew? (y/n) " -n 1 -r
+    echo    # Move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Installing Bun using Homebrew..."
+        brew install oven-sh/bun/bun
+    else
+        echo "Bun installation skipped. Exiting script."
+        exit 1
+    fi
+fi
+
 cd "$(dirname "$0")/.."
 
 # Kill any existing server on port 41520


### PR DESCRIPTION
scripts/desktop and scripts/server now offer to `brew install oven-sh/bun/bun` when bun is missing, matching the existing wails/create-dmg/go prompts.

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-279-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-279-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-279-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-279-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-279-newproject.png)

</details>
