### PR TITLE
Added kaja.ask() to prompt the user for input from scripts

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,7 +21,7 @@ import { GetStartedBlankslate } from "./GetStartedBlankslate";
 import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Gutter } from "./Gutter";
-import { Kaja, MethodCall } from "./kaja";
+import { AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { appConfiguration, createProjectRef, getDefaultMethod, Method, Project, Script, Service, updateProjectRef } from "./project";
 import { Sidebar } from "./Sidebar";
 import { NewAppDialog } from "./NewAppDialog";
@@ -146,6 +146,13 @@ export function App() {
   // Save-as dialog state for ⌘S; null when closed.
   const [saveAs, setSaveAs] = useState<{ name: string; content: string } | null>(null);
   const [saveAsError, setSaveAsError] = useState<string>();
+  // Active `kaja.ask(...)` prompt; null when no script is waiting for input.
+  const [askPrompt, setAskPrompt] = useState<{
+    message: string;
+    value: string;
+    resolve: (value: string) => void;
+    reject: (reason: unknown) => void;
+  } | null>(null);
   // Whether the New App dialog is open.
   const [newAppOpen, setNewAppOpen] = useState(false);
   // Rename dialog and delete confirmation for scripts (right-click menu).
@@ -169,9 +176,17 @@ export function App() {
     });
   }, []);
 
+  // Open the input dialog for a `kaja.ask(...)` call, resolving once the user
+  // submits. Rejecting on cancel is handled by the dialog itself.
+  const onAsk = useCallback((message: string) => {
+    return new Promise<string>((resolve, reject) => {
+      setAskPrompt({ message, value: "", resolve, reject });
+    });
+  }, []);
+
   const kajaRef = useRef<Kaja>(null);
   if (!kajaRef.current) {
-    kajaRef.current = new Kaja(onMethodCallUpdate);
+    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk);
   }
 
   const onClearConsole = useCallback(() => {
@@ -1405,6 +1420,50 @@ export function App() {
                 }}
               />
               {saveAsError && <FormControl.Validation variant="error">{saveAsError}</FormControl.Validation>}
+            </FormControl>
+          </Dialog>
+        )}
+        {askPrompt && (
+          <Dialog
+            title="Input"
+            width="medium"
+            onClose={() => {
+              askPrompt.reject(new AskCancelledError());
+              setAskPrompt(null);
+            }}
+            footerButtons={[
+              {
+                content: "Cancel",
+                onClick: () => {
+                  askPrompt.reject(new AskCancelledError());
+                  setAskPrompt(null);
+                },
+              },
+              {
+                content: "Submit",
+                buttonType: "primary",
+                onClick: () => {
+                  askPrompt.resolve(askPrompt.value);
+                  setAskPrompt(null);
+                },
+              },
+            ]}
+          >
+            <FormControl>
+              <FormControl.Label>{askPrompt.message}</FormControl.Label>
+              <TextInput
+                block
+                autoFocus
+                value={askPrompt.value}
+                onChange={(e) => setAskPrompt((prev) => (prev ? { ...prev, value: e.target.value } : prev))}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    askPrompt.resolve(askPrompt.value);
+                    setAskPrompt(null);
+                  }
+                }}
+              />
             </FormControl>
           </Dialog>
         )}

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -44,6 +44,13 @@ declare const kaja: {
    * from the editor, so guard with a fallback (e.g. kaja.input ?? "").
    */
   input?: string;
+  /**
+   * Pause the script and pop up a dialog asking the user for input. Resolves
+   * with the submitted text; if the user cancels, the script stops.
+   *
+   *   const name = await kaja.ask("What's your name?");
+   */
+  ask(message: string): Promise<string>;
 };
 `,
   "ts:kaja-globals.d.ts",

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -2,14 +2,35 @@ import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./project";
 import { captureValues } from "./typeMemory";
 
+// Thrown when the user cancels a `kaja.ask(...)` prompt. The task runner
+// swallows it so a cancelled prompt quietly stops the script.
+export class AskCancelledError extends Error {
+  constructor() {
+    super("Kaja prompt cancelled");
+    this.name = "AskCancelledError";
+  }
+}
+
+export interface AskRequest {
+  (message: string): Promise<string>;
+}
+
 export class Kaja {
   readonly _internal: KajaInternal;
   // Text passed in when a script is run from the macOS "Run Kaja Script" text
   // service. Scripts can read it as `kaja.input`.
   input?: string;
+  #onAsk: AskRequest;
 
-  constructor(onMethodCallUpdate: MethodCallUpdate) {
+  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest) {
     this._internal = new KajaInternal(onMethodCallUpdate);
+    this.#onAsk = onAsk;
+  }
+
+  // Pause the script and pop up a dialog asking the user for input. Resolves
+  // with the submitted text; rejects (aborting the script) if the user cancels.
+  ask(message: string): Promise<string> {
+    return this.#onAsk(message);
   }
 }
 

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { Kaja } from "./kaja";
+import { AskCancelledError, Kaja } from "./kaja";
 import { Client, Project, serviceId } from "./project";
 import { printStatements } from "./projectLoader";
 
@@ -57,5 +57,12 @@ export function runTask(code: string, kaja: Kaja, projects: Project[]) {
   `,
   );
 
-  func(...Object.values(args), kaja);
+  const result = func(...Object.values(args), kaja);
+  if (result && typeof result.then === "function") {
+    result.catch((err: unknown) => {
+      // A cancelled prompt simply stops the script; surface everything else.
+      if (err instanceof AskCancelledError) return;
+      throw err;
+    });
+  }
 }


### PR DESCRIPTION
Adds a `kaja.ask(message)` method to the built-in Kaja object that pauses a script, pops up a dialog to capture text input, and resumes with the submitted value (cancelling aborts the script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDGMLway3hzHnDdy1ANimV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDGMLway3hzHnDdy1ANimV)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-301-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-301-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-301-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-301-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-301-newproject.png)

</details>
