### PR TITLE
Made captured frontend error logs readable

### DIFF
--- a/server/internal/ui/builder.go
+++ b/server/internal/ui/builder.go
@@ -70,7 +70,10 @@ func BuildForProduction() (*UiBundle, error) {
 		MinifyWhitespace:  true,
 		MinifyIdentifiers: true,
 		MinifySyntax:      true,
-		Outdir:            "build",
+		// Preserve function/class names so stack traces captured in the desktop
+		// logs (uiLog.ts) stay readable instead of showing mangled identifiers.
+		KeepNames: true,
+		Outdir:    "build",
 		Loader: map[string]esbuild.Loader{
 			".ttf": esbuild.LoaderFile,
 		},

--- a/ui/src/uiLog.ts
+++ b/ui/src/uiLog.ts
@@ -6,7 +6,14 @@ function formatArg(arg: unknown): string {
     return arg;
   }
   if (arg instanceof Error) {
-    return arg.stack || arg.message;
+    const head = arg.message ? `${arg.name}: ${arg.message}` : arg.name;
+    const stack = arg.stack ?? "";
+    // V8 prefixes the stack with "name: message"; WebKit (macOS WKWebView) emits
+    // only the call frames, so prepend the header ourselves to keep the message.
+    if (stack === "" || stack.startsWith(arg.name)) {
+      return stack || head;
+    }
+    return `${head}\n${stack}`;
   }
   try {
     return JSON.stringify(arg);
@@ -45,7 +52,12 @@ export function installUiLog(): void {
   };
 
   window.addEventListener("error", (event) => {
-    send("ERROR", [event.error ?? event.message]);
+    if (event.error instanceof Error) {
+      send("ERROR", [event.error]);
+      return;
+    }
+    const where = event.filename ? ` (${event.filename}:${event.lineno}:${event.colno})` : "";
+    send("ERROR", [`${event.message}${where}`]);
   });
   window.addEventListener("unhandledrejection", (event) => {
     send("ERROR", [event.reason]);


### PR DESCRIPTION
Frontend errors captured into the desktop logs were unhelpful: on macOS WebKit, `Error.stack` omits the `name: message` header that V8 includes, so the actual error message was dropped. This prepends it in `uiLog`, enriches uncaught `error` events with their source location, and enables esbuild `KeepNames` so minified stack frames retain real function names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzpDCxYNJt8hTPTDSNM459)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-300-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-300-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-300-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-300-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-300-newproject.png)

</details>
