### PR TITLE
Fixed cert import format in TestFlight script

### DIFF
--- a/scripts/testflight
+++ b/scripts/testflight
@@ -113,7 +113,10 @@ if [ -n "${DISTRIBUTION_CERT_P12_BASE64:-}" ] || [ -n "${INSTALLER_CERT_P12_BASE
         local cert_path
         cert_path="$(mktemp)"
         echo "$cert_base64" | base64 --decode > "$cert_path"
+        # -f pkcs12 is required: the temp file has no .p12 extension, so without
+        # it `security import` auto-detection fails with "Unknown format in import".
         security import "$cert_path" \
+            -f pkcs12 \
             -k "$KEYCHAIN_NAME" \
             -P "$cert_password" \
             -T /usr/bin/codesign \


### PR DESCRIPTION
Force `-f pkcs12` in the TestFlight script's cert import — the temp file has no `.p12` extension, so `security import` auto-detection failed with "Unknown format in import" on the first run.

https://claude.ai/code/session_012xk78SX7naULD1gpfph581

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-290-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-290-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-290-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-290-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-290-newproject.png)

</details>
