### PR TITLE
Optimized console rendering for long sessions

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -61,6 +61,9 @@ import { BrowserOpenURL, EventsEmit, EventsOn, WindowSetTitle } from "./wailsjs/
 import { CreateScript, DeleteScript, ListScripts, ReadScriptFile, RenameScript, WriteScriptFile } from "./wailsjs/go/main/App";
 import { runTask } from "./taskRunner";
 
+// Maximum number of console items kept in memory; older calls are dropped.
+const MAX_CONSOLE_ITEMS = 500;
+
 // Lowercase the first letter (e.g. method name "GetUser" -> "getUser").
 function lowerFirst(s: string): string {
   return s ? s.charAt(0).toLowerCase() + s.slice(1) : s;
@@ -159,9 +162,10 @@ export function App() {
       const index = consoleItems.findIndex((item) => "id" in item && item.id === methodCall.id);
       if (index > -1) {
         return consoleItems.map((item, i) => (i === index ? { ...methodCall } : item));
-      } else {
-        return [...consoleItems, { ...methodCall }];
       }
+      const next = [...consoleItems, { ...methodCall }];
+      // Cap history so a long session can't grow the console unbounded.
+      return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
     });
   }, []);
 

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon, FoldIcon, PlayIcon, TrashIcon, UnfoldIcon } from "@primer/octicons-react";
-import { useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Gutter } from "./Gutter";
 import { IconButton } from "@primer/react";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
@@ -64,9 +64,9 @@ export function Console({ items, onClear, colorMode = "night" }: ConsoleProps) {
     }
   }, [items.length]);
 
-  const handleRowClick = (index: number) => {
+  const handleRowClick = useCallback((index: number) => {
     setSelectedIndex(index);
-  };
+  }, []);
 
   const handleCopy = async () => {
     if (jsonViewerRef.current) {
@@ -186,7 +186,6 @@ export function Console({ items, onClear, colorMode = "night" }: ConsoleProps) {
         {/* Left panel - Call list */}
         <div
           ref={listRef}
-
           style={{
             width: callListWidth,
             overflowY: "auto",
@@ -195,10 +194,17 @@ export function Console({ items, onClear, colorMode = "night" }: ConsoleProps) {
         >
           {items.map((item, index) => {
             if (Array.isArray(item)) {
-              return <Console.LogRow key={index} logs={item} />;
+              return <Console.LogRow key={`log:${index}`} logs={item} />;
             } else if ("method" in item) {
               return (
-                <Console.MethodCallRow key={index} methodCall={item} isSelected={selectedIndex === index} onClick={() => handleRowClick(index)} now={now} />
+                <Console.MethodCallRow
+                  key={`mc:${item.id}`}
+                  methodCall={item}
+                  index={index}
+                  isSelected={selectedIndex === index}
+                  onSelect={handleRowClick}
+                  relativeTime={formatRelativeTime(item.timestamp, now)}
+                />
               );
             }
             return null;
@@ -261,12 +267,15 @@ Console.LogRow = function ({ logs }: LogRowProps) {
 
 interface MethodCallRowProps {
   methodCall: MethodCall;
+  index: number;
   isSelected: boolean;
-  onClick: () => void;
-  now: number;
+  onSelect: (index: number) => void;
+  relativeTime: string;
 }
 
-Console.MethodCallRow = function ({ methodCall, isSelected, onClick, now }: MethodCallRowProps) {
+// Memoized so the per-second timestamp tick only re-renders rows whose displayed
+// relative time actually changed, instead of every row on every tick.
+Console.MethodCallRow = memo(function MethodCallRow({ methodCall, index, isSelected, onSelect, relativeTime }: MethodCallRowProps) {
   const isStreaming = methodCall.streamOutputs !== undefined;
   const isStreamActive = isStreaming && !methodCall.streamComplete && !methodCall.error;
 
@@ -287,7 +296,7 @@ Console.MethodCallRow = function ({ methodCall, isSelected, onClick, now }: Meth
   }[status];
 
   return (
-    <div className={`console-row ${isSelected ? "selected" : ""}`} onClick={onClick}>
+    <div className={`console-row ${isSelected ? "selected" : ""}`} onClick={() => onSelect(index)}>
       <span style={{ color: statusColor, marginRight: 8, fontSize: 10 }}>{statusIcon}</span>
       <span
         style={{
@@ -308,11 +317,11 @@ Console.MethodCallRow = function ({ methodCall, isSelected, onClick, now }: Meth
           flexShrink: 0,
         }}
       >
-        {formatRelativeTime(methodCall.timestamp, now)}
+        {relativeTime}
       </span>
     </div>
   );
-};
+});
 
 type ConsoleTab = "request" | "response" | "headers";
 


### PR DESCRIPTION
The console kept every method call forever and re-rendered all rows once a second to refresh timestamps. Now history is capped at 500 calls, rows are keyed by stable id, and the method-call row is memoized so the per-second tick only re-renders rows whose displayed time changed.

https://claude.ai/code/session_017iWRm6SqgLjJ3VqTw4wysY

---
_Generated by [Claude Code](https://claude.ai/code/session_017iWRm6SqgLjJ3VqTw4wysY)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-295-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-295-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-295-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-295-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-295-newproject.png)

</details>
