### PR TITLE
Fixed Show Logs in Finder menu action

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -144,7 +144,7 @@ func (a *App) showLogsInFinder() {
 		slog.Warn("Failed to create logs directory", "error", err)
 		return
 	}
-	runtime.BrowserOpenURL(a.ctx, "file://"+dir)
+	revealInFinder(dir)
 }
 
 // ScriptFile is the on-disk representation of a Kaja script.

--- a/desktop/reveal_darwin.go
+++ b/desktop/reveal_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo LDFLAGS: -framework Cocoa
+#include <stdlib.h>
+
+// Defined in reveal_darwin.m.
+void revealPathInFinder(char *path);
+*/
+import "C"
+
+import "unsafe"
+
+// revealInFinder opens the given directory in Finder. Uses NSWorkspace so it
+// works inside the App Sandbox, where launching a subprocess would be blocked.
+func revealInFinder(path string) {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	C.revealPathInFinder(cpath)
+}

--- a/desktop/reveal_darwin.m
+++ b/desktop/reveal_darwin.m
@@ -1,0 +1,15 @@
+#import <Cocoa/Cocoa.h>
+
+// Opens the given directory in Finder. Called from Go (reveal_darwin.go).
+void revealPathInFinder(char *path) {
+    @autoreleasepool {
+        NSString *p = [NSString stringWithUTF8String:path];
+        if (p == nil) {
+            return;
+        }
+        NSURL *url = [NSURL fileURLWithPath:p isDirectory:YES];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSWorkspace sharedWorkspace] openURL:url];
+        });
+    }
+}

--- a/desktop/reveal_other.go
+++ b/desktop/reveal_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin
+
+package main
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// revealInFinder opens the given directory in the system file browser.
+func revealInFinder(path string) {
+	if runtime.GOOS == "windows" {
+		_ = exec.Command("explorer", path).Start()
+		return
+	}
+	_ = exec.Command("xdg-open", path).Start()
+}


### PR DESCRIPTION
The "Show Logs in Finder" menu action did nothing because Wails' `BrowserOpenURL` rejects the `file://` scheme. This reveals the logs directory via `NSWorkspace` on macOS instead, which also works inside the App Sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzpDCxYNJt8hTPTDSNM459)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-299-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-299-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-299-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-299-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-299-newproject.png)

</details>
