### PR TITLE
Enforced canUpdateConfiguration on the server side

### DIFF
--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -208,19 +208,23 @@ func (s *ApiService) GetConfiguration(ctx context.Context, req *GetConfiguration
 }
 
 func (s *ApiService) UpdateConfiguration(ctx context.Context, req *UpdateConfigurationRequest) (*UpdateConfigurationResponse, error) {
-	if !s.canUpdateConfiguration {
-		return nil, fmt.Errorf("updating configuration is not allowed")
-	}
-
 	if req.Configuration == nil {
 		return nil, fmt.Errorf("configuration is required")
 	}
 
-	slog.Info("Updating configuration")
-
 	currentResponse := LoadGetConfigurationResponse(s.configurationPath, s.canUpdateConfiguration)
 
-	req.Configuration.System = currentResponse.Configuration.System
+	// Enforce the effective flag, which honors both the constructor value and the
+	// file-based dev override (system.canUpdateConfiguration) - the same value
+	// GetConfiguration reports to the UI to gate config editing.
+	system := currentResponse.Configuration.System
+	if system == nil || !system.CanUpdateConfiguration {
+		return nil, fmt.Errorf("updating configuration is not allowed")
+	}
+
+	slog.Info("Updating configuration")
+
+	req.Configuration.System = system
 
 	if err := SaveConfiguration(s.configurationPath, req.Configuration); err != nil {
 		return nil, fmt.Errorf("failed to save configuration: %w", err)

--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -208,6 +208,10 @@ func (s *ApiService) GetConfiguration(ctx context.Context, req *GetConfiguration
 }
 
 func (s *ApiService) UpdateConfiguration(ctx context.Context, req *UpdateConfigurationRequest) (*UpdateConfigurationResponse, error) {
+	if !s.canUpdateConfiguration {
+		return nil, fmt.Errorf("updating configuration is not allowed")
+	}
+
 	if req.Configuration == nil {
 		return nil, fmt.Errorf("configuration is required")
 	}

--- a/server/pkg/api/configuration_test.go
+++ b/server/pkg/api/configuration_test.go
@@ -147,6 +147,38 @@ func TestUpdateConfiguration_AllowedWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestUpdateConfiguration_AllowedByFileOverride(t *testing.T) {
+	// Web/dev server constructs the service with canUpdateConfiguration=false, but
+	// the file-based dev override (system.canUpdateConfiguration) must still enable
+	// updates - the same effective flag GetConfiguration reports to the UI.
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(`{"system":{"canUpdateConfiguration":true}}`)); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	service := NewApiService(tmpfile.Name(), false, "")
+
+	_, err = service.UpdateConfiguration(context.Background(), &UpdateConfigurationRequest{
+		Configuration: &Configuration{
+			Projects: []*ConfigurationProject{
+				{Name: "test-project", Protocol: RpcProtocol_RPC_PROTOCOL_GRPC, Url: "http://localhost:8080"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error when file override enables updates, got %v", err)
+	}
+
+	getConfigurationResponse := LoadGetConfigurationResponse(tmpfile.Name(), false)
+	if len(getConfigurationResponse.Configuration.Projects) != 1 {
+		t.Fatalf("expected 1 saved project, got %d", len(getConfigurationResponse.Configuration.Projects))
+	}
+}
+
 func TestLoadGetConfigurationResponse_PathPrefixNormalization(t *testing.T) {
 	configContent := `{
 		"projects": [],

--- a/server/pkg/api/configuration_test.go
+++ b/server/pkg/api/configuration_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"os"
 	"testing"
 )
@@ -85,6 +86,64 @@ func TestLoadGetConfigurationResponse_MultipleProjectsScenario(t *testing.T) {
 
 	if getConfigurationResponse.Configuration.PathPrefix != "/test-prefix" {
 		t.Errorf("expected path prefix '/test-prefix', got %q", getConfigurationResponse.Configuration.PathPrefix)
+	}
+}
+
+func TestUpdateConfiguration_DeniedWhenNotAllowed(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte("{}")); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	service := NewApiService(tmpfile.Name(), false, "")
+
+	_, err = service.UpdateConfiguration(context.Background(), &UpdateConfigurationRequest{
+		Configuration: &Configuration{},
+	})
+	if err == nil {
+		t.Fatal("expected error when canUpdateConfiguration is false")
+	}
+
+	// The file must be left untouched.
+	content, readErr := os.ReadFile(tmpfile.Name())
+	if readErr != nil {
+		t.Fatalf("failed to read config file: %v", readErr)
+	}
+	if string(content) != "{}" {
+		t.Errorf("expected config file to be unchanged, got %q", string(content))
+	}
+}
+
+func TestUpdateConfiguration_AllowedWhenEnabled(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte("{}")); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	service := NewApiService(tmpfile.Name(), true, "")
+
+	_, err = service.UpdateConfiguration(context.Background(), &UpdateConfigurationRequest{
+		Configuration: &Configuration{
+			Projects: []*ConfigurationProject{
+				{Name: "test-project", Protocol: RpcProtocol_RPC_PROTOCOL_GRPC, Url: "http://localhost:8080"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error when canUpdateConfiguration is true, got %v", err)
+	}
+
+	getConfigurationResponse := LoadGetConfigurationResponse(tmpfile.Name(), true)
+	if len(getConfigurationResponse.Configuration.Projects) != 1 {
+		t.Fatalf("expected 1 saved project, got %d", len(getConfigurationResponse.Configuration.Projects))
 	}
 }
 


### PR DESCRIPTION
The `UpdateConfiguration` RPC saved `kaja.json` regardless of the `canUpdateConfiguration` flag (previously only a UI hint), letting an unauthenticated caller overwrite the configuration on the web/Docker build. It now rejects the call server-side when updates aren't allowed.

https://claude.ai/code/session_01Fqhx9SUqLd6bCZruErNjjt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fqhx9SUqLd6bCZruErNjjt)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-293-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-293-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-293-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-293-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-293-newproject.png)

</details>
