### PR TITLE
Added Help menu with Show Logs in Finder action

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -127,7 +127,24 @@ func (a *App) buildAppMenu(scriptsEnabled bool) *menu.Menu {
 		runtime.WindowReloadApp(a.ctx)
 	})
 	appMenu.Append(menu.WindowMenu())
+
+	helpMenu := appMenu.AddSubmenu("Help")
+	helpMenu.AddText("Show Logs in Finder", nil, func(_ *menu.CallbackData) {
+		a.showLogsInFinder()
+	})
+
 	return appMenu
+}
+
+// showLogsInFinder reveals the logs directory (see LogFromUI) in the system
+// file browser, creating it first if it doesn't exist yet.
+func (a *App) showLogsInFinder() {
+	dir := filepath.Join(a.workspaceDir, "logs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		slog.Warn("Failed to create logs directory", "error", err)
+		return
+	}
+	runtime.BrowserOpenURL(a.ctx, "file://"+dir)
 }
 
 // ScriptFile is the on-disk representation of a Kaja script.


### PR DESCRIPTION
Added a Help menu as the last item in the desktop app's native menu bar with a "Show Logs in Finder" action that reveals the `<kajaHome>/logs/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzpDCxYNJt8hTPTDSNM459)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-297-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-297-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-297-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-297-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-297-newproject.png)

</details>
