### PR TITLE
Added the built-in Markdown app and typed app parameters

### DIFF
--- a/desktop/build/darwin/entitlements.plist
+++ b/desktop/build/darwin/entitlements.plist
@@ -14,7 +14,7 @@
     <key>com.apple.security.network.client</key>
     <true/>
 
-    <key>com.apple.security.files.user-selected.read-only</key>
+    <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
 
     <key>com.apple.security.files.bookmarks.app-scope</key>

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -267,6 +267,29 @@ func (a *App) OpenDirectoryDialog() (string, error) {
 	return dir, nil
 }
 
+// OpenFileDialog opens a native file picker for a single file. On macOS it saves
+// a security-scoped bookmark for the chosen file so a sandboxed app (e.g. the
+// Markdown app) can read and append to it across restarts.
+func (a *App) OpenFileDialog() (string, error) {
+	path, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{
+		Title: "Select Markdown File",
+		Filters: []runtime.FileFilter{
+			{DisplayName: "Markdown", Pattern: "*.md;*.markdown"},
+		},
+	})
+	if err != nil || path == "" {
+		return path, err
+	}
+
+	if a.bookmarkStore != nil {
+		if err := a.bookmarkStore.Save(path, path); err != nil {
+			slog.Warn("Failed to save bookmark", "path", path, "error", err)
+		}
+	}
+
+	return path, nil
+}
+
 func (a *App) Twirp(method string, req []byte) ([]byte, error) {
 	slog.Info("Twirp called", "method", method, "req_length", len(req))
 

--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wham/kaja/v2/internal/tempdir"
 	"github.com/wham/kaja/v2/pkg/apps"
+	"github.com/wham/kaja/v2/pkg/apps/markdown"
 	"github.com/wham/kaja/v2/pkg/apps/openapi"
 	"github.com/wham/kaja/v2/pkg/grpc"
 )
@@ -29,7 +30,8 @@ func NewApiService(configurationPath string, canUpdateConfiguration bool, gitRef
 		canUpdateConfiguration: canUpdateConfiguration,
 		gitRef:                 gitRef,
 		apps: apps.NewManager(map[string]apps.App{
-			"openapi": openapi.New(),
+			"openapi":  openapi.New(),
+			"markdown": markdown.New(),
 		}),
 	}
 }

--- a/server/pkg/api/api.pb.go
+++ b/server/pkg/api/api.pb.go
@@ -989,9 +989,10 @@ func (x *ConfigurationProject) GetHeaders() map[string]string {
 type ConfigurationApp struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Built-in app type. Currently only "openapi" is supported.
+	// Built-in app type, e.g. "openapi" or "markdown".
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	// App-specific creation parameters. For "openapi": {"spec_url": "<url>"}.
+	// App-specific creation parameters. For "openapi": {"spec_url": "<url>"};
+	// for "markdown": {"path": "<file>"}.
 	Parameters map[string]string `protobuf:"bytes,3,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Headers sent with each request the app makes to the upstream service.
 	Headers       map[string]string `protobuf:"bytes,4,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`

--- a/server/pkg/apps/markdown/markdown.go
+++ b/server/pkg/apps/markdown/markdown.go
@@ -1,0 +1,139 @@
+// Package markdown implements the built-in "markdown" app: it exposes a single
+// method that appends a line of text to a Markdown file on disk.
+//
+// The app has one creation parameter, "path", the absolute path to the Markdown
+// file. On the sandboxed macOS desktop the file is reached through a
+// security-scoped bookmark saved when the user picks it; the append itself is a
+// plain file write, the same on every platform.
+package markdown
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wham/kaja/v2/pkg/apps"
+	"github.com/wham/protoc-go/protoc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+const serviceTypeName = "markdown.Markdown"
+
+// protoSource is the static proto surface the markdown app renders: a single
+// AppendLine method that appends a line of text to the configured file.
+const protoSource = `syntax = "proto3";
+
+package markdown;
+
+message AppendLineRequest {
+  string text = 1 [json_name = "text"];
+}
+
+message AppendLineResponse {}
+
+service Markdown {
+  // Append a line of text to the Markdown file.
+  rpc AppendLine(AppendLineRequest) returns (AppendLineResponse);
+}
+`
+
+// App is the markdown app factory. Register it with the apps.Manager.
+type App struct{}
+
+func New() *App { return &App{} }
+
+func (a *App) Open(parameters map[string]string, protoDir string, log func(string)) (apps.Instance, error) {
+	path := strings.TrimSpace(parameters["path"])
+	if path == "" {
+		return nil, fmt.Errorf("missing required parameter %q", "path")
+	}
+	log("Markdown file: " + path)
+
+	if err := os.WriteFile(filepath.Join(protoDir, "markdown.proto"), []byte(protoSource), 0o644); err != nil {
+		return nil, fmt.Errorf("writing proto: %w", err)
+	}
+
+	input, output, err := compile(protoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &instance{path: path, input: input, output: output}, nil
+}
+
+// compile compiles the static proto and resolves AppendLine's request and
+// response descriptors, used to decode the request and encode the response.
+func compile(protoDir string) (protoreflect.MessageDescriptor, protoreflect.MessageDescriptor, error) {
+	result, err := protoc.New(protoc.WithProtoPaths(protoDir)).Compile("markdown.proto")
+	if err != nil {
+		return nil, nil, fmt.Errorf("compiling generated proto: %w", err)
+	}
+	files, err := protodesc.NewFiles(result.AsFileDescriptorSet())
+	if err != nil {
+		return nil, nil, fmt.Errorf("building descriptors: %w", err)
+	}
+	descriptor, err := files.FindDescriptorByName(protoreflect.FullName(serviceTypeName))
+	if err != nil {
+		return nil, nil, fmt.Errorf("finding service %s: %w", serviceTypeName, err)
+	}
+	service, ok := descriptor.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s is not a service", serviceTypeName)
+	}
+	method := service.Methods().ByName("AppendLine")
+	if method == nil {
+		return nil, nil, fmt.Errorf("method AppendLine missing from compiled descriptors")
+	}
+	return method.Input(), method.Output(), nil
+}
+
+// instance is a live opened markdown app bound to a single file on disk.
+type instance struct {
+	path   string
+	input  protoreflect.MessageDescriptor
+	output protoreflect.MessageDescriptor
+}
+
+func (in *instance) Invoke(methodPath string, request []byte, headers map[string]string) ([]byte, error) {
+	if lastSegment(methodPath) != "AppendLine" {
+		return nil, fmt.Errorf("unknown method %q", methodPath)
+	}
+
+	reqMsg := dynamicpb.NewMessage(in.input)
+	if len(request) > 0 {
+		if err := proto.Unmarshal(request, reqMsg); err != nil {
+			return nil, fmt.Errorf("decoding request: %w", err)
+		}
+	}
+	text := reqMsg.Get(in.input.Fields().ByName("text")).String()
+
+	if err := appendLine(in.path, text); err != nil {
+		return nil, err
+	}
+
+	return proto.Marshal(dynamicpb.NewMessage(in.output))
+}
+
+// appendLine appends text as a new line to the file, terminated by a newline.
+func appendLine(path, text string) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(text + "\n"); err != nil {
+		return fmt.Errorf("writing to %s: %w", path, err)
+	}
+	return nil
+}
+
+func lastSegment(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}

--- a/server/proto/api.proto
+++ b/server/proto/api.proto
@@ -126,9 +126,10 @@ message ConfigurationProject {
 
 message ConfigurationApp {
   string name = 1;
-  // Built-in app type. Currently only "openapi" is supported.
+  // Built-in app type, e.g. "openapi" or "markdown".
   string type = 2;
-  // App-specific creation parameters. For "openapi": {"spec_url": "<url>"}.
+  // App-specific creation parameters. For "openapi": {"spec_url": "<url>"};
+  // for "markdown": {"path": "<file>"}.
   map<string, string> parameters = 3;
   // Headers sent with each request the app makes to the upstream service.
   map<string, string> headers = 4;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,13 +8,12 @@ import {
   Flash,
   FormControl,
   IconButton,
-  Link,
   TextInput,
   ThemeProvider,
   Tooltip,
   useResponsiveValue,
 } from "@primer/react";
-import { ColumnsIcon, CommentDiscussionIcon, LightBulbIcon, RowsIcon, SidebarCollapseIcon, SidebarExpandIcon } from "@primer/octicons-react";
+import { ColumnsIcon, CommentDiscussionIcon, RowsIcon, SidebarCollapseIcon, SidebarExpandIcon } from "@primer/octicons-react";
 import * as monaco from "monaco-editor";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Console, ConsoleItem } from "./Console";
@@ -24,7 +23,8 @@ import { Definition } from "./Definition";
 import { Gutter } from "./Gutter";
 import { Kaja, MethodCall } from "./kaja";
 import { appConfiguration, createProjectRef, getDefaultMethod, Method, Project, Script, Service, updateProjectRef } from "./project";
-import { Sidebar, PreviewPill } from "./Sidebar";
+import { Sidebar } from "./Sidebar";
+import { NewAppDialog } from "./NewAppDialog";
 import { SearchPopup } from "./SearchPopup";
 import { StatusBar, ColorMode } from "./StatusBar";
 import { FeaturePreview } from "./FeaturePreviews";
@@ -143,9 +143,8 @@ export function App() {
   // Save-as dialog state for ⌘S; null when closed.
   const [saveAs, setSaveAs] = useState<{ name: string; content: string } | null>(null);
   const [saveAsError, setSaveAsError] = useState<string>();
-  // New App dialog state (currently only the built-in OpenAPI app); null when closed.
-  const [newApp, setNewApp] = useState<{ name: string; specUrl: string } | null>(null);
-  const [newAppError, setNewAppError] = useState<string>();
+  // Whether the New App dialog is open.
+  const [newAppOpen, setNewAppOpen] = useState(false);
   // Rename dialog and delete confirmation for scripts (right-click menu).
   const [renameScript, setRenameScript] = useState<{ script: Script; name: string } | null>(null);
   const [renameError, setRenameError] = useState<string>();
@@ -982,28 +981,11 @@ export function App() {
   };
 
   const onNewAppClick = () => {
-    setNewAppError(undefined);
-    setNewApp({ name: "", specUrl: "" });
+    setNewAppOpen(true);
   };
 
-  const onConfirmNewApp = async () => {
-    if (!newApp || !configuration) return;
-    const name = newApp.name.trim();
-    const specUrl = newApp.specUrl.trim();
-    if (!name) {
-      setNewAppError("Name is required");
-      return;
-    }
-    if (!specUrl) {
-      setNewAppError("OpenAPI spec URL is required");
-      return;
-    }
-    if (configuration.projects.some((p) => p.name === name) || (configuration.apps || []).some((a) => a.name === name)) {
-      setNewAppError("A project or app with this name already exists");
-      return;
-    }
-
-    const app: ConfigurationApp = { name, type: "openapi", parameters: { spec_url: specUrl }, headers: {} };
+  const onCreateApp = async (app: ConfigurationApp) => {
+    if (!configuration) return;
     const updatedConfiguration: Configuration = {
       ...configuration,
       apps: [...(configuration.apps || []), app],
@@ -1014,7 +996,7 @@ export function App() {
     if (response.configuration) {
       applyConfiguration(response.configuration);
     }
-    setNewApp(null);
+    setNewAppOpen(false);
     onCompilerClick();
   };
 
@@ -1421,72 +1403,12 @@ export function App() {
             </FormControl>
           </Dialog>
         )}
-        {newApp && (
-          <Dialog
-            title={
-              <>
-                New App
-                <PreviewPill />
-              </>
-            }
-            width="medium"
-            onClose={() => {
-              setNewApp(null);
-              setNewAppError(undefined);
-            }}
-            footerButtons={[
-              { content: "Cancel", onClick: () => setNewApp(null) },
-              { content: "Create", buttonType: "primary", onClick: onConfirmNewApp },
-            ]}
-          >
-            <FormControl>
-              <FormControl.Label>Name</FormControl.Label>
-              <TextInput
-                block
-                autoFocus
-                placeholder="Petstore"
-                value={newApp.name}
-                onChange={(e) => setNewApp((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
-              />
-            </FormControl>
-            <div style={{ marginTop: 16 }}>
-              <FormControl>
-                <FormControl.Label>OpenAPI spec URL</FormControl.Label>
-                <TextInput
-                  block
-                  placeholder="https://petstore3.swagger.io/api/v3/openapi.json"
-                  value={newApp.specUrl}
-                  onChange={(e) => setNewApp((prev) => (prev ? { ...prev, specUrl: e.target.value } : prev))}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      onConfirmNewApp();
-                    }
-                  }}
-                />
-                <FormControl.Caption>The OpenAPI 3.x document is converted into a service you can call like a gRPC or Twirp project.</FormControl.Caption>
-              </FormControl>
-            </div>
-            <div style={{ marginTop: 8 }}>
-              <Link
-                as="button"
-                type="button"
-                onClick={() => {
-                  setNewAppError(undefined);
-                  setNewApp({ name: "Petstore", specUrl: "https://petstore3.swagger.io/api/v3/openapi.json" });
-                }}
-                style={{ fontSize: 12, lineHeight: "18px", display: "inline-flex", alignItems: "center", gap: 4 }}
-              >
-                <LightBulbIcon size={12} />
-                Try the Swagger Petstore demo
-              </Link>
-            </div>
-            {newAppError && (
-              <div style={{ marginTop: 16 }}>
-                <Flash variant="danger">{newAppError}</Flash>
-              </div>
-            )}
-          </Dialog>
+        {newAppOpen && (
+          <NewAppDialog
+            existingNames={configuration ? [...configuration.projects.map((p) => p.name), ...(configuration.apps || []).map((a) => a.name)] : []}
+            onClose={() => setNewAppOpen(false)}
+            onCreate={onCreateApp}
+          />
         )}
         {renameScript && (
           <Dialog

--- a/ui/src/NewAppDialog.tsx
+++ b/ui/src/NewAppDialog.tsx
@@ -1,0 +1,157 @@
+import { Button, Dialog, Flash, FormControl, Link, TextInput, Tooltip } from "@primer/react";
+import { FileIcon, LightBulbIcon } from "@primer/octicons-react";
+import { useState } from "react";
+import { appTypes, AppTypeDefinition } from "./appTypes";
+import { ConfigurationApp } from "./server/api";
+import { PreviewPill } from "./Sidebar";
+import { isWailsEnvironment } from "./wails";
+import { OpenFileDialog } from "./wailsjs/go/main/App";
+
+interface NewAppDialogProps {
+  // Existing project and app names, used to reject duplicates.
+  existingNames: string[];
+  onClose: () => void;
+  onCreate: (app: ConfigurationApp) => Promise<void>;
+}
+
+// NewAppDialog walks the user through creating a built-in app: first a grid to
+// pick the app type, then a form with that type's parameters.
+export function NewAppDialog({ existingNames, onClose, onCreate }: NewAppDialogProps) {
+  const [selected, setSelected] = useState<AppTypeDefinition | null>(null);
+  const [name, setName] = useState("");
+  const [parameters, setParameters] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string>();
+  const [creating, setCreating] = useState(false);
+
+  const selectType = (type: AppTypeDefinition) => {
+    setSelected(type);
+    setName("");
+    setParameters({});
+    setError(undefined);
+  };
+
+  const submit = async () => {
+    if (!selected) return;
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required");
+      return;
+    }
+    const params: Record<string, string> = {};
+    for (const parameter of selected.parameters) {
+      const value = (parameters[parameter.key] ?? "").trim();
+      if (!value) {
+        setError(`${parameter.label} is required`);
+        return;
+      }
+      params[parameter.key] = value;
+    }
+    if (existingNames.includes(trimmedName)) {
+      setError("A project or app with this name already exists");
+      return;
+    }
+    setError(undefined);
+    setCreating(true);
+    try {
+      await onCreate({ name: trimmedName, type: selected.type, parameters: params, headers: {} });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const title = (
+    <>
+      New App
+      <PreviewPill />
+    </>
+  );
+
+  if (!selected) {
+    return (
+      <Dialog title={title} width="medium" onClose={onClose} footerButtons={[{ content: "Cancel", onClick: onClose }]}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          {appTypes.map((type) => (
+            <Tooltip key={type.type} text={type.description} direction="s">
+              <Button block size="large" leadingVisual={type.icon} onClick={() => selectType(type)}>
+                {type.label}
+              </Button>
+            </Tooltip>
+          ))}
+        </div>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog
+      title={title}
+      width="medium"
+      onClose={onClose}
+      footerButtons={[
+        { content: "Back", onClick: () => setSelected(null) },
+        { content: "Create", buttonType: "primary", onClick: submit, disabled: creating },
+      ]}
+    >
+      <FormControl>
+        <FormControl.Label>Name</FormControl.Label>
+        <TextInput block autoFocus placeholder={selected.label} value={name} onChange={(e) => setName(e.target.value)} />
+      </FormControl>
+      {selected.parameters.map((parameter) => (
+        <div key={parameter.key} style={{ marginTop: 16 }}>
+          <FormControl>
+            <FormControl.Label>{parameter.label}</FormControl.Label>
+            <TextInput
+              block
+              placeholder={parameter.placeholder}
+              value={parameters[parameter.key] ?? ""}
+              onChange={(e) => setParameters((prev) => ({ ...prev, [parameter.key]: e.target.value }))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submit();
+                }
+              }}
+              trailingAction={
+                parameter.type === "file" && isWailsEnvironment() ? (
+                  <TextInput.Action
+                    icon={FileIcon}
+                    aria-label="Select file"
+                    onClick={async () => {
+                      const path = await OpenFileDialog();
+                      if (path) {
+                        setParameters((prev) => ({ ...prev, [parameter.key]: path }));
+                      }
+                    }}
+                  />
+                ) : undefined
+              }
+            />
+            {parameter.caption && <FormControl.Caption>{parameter.caption}</FormControl.Caption>}
+          </FormControl>
+        </div>
+      ))}
+      {selected.demo && (
+        <div style={{ marginTop: 8 }}>
+          <Link
+            as="button"
+            type="button"
+            onClick={() => {
+              setError(undefined);
+              setName(selected.demo!.name);
+              setParameters({ ...selected.demo!.parameters });
+            }}
+            style={{ fontSize: 12, lineHeight: "18px", display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            <LightBulbIcon size={12} />
+            {selected.demo.label}
+          </Link>
+        </div>
+      )}
+      {error && (
+        <div style={{ marginTop: 16 }}>
+          <Flash variant="danger">{error}</Flash>
+        </div>
+      )}
+    </Dialog>
+  );
+}

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRightIcon,
   PackageIcon,
 } from "@primer/octicons-react";
+import { appTypeLabel } from "./appTypes";
 import { Method, Project, Script, Service, methodId } from "./project";
 import { RpcProtocol } from "./server/api";
 import { getPersistedValue, setPersistedValue } from "./storage";
@@ -67,7 +68,7 @@ function AppPill({ type }: { type: string }) {
         color: "var(--fgColor-accent)",
       }}
     >
-      {type === "openapi" ? "OpenAPI" : type}
+      {appTypeLabel(type)}
     </span>
   );
 }

--- a/ui/src/appTypes.ts
+++ b/ui/src/appTypes.ts
@@ -1,0 +1,71 @@
+import { GlobeIcon, Icon, MarkdownIcon } from "@primer/octicons-react";
+
+// Parameter kinds an app exposes in the New App form. "file" renders a native
+// file picker on the desktop (and a plain text field everywhere else).
+export type AppParameterType = "text" | "url" | "file";
+
+export interface AppParameterDefinition {
+  key: string;
+  label: string;
+  type: AppParameterType;
+  placeholder?: string;
+  caption?: string;
+}
+
+export interface AppTypeDefinition {
+  type: string;
+  label: string;
+  description: string;
+  icon: Icon;
+  parameters: AppParameterDefinition[];
+  // Optional one-click demo that prefills the form.
+  demo?: { label: string; name: string; parameters: Record<string, string> };
+}
+
+// The built-in app types, in the order shown in the New App grid. Keep in sync
+// with the app types registered on the server (server/pkg/api/api.go).
+export const appTypes: AppTypeDefinition[] = [
+  {
+    type: "openapi",
+    label: "OpenAPI",
+    description: "Call a REST API from its OpenAPI 3.x document.",
+    icon: GlobeIcon,
+    parameters: [
+      {
+        key: "spec_url",
+        label: "OpenAPI spec URL",
+        type: "url",
+        placeholder: "https://petstore3.swagger.io/api/v3/openapi.json",
+        caption: "The OpenAPI 3.x document is converted into a service you can call like a gRPC or Twirp project.",
+      },
+    ],
+    demo: {
+      label: "Try the Swagger Petstore demo",
+      name: "Petstore",
+      parameters: { spec_url: "https://petstore3.swagger.io/api/v3/openapi.json" },
+    },
+  },
+  {
+    type: "markdown",
+    label: "Markdown",
+    description: "Append lines of text to a Markdown file on disk.",
+    icon: MarkdownIcon,
+    parameters: [
+      {
+        key: "path",
+        label: "Markdown file",
+        type: "file",
+        placeholder: "/path/to/notes.md",
+        caption: "Calls append a line to this file. On the desktop, pick the file to grant access.",
+      },
+    ],
+  },
+];
+
+export function getAppType(type: string): AppTypeDefinition | undefined {
+  return appTypes.find((t) => t.type === type);
+}
+
+export function appTypeLabel(type: string): string {
+  return getAppType(type)?.label ?? type;
+}

--- a/ui/src/server/api.ts
+++ b/ui/src/server/api.ts
@@ -250,13 +250,14 @@ export interface ConfigurationApp {
      */
     name: string;
     /**
-     * Built-in app type. Currently only "openapi" is supported.
+     * Built-in app type, e.g. "openapi" or "markdown".
      *
      * @generated from protobuf field: string type = 2
      */
     type: string;
     /**
-     * App-specific creation parameters. For "openapi": {"spec_url": "<url>"}.
+     * App-specific creation parameters. For "openapi": {"spec_url": "<url>"};
+     * for "markdown": {"path": "<file>"}.
      *
      * @generated from protobuf field: map<string, string> parameters = 3
      */

--- a/ui/src/wailsjs/go/main/App.d.ts
+++ b/ui/src/wailsjs/go/main/App.d.ts
@@ -12,6 +12,8 @@ export function ListScripts():Promise<Array<main.ScriptFile>>;
 
 export function OpenDirectoryDialog():Promise<string>;
 
+export function OpenFileDialog():Promise<string>;
+
 export function ReadScriptFile(arg1:string):Promise<main.ScriptFile>;
 
 export function RenameScript(arg1:string,arg2:string):Promise<main.ScriptFile>;

--- a/ui/src/wailsjs/go/main/App.js
+++ b/ui/src/wailsjs/go/main/App.js
@@ -22,6 +22,10 @@ export function OpenDirectoryDialog() {
   return window['go']['main']['App']['OpenDirectoryDialog']();
 }
 
+export function OpenFileDialog() {
+  return window['go']['main']['App']['OpenFileDialog']();
+}
+
 export function ReadScriptFile(arg1) {
   return window['go']['main']['App']['ReadScriptFile'](arg1);
 }


### PR DESCRIPTION
Added a second built-in app, Markdown, that appends a line of text to a chosen Markdown file, and introduced typed app parameters (text/url/file) so the New App flow now opens with a grid of app types and renders a form per type — the file parameter uses the native macOS picker (with a security-scoped bookmark) on desktop and a text field on the server.

https://claude.ai/code/session_01EZ7ww6N4dm1rmcvSFmKVBv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ7ww6N4dm1rmcvSFmKVBv)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-287-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-287-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-287-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-287-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-287-newproject.png)

</details>
