### PR TITLE
Added three macOS "Run Kaja Script" service slots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ small popup with a toggle per experimental feature. Enabled features are marked 
 `usePersistedState` under `featurePreview:<key>` keys.
 
 - **Scripts** (`featurePreview:scripts`, desktop only) — a global `<kajaHome>/scripts/` folder of standalone TypeScript scripts that bind to projects through their import paths and run from their own tabs.
-- **macOS "Run Kaja Script" text service** — select text in any app, then right-click → Services → "Run Kaja Script" to run a _pinned_ script with the selection exposed as `kaja.input` (macOS desktop only).
+- **macOS "Run Kaja Script" text service** — select text in any app, then right-click → Services → "Run Kaja Script 1/2/3" to run the script pinned to that slot, with the selection exposed as `kaja.input` (macOS desktop only). The three slots are static `NSServices` entries in `desktop/build/darwin/Info.plist` distinguished by `NSUserData`; scripts are assigned to slots from the Scripts sidebar context menu, persisted under `contextMenuScriptPaths`.
 - **Apps** (`featurePreview:apps`) — alongside projects, an _app_ is a built-in integration that exposes a proto surface kaja renders and invokes just like a gRPC project. When the preview is on, the "+" menu in the sidebar offers "New Project" vs "New App" (the New App entry and form both carry the "Preview" pill). Apps live in `kaja.json` under `apps` (`ConfigurationApp`: `name`, `type`, `parameters`, `headers`). The first built-in app type is **openapi**: given an OpenAPI 3.x spec URL (`parameters.spec_url`), it converts operations into proto services/methods and transcodes method calls into HTTP REST requests against the upstream API. Apps are **gRPC apps** — there is no Twirp path for apps.
 
 ### Apps architecture

--- a/desktop/build/darwin/Info.dev.plist
+++ b/desktop/build/darwin/Info.dev.plist
@@ -31,12 +31,50 @@
                 <key>NSMenuItem</key>
                 <dict>
                     <key>default</key>
-                    <string>Run Kaja Script</string>
+                    <string>Run Kaja Script 1</string>
                 </dict>
                 <key>NSMessage</key>
                 <string>runScript</string>
                 <key>NSPortName</key>
                 <string>Kaja</string>
+                <key>NSUserData</key>
+                <string>1</string>
+                <key>NSSendTypes</key>
+                <array>
+                    <string>public.utf8-plain-text</string>
+                    <string>NSStringPboardType</string>
+                </array>
+            </dict>
+            <dict>
+                <key>NSMenuItem</key>
+                <dict>
+                    <key>default</key>
+                    <string>Run Kaja Script 2</string>
+                </dict>
+                <key>NSMessage</key>
+                <string>runScript</string>
+                <key>NSPortName</key>
+                <string>Kaja</string>
+                <key>NSUserData</key>
+                <string>2</string>
+                <key>NSSendTypes</key>
+                <array>
+                    <string>public.utf8-plain-text</string>
+                    <string>NSStringPboardType</string>
+                </array>
+            </dict>
+            <dict>
+                <key>NSMenuItem</key>
+                <dict>
+                    <key>default</key>
+                    <string>Run Kaja Script 3</string>
+                </dict>
+                <key>NSMessage</key>
+                <string>runScript</string>
+                <key>NSPortName</key>
+                <string>Kaja</string>
+                <key>NSUserData</key>
+                <string>3</string>
                 <key>NSSendTypes</key>
                 <array>
                     <string>public.utf8-plain-text</string>

--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -33,12 +33,50 @@
                 <key>NSMenuItem</key>
                 <dict>
                     <key>default</key>
-                    <string>Run Kaja Script</string>
+                    <string>Run Kaja Script 1</string>
                 </dict>
                 <key>NSMessage</key>
                 <string>runScript</string>
                 <key>NSPortName</key>
                 <string>Kaja</string>
+                <key>NSUserData</key>
+                <string>1</string>
+                <key>NSSendTypes</key>
+                <array>
+                    <string>public.utf8-plain-text</string>
+                    <string>NSStringPboardType</string>
+                </array>
+            </dict>
+            <dict>
+                <key>NSMenuItem</key>
+                <dict>
+                    <key>default</key>
+                    <string>Run Kaja Script 2</string>
+                </dict>
+                <key>NSMessage</key>
+                <string>runScript</string>
+                <key>NSPortName</key>
+                <string>Kaja</string>
+                <key>NSUserData</key>
+                <string>2</string>
+                <key>NSSendTypes</key>
+                <array>
+                    <string>public.utf8-plain-text</string>
+                    <string>NSStringPboardType</string>
+                </array>
+            </dict>
+            <dict>
+                <key>NSMenuItem</key>
+                <dict>
+                    <key>default</key>
+                    <string>Run Kaja Script 3</string>
+                </dict>
+                <key>NSMessage</key>
+                <string>runScript</string>
+                <key>NSPortName</key>
+                <string>Kaja</string>
+                <key>NSUserData</key>
+                <string>3</string>
                 <key>NSSendTypes</key>
                 <array>
                     <string>public.utf8-plain-text</string>

--- a/desktop/services_darwin.go
+++ b/desktop/services_darwin.go
@@ -22,10 +22,11 @@ import (
 var serviceContext context.Context
 
 //export goServiceRunScript
-func goServiceRunScript(text *C.char) {
+func goServiceRunScript(slot *C.char, text *C.char) {
 	if serviceContext == nil {
 		return
 	}
+	slotNumber := C.GoString(slot)
 	selected := C.GoString(text)
 	// macOS calls this on the main thread inside the synchronous service handler.
 	// Wails runtime calls dispatch to the main thread internally, so invoking them
@@ -34,7 +35,7 @@ func goServiceRunScript(text *C.char) {
 	go func() {
 		runtime.WindowUnminimise(serviceContext)
 		runtime.WindowShow(serviceContext)
-		runtime.EventsEmit(serviceContext, "service:runScript", selected)
+		runtime.EventsEmit(serviceContext, "service:runScript", slotNumber, selected)
 	}()
 }
 

--- a/desktop/services_darwin.m
+++ b/desktop/services_darwin.m
@@ -1,12 +1,14 @@
 #import <Cocoa/Cocoa.h>
 
 // Implemented in Go (services_darwin.go) and called back when macOS delivers
-// selected text to our service.
-extern void goServiceRunScript(char *text);
+// selected text to our service. slot is the 1-based slot number identifying
+// which "Run Kaja Script N" menu item was invoked.
+extern void goServiceRunScript(char *slot, char *text);
 
-// KajaServiceProvider receives the "Run Kaja Script" Services invocation. The
+// KajaServiceProvider receives the "Run Kaja Script N" Services invocations. The
 // method name matches the NSMessage key in Info.plist, so the full selector is
-// runScript:userData:error:.
+// runScript:userData:error:. All three slots share this selector and are
+// distinguished by the NSUserData ("1", "2", "3") set per entry in Info.plist.
 @interface KajaServiceProvider : NSObject
 - (void)runScript:(NSPasteboard *)pboard userData:(NSString *)userData error:(NSString **)error;
 @end
@@ -19,9 +21,10 @@ extern void goServiceRunScript(char *text);
             if (error) *error = @"No text was selected.";
             return;
         }
-        // goServiceRunScript copies the string synchronously, so the autorelease
-        // pool may reclaim it afterwards.
-        goServiceRunScript((char *)[text UTF8String]);
+        // goServiceRunScript copies the strings synchronously, so the autorelease
+        // pool may reclaim them afterwards.
+        NSString *slot = userData ? userData : @"1";
+        goServiceRunScript((char *)[slot UTF8String], (char *)[text UTF8String]);
     }
 }
 @end

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -152,8 +152,14 @@ export function App() {
   const [renameScript, setRenameScript] = useState<{ script: Script; name: string } | null>(null);
   const [renameError, setRenameError] = useState<string>();
   const [deleteScript, setDeleteScript] = useState<Script | null>(null);
-  // Path of the script pinned to the macOS "Run Kaja Script" text service.
-  const [pinnedScriptPath, setPinnedScriptPath] = useState<string | undefined>(() => getPersistedValue<string>("contextMenuScriptPath"));
+  // Paths of the scripts pinned to the three macOS "Run Kaja Script N" text
+  // service slots. Index 0 maps to slot 1, etc. Empty entries are unassigned.
+  const [pinnedScriptPaths, setPinnedScriptPaths] = useState<(string | undefined)[]>(() => {
+    const stored = getPersistedValue<(string | undefined)[]>("contextMenuScriptPaths");
+    if (Array.isArray(stored)) return [stored[0], stored[1], stored[2]];
+    // Migrate the previous single-pin setting into slot 1.
+    return [getPersistedValue<string>("contextMenuScriptPath"), undefined, undefined];
+  });
   // Pending debounced disk writes for open script tabs, keyed by tab id.
   const scriptSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
@@ -637,28 +643,34 @@ export function App() {
     [captureActiveViewState, persistTabs, showFileError],
   );
 
-  // Persist the pinned script path so the macOS text service keeps targeting it
-  // across restarts.
+  // Persist the pinned script paths so the macOS text service slots keep
+  // targeting them across restarts.
   useEffect(() => {
-    setPersistedValue("contextMenuScriptPath", pinnedScriptPath);
-  }, [pinnedScriptPath]);
+    setPersistedValue("contextMenuScriptPaths", pinnedScriptPaths);
+  }, [pinnedScriptPaths]);
 
-  // Right-click → toggle which script the macOS "Run Kaja Script" service runs.
-  const onPinScript = useCallback((script: Script) => {
-    setPinnedScriptPath((current) => (current === script.path ? undefined : script.path));
+  // Right-click → toggle which script a given macOS "Run Kaja Script N" slot
+  // runs. A script occupies at most one slot, so assigning it clears any other.
+  const onPinScript = useCallback((script: Script, slot: number) => {
+    setPinnedScriptPaths((current) => {
+      const next = current.map((path) => (path === script.path ? undefined : path));
+      next[slot] = current[slot] === script.path ? undefined : script.path;
+      return next;
+    });
   }, []);
 
-  // Run the pinned script with text handed over by the macOS text service,
-  // exposing it to the script as `kaja.input`.
+  // Run the script pinned to a slot with text handed over by the macOS text
+  // service, exposing it to the script as `kaja.input`.
   const runContextMenuScript = useCallback(
-    async (text: string) => {
+    async (slot: number, text: string) => {
       if (!isWailsEnvironment()) return;
-      if (!pinnedScriptPath) {
-        showFileError("Pin a script to the context menu first.");
+      const path = pinnedScriptPaths[slot];
+      if (!path) {
+        showFileError(`Pin a script to slot ${slot + 1} first.`);
         return;
       }
       try {
-        const file = await ReadScriptFile(pinnedScriptPath);
+        const file = await ReadScriptFile(path);
         if (!file) return;
         // Open the script so the run is visible, then run it.
         await onScriptSelect({ path: file.path, name: file.name });
@@ -669,16 +681,17 @@ export function App() {
         showFileError(`Run failed: ${err}`);
       }
     },
-    [pinnedScriptPath, onScriptSelect, projects, showFileError],
+    [pinnedScriptPaths, onScriptSelect, projects, showFileError],
   );
 
   const runContextMenuScriptRef = useRef(runContextMenuScript);
   runContextMenuScriptRef.current = runContextMenuScript;
 
-  // Wire the native macOS "Run Kaja Script" text service.
+  // Wire the native macOS "Run Kaja Script N" text service slots. The native
+  // side sends the 1-based slot number from the invoked menu item.
   useEffect(() => {
     if (!isWailsEnvironment()) return;
-    const unsub = EventsOn("service:runScript", (text: string) => runContextMenuScriptRef.current(text));
+    const unsub = EventsOn("service:runScript", (slot: string, text: string) => runContextMenuScriptRef.current((parseInt(slot, 10) || 1) - 1, text));
     return () => unsub();
   }, []);
 
@@ -805,8 +818,8 @@ export function App() {
       setScripts((prev) => (prev ?? []).map((s) => (s.path === original.path ? renamed : s)).sort((a, b) => a.name.localeCompare(b.name)));
       // Re-point any open tab for this script at the new path/name.
       setTabs((prev) => prev.map((t) => (t.type === "script" && t.script.path === original.path ? { ...t, script: renamed } : t)));
-      // Keep the context-menu pin pointing at the renamed file.
-      setPinnedScriptPath((current) => (current === original.path ? renamed.path : current));
+      // Keep any context-menu slot pointing at the renamed file.
+      setPinnedScriptPaths((current) => current.map((path) => (path === original.path ? renamed.path : path)));
       persistTabs();
       setRenameScript(null);
       setRenameError(undefined);
@@ -825,8 +838,8 @@ export function App() {
         return;
       }
       setScripts((prev) => (prev ?? []).filter((s) => s.path !== script.path));
-      // Drop the context-menu pin if it pointed at the deleted script.
-      setPinnedScriptPath((current) => (current === script.path ? undefined : current));
+      // Clear any context-menu slot that pointed at the deleted script.
+      setPinnedScriptPaths((current) => current.map((path) => (path === script.path ? undefined : path)));
       setTabs((prevTabs) => {
         const idx = prevTabs.findIndex((t) => t.type === "script" && t.script.path === script.path);
         if (idx === -1) return prevTabs;
@@ -1144,7 +1157,7 @@ export function App() {
                   onRenameScript={isWailsEnvironment() ? onRenameScript : undefined}
                   onDeleteScript={isWailsEnvironment() ? (script) => setDeleteScript(script) : undefined}
                   onPinScript={isDesktopMac ? onPinScript : undefined}
-                  pinnedScriptPath={pinnedScriptPath}
+                  pinnedScriptPaths={pinnedScriptPaths}
                   currentMethod={selectedMethod}
                   currentScriptPath={activeScriptPath}
                   scrollToMethod={scrollToMethod}

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -102,15 +102,16 @@ interface SidebarProps {
   scripts?: Script[];
   currentMethod?: Method;
   currentScriptPath?: string;
-  // Path of the script pinned to the macOS "Run Kaja Script" text service.
-  pinnedScriptPath?: string;
+  // Paths pinned to the three macOS "Run Kaja Script N" text service slots;
+  // index 0 is slot 1. Empty entries are unassigned.
+  pinnedScriptPaths?: (string | undefined)[];
   scrollToMethod?: ScrollToMethod;
   canDeleteProjects?: boolean;
   onSelect: (method: Method, service: Service, project: Project) => void;
   onScriptSelect?: (script: Script) => void;
   onRenameScript?: (script: Script) => void;
   onDeleteScript?: (script: Script) => void;
-  onPinScript?: (script: Script) => void;
+  onPinScript?: (script: Script, slot: number) => void;
   onCompilerClick: () => void;
   onNewProjectClick: () => void;
   onNewAppClick: () => void;
@@ -125,7 +126,7 @@ export function Sidebar({
   scripts,
   currentMethod,
   currentScriptPath,
-  pinnedScriptPath,
+  pinnedScriptPaths,
   scrollToMethod,
   canDeleteProjects = true,
   onSelect,
@@ -452,11 +453,18 @@ export function Sidebar({
                     current={currentScriptPath === script.path}
                   >
                     {script.name}
-                    {pinnedScriptPath === script.path && (
-                      <TreeView.TrailingVisual label="Pinned to context menu">
-                        <PinIcon size={12} />
-                      </TreeView.TrailingVisual>
-                    )}
+                    {(() => {
+                      const slot = pinnedScriptPaths ? pinnedScriptPaths.indexOf(script.path) : -1;
+                      if (slot < 0) return null;
+                      return (
+                        <TreeView.TrailingVisual label={`Pinned to "Run Kaja Script ${slot + 1}"`}>
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 2 }}>
+                            <PinIcon size={12} />
+                            {slot + 1}
+                          </span>
+                        </TreeView.TrailingVisual>
+                      );
+                    })()}
                   </TreeView.Item>
                 ))}
               </TreeView>
@@ -650,19 +658,23 @@ export function Sidebar({
       <ActionMenu open={!!scriptMenu} onOpenChange={(open) => !open && setScriptMenu(null)} anchorRef={scriptMenuAnchorRef}>
         <ActionMenu.Overlay width="small">
           <ActionList>
-            {onPinScript && (
-              <ActionList.Item
-                onSelect={() => {
-                  const script = scriptMenu?.script;
-                  if (script) onPinScript(script);
-                }}
-              >
-                <ActionList.LeadingVisual>
-                  <PinIcon />
-                </ActionList.LeadingVisual>
-                {pinnedScriptPath === scriptMenu?.script.path ? "Unpin from context menu" : "Pin to context menu"}
-              </ActionList.Item>
-            )}
+            {onPinScript &&
+              [0, 1, 2].map((slot) => {
+                const script = scriptMenu?.script;
+                const occupant = pinnedScriptPaths?.[slot];
+                const pinnedHere = !!script && occupant === script.path;
+                const otherName = occupant && !pinnedHere ? occupant.split("/").pop() : undefined;
+                return (
+                  <ActionList.Item key={slot} onSelect={() => script && onPinScript(script, slot)}>
+                    <ActionList.LeadingVisual>
+                      <PinIcon />
+                    </ActionList.LeadingVisual>
+                    {pinnedHere ? `Unpin from "Run Kaja Script ${slot + 1}"` : `Pin to "Run Kaja Script ${slot + 1}"`}
+                    {otherName && <ActionList.Description>{otherName}</ActionList.Description>}
+                  </ActionList.Item>
+                );
+              })}
+            {onPinScript && <ActionList.Divider />}
             <ActionList.Item
               onSelect={() => {
                 const script = scriptMenu?.script;


### PR DESCRIPTION
Replaced the single pinned-script macOS text service with three fixed slots ("Run Kaja Script 1/2/3"), assignable per script from the Scripts sidebar context menu.

Slots are static `NSServices` entries distinguished by `NSUserData`; the sandbox prevents truly dynamic, script-named Services items, so numbered slots are used.

https://claude.ai/code/session_012qXZ86S8zVukCLPP4Be4rt

---
_Generated by [Claude Code](https://claude.ai/code/session_012qXZ86S8zVukCLPP4Be4rt)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-292-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-292-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-292-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-292-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-292-newproject.png)

</details>
