### PR TITLE
Added feature previews menu to toggle experimental features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,15 @@
 - Ask me before creating custom UI components; prefer direct use of Primer components.
 - Keep pull-request descriptions super short - one or two sentences summarizing the change.
 
-## Experimental (Beta)
+## Experimental (Preview)
 
-Two features are still experimental and marked "Beta" in the UI:
+Experimental features are opt-in through the **feature previews** menu — a beaker
+button in the footer next to the theme selector (`FeaturePreviews.tsx`) that opens a
+small popup with a toggle per experimental feature. Enabled features are marked with a
+"Preview" pill in the UI (`PreviewPill` in `Sidebar.tsx`). Toggle state persists via
+`usePersistedState` under `featurePreview:<key>` keys.
 
-- **Scripts** — a global `<kajaHome>/scripts/` folder of standalone TypeScript scripts (desktop only) that bind to projects through their import paths and run from their own tabs.
+- **Scripts** (`featurePreview:scripts`, desktop only) — a global `<kajaHome>/scripts/` folder of standalone TypeScript scripts that bind to projects through their import paths and run from their own tabs.
 - **macOS "Run Kaja Script" text service** — select text in any app, then right-click → Services → "Run Kaja Script" to run a _pinned_ script with the selection exposed as `kaja.input` (macOS desktop only).
 
 ## Directory Structure

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -266,12 +266,12 @@ func (a *App) OpenDirectoryDialog() (string, error) {
 
 func (a *App) Twirp(method string, req []byte) ([]byte, error) {
 	slog.Info("Twirp called", "method", method, "req_length", len(req))
-	
+
 	if req == nil {
 		slog.Error("Received nil request")
 		return nil, fmt.Errorf("nil request")
 	}
-	
+
 	// Empty requests are valid for methods with no parameters (like GetConfiguration)
 	if len(req) == 0 {
 		slog.Info("Received empty request - this is valid for methods with no parameters")

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -89,6 +89,42 @@ func (a *App) startup(ctx context.Context) {
 			runtime.EventsEmit(ctx, "configuration:changed")
 		})
 	}
+
+	// Toggle the File → "Save as script" menu item with the Scripts feature
+	// preview. The UI reports the current state on load and whenever it changes.
+	runtime.EventsOn(ctx, "scripts:previewEnabled", func(optionalData ...interface{}) {
+		enabled := false
+		if len(optionalData) > 0 {
+			if b, ok := optionalData[0].(bool); ok {
+				enabled = b
+			}
+		}
+		runtime.MenuSetApplicationMenu(ctx, a.buildAppMenu(enabled))
+		runtime.MenuUpdateApplicationMenu(ctx)
+	})
+}
+
+// buildAppMenu assembles the native application menu. The File menu holds only
+// the experimental "Save as script" action, so it is included only when the
+// Scripts feature preview is enabled.
+func (a *App) buildAppMenu(scriptsEnabled bool) *menu.Menu {
+	appMenu := menu.NewMenu()
+	appMenu.Append(menu.AppMenu())
+
+	if scriptsEnabled {
+		fileMenu := appMenu.AddSubmenu("File")
+		fileMenu.AddText("Save as script", keys.CmdOrCtrl("s"), func(_ *menu.CallbackData) {
+			runtime.EventsEmit(a.ctx, "menu:saveScript")
+		})
+	}
+
+	appMenu.Append(menu.EditMenu())
+	viewMenu := appMenu.AddSubmenu("View")
+	viewMenu.AddText("Reload", keys.CmdOrCtrl("r"), func(_ *menu.CallbackData) {
+		runtime.WindowReloadApp(a.ctx)
+	})
+	appMenu.Append(menu.WindowMenu())
+	return appMenu
 }
 
 // ScriptFile is the on-disk representation of a Kaja script.
@@ -511,20 +547,9 @@ func main() {
 	// Create application with options
 	app := NewApp(twirpHandler, configurationWatcher, bookmarkStore, kajaDir)
 
-	appMenu := menu.NewMenu()
-	appMenu.Append(menu.AppMenu())
-
-	fileMenu := appMenu.AddSubmenu("File")
-	fileMenu.AddText("Save as script", keys.CmdOrCtrl("s"), func(_ *menu.CallbackData) {
-		runtime.EventsEmit(app.ctx, "menu:saveScript")
-	})
-
-	appMenu.Append(menu.EditMenu())
-	viewMenu := appMenu.AddSubmenu("View")
-	viewMenu.AddText("Reload", keys.CmdOrCtrl("r"), func(_ *menu.CallbackData) {
-		runtime.WindowReloadApp(app.ctx)
-	})
-	appMenu.Append(menu.WindowMenu())
+	// The File menu starts hidden; the UI enables it once it reports the Scripts
+	// feature preview as on (see startup).
+	appMenu := app.buildAppMenu(false)
 
 	err = wails.Run(&options.App{
 		Title:  "Kaja",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -44,7 +44,7 @@ import { usePersistedState } from "./usePersistedState";
 import { flushPersistedWrites, getPersistedValue, setPersistedValue } from "./storage";
 import { FirstProjectBlankslate } from "./FirstProjectBlankslate";
 import { isWailsEnvironment } from "./wails";
-import { BrowserOpenURL, EventsOn, WindowSetTitle } from "./wailsjs/runtime";
+import { BrowserOpenURL, EventsEmit, EventsOn, WindowSetTitle } from "./wailsjs/runtime";
 import { CreateScript, DeleteScript, ListScripts, ReadScriptFile, RenameScript, WriteScriptFile } from "./wailsjs/go/main/App";
 import { runTask } from "./taskRunner";
 
@@ -112,6 +112,8 @@ export function App() {
   const [scripts, setScripts] = useState<Script[]>();
   // Experimental "Scripts" feature, toggled from the feature previews menu in the footer.
   const [previewScripts, setPreviewScripts] = usePersistedState("featurePreview:scripts", false);
+  const previewScriptsRef = useRef(previewScripts);
+  previewScriptsRef.current = previewScripts;
   const [fileError, setFileError] = useState<string | undefined>();
   // Save-as dialog state for ⌘S; null when closed.
   const [saveAs, setSaveAs] = useState<{ name: string; content: string } | null>(null);
@@ -651,7 +653,7 @@ export function App() {
 
   // ⌘S saves the active editor (a method or a script) as a new named script.
   const onRequestSaveAsScript = useCallback(() => {
-    if (!isWailsEnvironment()) return;
+    if (!isWailsEnvironment() || !previewScriptsRef.current) return;
     const tab = tabsRef.current[activeTabIndexRef.current];
     if (!tab || (tab.type !== "task" && tab.type !== "script")) return;
     const defaultName = tab.type === "task" ? lowerFirst(tab.originMethod.name) : getScriptTabLabel(tab);
@@ -668,6 +670,12 @@ export function App() {
     const unsub = EventsOn("menu:saveScript", () => onRequestSaveAsScriptRef.current());
     return () => unsub();
   }, []);
+
+  // Show/hide the native File menu in step with the Scripts feature preview.
+  useEffect(() => {
+    if (!isWailsEnvironment()) return;
+    EventsEmit("scripts:previewEnabled", previewScripts);
+  }, [previewScripts]);
 
   const onConfirmSaveAsScript = useCallback(async () => {
     if (!saveAs) return;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import { createProjectRef, getDefaultMethod, Method, Project, Script, Service, u
 import { Sidebar } from "./Sidebar";
 import { SearchPopup } from "./SearchPopup";
 import { StatusBar, ColorMode } from "./StatusBar";
+import { FeaturePreview } from "./FeaturePreviews";
 import { ProjectForm } from "./ProjectForm";
 import { remapEditorCode, remapSourcesToNewName } from "./sources";
 import { Configuration, ConfigurationProject } from "./server/api";
@@ -109,6 +110,8 @@ export function App() {
   const hasTabMemory = useRef(getPersistedValue<PersistedTabState>("tabs") !== undefined);
   const tabsRestoredRef = useRef(restoredState !== null && restoredState.tabs.some((t) => t.type === "task"));
   const [scripts, setScripts] = useState<Script[]>();
+  // Experimental "Scripts" feature, toggled from the feature previews menu in the footer.
+  const [previewScripts, setPreviewScripts] = usePersistedState("featurePreview:scripts", false);
   const [fileError, setFileError] = useState<string | undefined>();
   // Save-as dialog state for ⌘S; null when closed.
   const [saveAs, setSaveAs] = useState<{ name: string; content: string } | null>(null);
@@ -156,6 +159,15 @@ export function App() {
 
   const onToggleColorMode = useCallback(() => {
     setColorMode((mode) => (mode === "night" ? "day" : "night"));
+  }, []);
+
+  // Scripts are desktop-only, so the toggle is only offered in the Wails environment.
+  const featurePreviews: FeaturePreview[] = isWailsEnvironment() ? [{ key: "scripts", label: "Scripts", enabled: previewScripts }] : [];
+
+  const onToggleFeaturePreview = useCallback((key: string) => {
+    if (key === "scripts") {
+      setPreviewScripts((enabled) => !enabled);
+    }
   }, []);
 
   // Responsive layout: narrow (mobile) allows scrolling, regular/wide (desktop) is fixed
@@ -387,14 +399,17 @@ export function App() {
   // Load the global scripts directory (desktop only). Scripts are independent
   // of projects; they bind to a project at run time via their import paths.
   const refreshScripts = useCallback(() => {
-    if (!isWailsEnvironment()) return;
+    if (!isWailsEnvironment() || !previewScripts) {
+      setScripts(undefined);
+      return;
+    }
     ListScripts()
       .then((list) => setScripts((list ?? []).map((s) => ({ path: s.path, name: s.name })).sort((a, b) => a.name.localeCompare(b.name))))
       .catch((err) => {
         console.error("Failed to list scripts", err);
         setScripts([]);
       });
-  }, []);
+  }, [previewScripts]);
 
   useEffect(() => {
     refreshScripts();
@@ -1225,7 +1240,13 @@ export function App() {
               )}
             </div>
           </div>
-          <StatusBar colorMode={colorMode} onToggleColorMode={onToggleColorMode} gitRef={configuration?.system?.gitRef} />
+          <StatusBar
+            colorMode={colorMode}
+            onToggleColorMode={onToggleColorMode}
+            gitRef={configuration?.system?.gitRef}
+            featurePreviews={featurePreviews}
+            onToggleFeaturePreview={onToggleFeaturePreview}
+          />
         </div>
         <SearchPopup isOpen={isSearchOpen} projects={projects} onClose={() => setIsSearchOpen(false)} onSelect={onSearchMethodSelect} />
         {saveAs && (

--- a/ui/src/FeaturePreviews.tsx
+++ b/ui/src/FeaturePreviews.tsx
@@ -36,7 +36,7 @@ export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
               <span id={labelId} style={{ fontSize: 12, color: "var(--fgColor-default)" }}>
                 {feature.label}
               </span>
-              <ToggleSwitch size="small" checked={feature.enabled} aria-labelledby={labelId} onChange={() => onToggle(feature.key)} />
+              <ToggleSwitch size="small" checked={feature.enabled} aria-labelledby={labelId} onClick={() => onToggle(feature.key)} />
             </div>
           );
         })}

--- a/ui/src/FeaturePreviews.tsx
+++ b/ui/src/FeaturePreviews.tsx
@@ -1,0 +1,37 @@
+import { BeakerIcon } from "@primer/octicons-react";
+import { ActionList, ActionMenu } from "@primer/react";
+import { IconButtonXSmall } from "./IconButtonXSmall";
+
+export interface FeaturePreview {
+  key: string;
+  label: string;
+  enabled: boolean;
+}
+
+interface FeaturePreviewsProps {
+  features: FeaturePreview[];
+  onToggle: (key: string) => void;
+}
+
+export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
+  return (
+    <ActionMenu>
+      <ActionMenu.Anchor>
+        <IconButtonXSmall icon={BeakerIcon} aria-label="Feature previews" />
+      </ActionMenu.Anchor>
+      <ActionMenu.Overlay width="small">
+        <ActionList selectionVariant="multiple">
+          {features.length === 0 ? (
+            <ActionList.Item disabled>No feature previews available</ActionList.Item>
+          ) : (
+            features.map((feature) => (
+              <ActionList.Item key={feature.key} selected={feature.enabled} onSelect={() => onToggle(feature.key)}>
+                {feature.label}
+              </ActionList.Item>
+            ))
+          )}
+        </ActionList>
+      </ActionMenu.Overlay>
+    </ActionMenu>
+  );
+}

--- a/ui/src/FeaturePreviews.tsx
+++ b/ui/src/FeaturePreviews.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { BeakerIcon } from "@primer/octicons-react";
-import { ActionList, ActionMenu } from "@primer/react";
+import { AnchoredOverlay, ToggleSwitch } from "@primer/react";
 import { IconButtonXSmall } from "./IconButtonXSmall";
 
 export interface FeaturePreview {
@@ -14,24 +15,32 @@ interface FeaturePreviewsProps {
 }
 
 export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
+  const [open, setOpen] = useState(false);
+
   if (features.length === 0) {
     return null;
   }
 
   return (
-    <ActionMenu>
-      <ActionMenu.Anchor>
-        <IconButtonXSmall icon={BeakerIcon} aria-label="Feature previews" />
-      </ActionMenu.Anchor>
-      <ActionMenu.Overlay width="small">
-        <ActionList selectionVariant="multiple">
-          {features.map((feature) => (
-            <ActionList.Item key={feature.key} selected={feature.enabled} onSelect={() => onToggle(feature.key)}>
-              {feature.label}
-            </ActionList.Item>
-          ))}
-        </ActionList>
-      </ActionMenu.Overlay>
-    </ActionMenu>
+    <AnchoredOverlay
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      renderAnchor={(anchorProps) => <IconButtonXSmall icon={BeakerIcon} aria-label="Feature previews" {...anchorProps} />}
+    >
+      <div style={{ padding: 8, display: "flex", flexDirection: "column", gap: 8, minWidth: 180 }}>
+        {features.map((feature) => {
+          const labelId = `feature-preview-${feature.key}`;
+          return (
+            <div key={feature.key} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 24 }}>
+              <span id={labelId} style={{ fontSize: 12, color: "var(--fgColor-default)" }}>
+                {feature.label}
+              </span>
+              <ToggleSwitch size="small" checked={feature.enabled} aria-labelledby={labelId} onChange={() => onToggle(feature.key)} />
+            </div>
+          );
+        })}
+      </div>
+    </AnchoredOverlay>
   );
 }

--- a/ui/src/FeaturePreviews.tsx
+++ b/ui/src/FeaturePreviews.tsx
@@ -14,6 +14,10 @@ interface FeaturePreviewsProps {
 }
 
 export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
+  if (features.length === 0) {
+    return null;
+  }
+
   return (
     <ActionMenu>
       <ActionMenu.Anchor>
@@ -21,15 +25,11 @@ export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
       </ActionMenu.Anchor>
       <ActionMenu.Overlay width="small">
         <ActionList selectionVariant="multiple">
-          {features.length === 0 ? (
-            <ActionList.Item disabled>No feature previews available</ActionList.Item>
-          ) : (
-            features.map((feature) => (
-              <ActionList.Item key={feature.key} selected={feature.enabled} onSelect={() => onToggle(feature.key)}>
-                {feature.label}
-              </ActionList.Item>
-            ))
-          )}
+          {features.map((feature) => (
+            <ActionList.Item key={feature.key} selected={feature.enabled} onSelect={() => onToggle(feature.key)}>
+              {feature.label}
+            </ActionList.Item>
+          ))}
         </ActionList>
       </ActionMenu.Overlay>
     </ActionMenu>

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -42,7 +42,7 @@ function ProtocolPill({ protocol }: { protocol: RpcProtocol }) {
   );
 }
 
-function BetaPill() {
+function PreviewPill() {
   return (
     <span
       style={{
@@ -55,7 +55,7 @@ function BetaPill() {
         color: "var(--fgColor-accent)",
       }}
     >
-      Beta
+      Preview
     </span>
   );
 }
@@ -372,7 +372,7 @@ export function Sidebar({
               </span>
               <FileCodeIcon size={16} />
               <span style={{ marginLeft: 4 }}>Scripts</span>
-              <BetaPill />
+              <PreviewPill />
             </div>
             {scriptsExpanded && (
               <TreeView aria-label="Scripts">

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -2,6 +2,7 @@ import { MarkGithubIcon, MoonIcon, SunIcon } from "@primer/octicons-react";
 import { isWailsEnvironment } from "./wails";
 import { BrowserOpenURL } from "./wailsjs/runtime/runtime";
 import { IconButtonXSmall } from "./IconButtonXSmall";
+import { FeaturePreview, FeaturePreviews } from "./FeaturePreviews";
 
 export type ColorMode = "day" | "night";
 
@@ -9,9 +10,11 @@ interface StatusBarProps {
   colorMode: ColorMode;
   onToggleColorMode: () => void;
   gitRef?: string;
+  featurePreviews: FeaturePreview[];
+  onToggleFeaturePreview: (key: string) => void;
 }
 
-export function StatusBar({ colorMode, onToggleColorMode, gitRef }: StatusBarProps) {
+export function StatusBar({ colorMode, onToggleColorMode, gitRef, featurePreviews, onToggleFeaturePreview }: StatusBarProps) {
   const shortRef = gitRef ? (gitRef.length > 7 ? gitRef.slice(0, 7) : gitRef) : undefined;
   const githubUrl = gitRef ? `https://github.com/wham/kaja/tree/${gitRef}` : undefined;
 
@@ -59,11 +62,14 @@ export function StatusBar({ colorMode, onToggleColorMode, gitRef }: StatusBarPro
           <div />
         )}
       </div>
-      <IconButtonXSmall
-        icon={colorMode === "night" ? SunIcon : MoonIcon}
-        aria-label={colorMode === "night" ? "Switch to light theme" : "Switch to dark theme"}
-        onClick={onToggleColorMode}
-      />
+      <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
+        <FeaturePreviews features={featurePreviews} onToggle={onToggleFeaturePreview} />
+        <IconButtonXSmall
+          icon={colorMode === "night" ? SunIcon : MoonIcon}
+          aria-label={colorMode === "night" ? "Switch to light theme" : "Switch to dark theme"}
+          onClick={onToggleColorMode}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Added a beaker button in the footer next to the theme selector that opens a small popup with toggles for experimental features. The first is the global Scripts feature, now gated behind the toggle and labelled "Preview" instead of "Beta".

https://claude.ai/code/session_01StkVFazL2EvrEefZhTj2Sk

---
_Generated by [Claude Code](https://claude.ai/code/session_01StkVFazL2EvrEefZhTj2Sk)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-286-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-286-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-286-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-286-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-286-newproject.png)

</details>
