### PR TITLE
Added frontend log file capture for desktop

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -247,6 +247,24 @@ func (a *App) RenameScript(path string, newName string) (*ScriptFile, error) {
 	return &ScriptFile{Path: newPath, Name: newName, Content: string(data)}, nil
 }
 
+// LogFromUI appends a log line from the frontend to <kajaHome>/logs/ui.log.
+// The webview console is otherwise only reachable through Web Inspector, so this
+// lets TestFlight users capture frontend errors and share them for debugging.
+func (a *App) LogFromUI(level string, message string) error {
+	dir := filepath.Join(a.workspaceDir, "logs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	line := fmt.Sprintf("%s [%s] %s\n", time.Now().Format(time.RFC3339), level, message)
+	f, err := os.OpenFile(filepath.Join(dir, "ui.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(line)
+	return err
+}
+
 // OpenDirectoryDialog opens a native directory picker dialog.
 // On macOS, it saves a security-scoped bookmark so the sandbox remembers
 // access across app restarts.

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -247,16 +247,17 @@ func (a *App) RenameScript(path string, newName string) (*ScriptFile, error) {
 	return &ScriptFile{Path: newPath, Name: newName, Content: string(data)}, nil
 }
 
-// LogFromUI appends a log line from the frontend to <kajaHome>/logs/ui.log.
-// The webview console is otherwise only reachable through Web Inspector, so this
+// LogFromUI appends a log line from the frontend to <kajaHome>/logs/kaja.log.
+// Lines are tagged "[ui]" so the file can also hold server logs later; the
+// webview console is otherwise only reachable through Web Inspector, so this
 // lets TestFlight users capture frontend errors and share them for debugging.
 func (a *App) LogFromUI(level string, message string) error {
 	dir := filepath.Join(a.workspaceDir, "logs")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	line := fmt.Sprintf("%s [%s] %s\n", time.Now().Format(time.RFC3339), level, message)
-	f, err := os.OpenFile(filepath.Join(dir, "ui.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	line := fmt.Sprintf("%s [ui] [%s] %s\n", time.Now().Format(time.RFC3339), level, message)
+	f, err := os.OpenFile(filepath.Join(dir, "kaja.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,9 +4,12 @@ import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
 import { getPersistedValue, initializeStorage } from "./storage";
+import { installUiLog } from "./uiLog";
 
 export * from "@protobuf-ts/runtime";
 export * from "@protobuf-ts/runtime-rpc";
+
+installUiLog();
 
 initializeStorage().then(() => {
   const colorMode = getPersistedValue<"day" | "night">("colorMode") ?? "night";

--- a/ui/src/uiLog.ts
+++ b/ui/src/uiLog.ts
@@ -22,7 +22,7 @@ function send(level: string, args: unknown[]): void {
 }
 
 /**
- * Mirror frontend console errors and uncaught failures into <kajaHome>/logs/ui.log
+ * Mirror frontend console errors and uncaught failures into <kajaHome>/logs/kaja.log
  * via the desktop app. The webview console is otherwise only visible in Web
  * Inspector, so this is how TestFlight users can share frontend logs. No-op
  * outside the Wails desktop environment.

--- a/ui/src/uiLog.ts
+++ b/ui/src/uiLog.ts
@@ -1,0 +1,53 @@
+import { LogFromUI } from "./wailsjs/go/main/App";
+import { isWailsEnvironment } from "./wails";
+
+function formatArg(arg: unknown): string {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  if (arg instanceof Error) {
+    return arg.stack || arg.message;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function send(level: string, args: unknown[]): void {
+  const message = args.map(formatArg).join(" ");
+  // Logging must never throw or recurse back into the patched console.
+  LogFromUI(level, message).catch(() => {});
+}
+
+/**
+ * Mirror frontend console errors and uncaught failures into <kajaHome>/logs/ui.log
+ * via the desktop app. The webview console is otherwise only visible in Web
+ * Inspector, so this is how TestFlight users can share frontend logs. No-op
+ * outside the Wails desktop environment.
+ */
+export function installUiLog(): void {
+  if (!isWailsEnvironment()) {
+    return;
+  }
+
+  const originalError = console.error.bind(console);
+  const originalWarn = console.warn.bind(console);
+
+  console.error = (...args: unknown[]) => {
+    originalError(...args);
+    send("ERROR", args);
+  };
+  console.warn = (...args: unknown[]) => {
+    originalWarn(...args);
+    send("WARN", args);
+  };
+
+  window.addEventListener("error", (event) => {
+    send("ERROR", [event.error ?? event.message]);
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    send("ERROR", [event.reason]);
+  });
+}

--- a/ui/src/wailsjs/go/main/App.d.ts
+++ b/ui/src/wailsjs/go/main/App.d.ts
@@ -10,6 +10,8 @@ export function DeleteScript(arg1:string):Promise<void>;
 
 export function ListScripts():Promise<Array<main.ScriptFile>>;
 
+export function LogFromUI(arg1:string,arg2:string):Promise<void>;
+
 export function OpenDirectoryDialog():Promise<string>;
 
 export function OpenFileDialog():Promise<string>;

--- a/ui/src/wailsjs/go/main/App.js
+++ b/ui/src/wailsjs/go/main/App.js
@@ -18,6 +18,10 @@ export function ListScripts() {
   return window['go']['main']['App']['ListScripts']();
 }
 
+export function LogFromUI(arg1, arg2) {
+  return window['go']['main']['App']['LogFromUI'](arg1, arg2);
+}
+
 export function OpenDirectoryDialog() {
   return window['go']['main']['App']['OpenDirectoryDialog']();
 }


### PR DESCRIPTION
Mirrors webview console errors/warnings and uncaught failures into `<kajaHome>/logs/ui.log` (via a new `LogFromUI` binding) so TestFlight users can share frontend logs that are otherwise only visible in Web Inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1mWZr92N1nq1Ubuuw8Uvk)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-296-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-296-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-296-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-296-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-296-newproject.png)

</details>
