### PR TITLE
Bumped productVersion to 0.13.0 for TestFlight

### DIFF
--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -11,7 +11,7 @@
   "reloaddirs": "../server",
   "info": {
     "productName": "Kaja",
-    "productVersion": "0.12.0",
+    "productVersion": "0.13.0",
     "copyright": "2026 Tomas Vesely"
   },
   "author": {


### PR DESCRIPTION
0.12.0 is the released App Store version and its pre-release train is closed, so TestFlight uploads were rejected. Bumping to 0.13.0 opens a fresh train for build uploads on each merge.

https://claude.ai/code/session_012xk78SX7naULD1gpfph581

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-291-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-291-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-291-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-291-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-291-newproject.png)

</details>
