### PR TITLE
Added an OpenAI app exposing the chat completions API

### DIFF
--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wham/kaja/v2/internal/tempdir"
 	"github.com/wham/kaja/v2/pkg/apps"
 	"github.com/wham/kaja/v2/pkg/apps/markdown"
+	"github.com/wham/kaja/v2/pkg/apps/openai"
 	"github.com/wham/kaja/v2/pkg/apps/openapi"
 	"github.com/wham/kaja/v2/pkg/grpc"
 )
@@ -33,6 +34,7 @@ func NewApiService(configurationPath string, canUpdateConfiguration bool, gitRef
 		buildNumber:            buildNumber,
 		apps: apps.NewManager(map[string]apps.App{
 			"openapi":  openapi.New(),
+			"openai":   openai.New(),
 			"markdown": markdown.New(),
 		}),
 	}

--- a/server/pkg/apps/openai/invoke.go
+++ b/server/pkg/apps/openai/invoke.go
@@ -42,16 +42,36 @@ func (in *instance) Invoke(methodPath string, request []byte, headers map[string
 		return nil, err
 	}
 
-	respJSON, err := in.call(body, headers)
+	respBody, status, err := in.call(body, headers)
 	if err != nil {
 		return nil, err
 	}
 
 	respMsg := dynamicpb.NewMessage(in.output)
-	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respJSON, respMsg); err != nil {
+	if status >= 400 {
+		// Surface the upstream failure as a structured error on the response
+		// rather than a flat transport error, so the status code, the OpenAI
+		// error type/code/param and the raw body are all visible in the response.
+		return in.encodeError(respMsg, parseUpstreamError(status, respBody))
+	}
+
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respBody, respMsg); err != nil {
 		return nil, fmt.Errorf("decoding response JSON: %w", err)
 	}
 	setReplyContent(respMsg)
+	return proto.Marshal(respMsg)
+}
+
+// encodeError populates the response's "error" field from the structured upstream
+// error and marshals it.
+func (in *instance) encodeError(respMsg *dynamicpb.Message, upstream map[string]any) ([]byte, error) {
+	payload, err := json.Marshal(map[string]any{"error": upstream})
+	if err != nil {
+		return nil, fmt.Errorf("encoding error response: %w", err)
+	}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(payload, respMsg); err != nil {
+		return nil, fmt.Errorf("encoding error response: %w", err)
+	}
 	return proto.Marshal(respMsg)
 }
 
@@ -94,12 +114,14 @@ func (in *instance) buildRequestBody(reqMsg *dynamicpb.Message) ([]byte, error) 
 }
 
 // call POSTs the request body to <base_url>/chat/completions, returning the raw
-// JSON response body.
-func (in *instance) call(body []byte, headers map[string]string) ([]byte, error) {
+// response body and HTTP status code. An error is returned only for transport
+// failures (the upstream could not be reached); HTTP error responses are returned
+// with their status so the caller can shape them into a structured error.
+func (in *instance) call(body []byte, headers map[string]string) ([]byte, int, error) {
 	endpoint := in.baseURL + "/chat/completions"
 	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("building request: %w", err)
+		return nil, 0, fmt.Errorf("building request: %w", err)
 	}
 	for k, v := range headers {
 		httpReq.Header.Set(k, v)
@@ -112,18 +134,72 @@ func (in *instance) call(body []byte, headers map[string]string) ([]byte, error)
 
 	resp, err := in.client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("calling %s: %w", endpoint, err)
+		return nil, 0, fmt.Errorf("calling %s: %w", endpoint, err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
 	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("reading response: %w", err)
 	}
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("upstream %s returned %s: %s", endpoint, resp.Status, truncate(respBody, 500))
+	return respBody, resp.StatusCode, nil
+}
+
+// parseUpstreamError turns a failed (HTTP >= 400) upstream response into the
+// structured error shape exposed on ChatCompletionResponse.error. It understands
+// the standard OpenAI error envelope ({"error": {"message", "type", "code",
+// "param"}}) and falls back to the raw body for anything else.
+func parseUpstreamError(status int, body []byte) map[string]any {
+	result := map[string]any{
+		"status": status,
+		"body":   truncate(body, 4000),
 	}
-	return respBody, nil
+
+	var envelope struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if json.Unmarshal(body, &envelope) == nil {
+		if len(bytes.TrimSpace(envelope.Error)) > 0 {
+			var detail struct {
+				Message string          `json:"message"`
+				Type    string          `json:"type"`
+				Code    json.RawMessage `json:"code"`
+				Param   json.RawMessage `json:"param"`
+			}
+			if json.Unmarshal(envelope.Error, &detail) == nil && detail.Message != "" {
+				result["message"] = detail.Message
+				result["type"] = detail.Type
+				result["code"] = rawString(detail.Code)
+				result["param"] = rawString(detail.Param)
+			} else if s := rawString(envelope.Error); s != "" {
+				result["message"] = s
+			}
+		} else if envelope.Message != "" {
+			result["message"] = envelope.Message
+		}
+	}
+	if _, ok := result["message"]; !ok {
+		if text := http.StatusText(status); text != "" {
+			result["message"] = text
+		} else {
+			result["message"] = fmt.Sprintf("upstream returned HTTP %d", status)
+		}
+	}
+	return result
+}
+
+// rawString renders a JSON value as a plain string, treating null/absent as "".
+func rawString(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return trimmed
 }
 
 // setReplyContent copies the first choice's message content into the top-level

--- a/server/pkg/apps/openai/invoke.go
+++ b/server/pkg/apps/openai/invoke.go
@@ -1,0 +1,168 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// instance is a live opened OpenAI app. It is a gRPC app: a ChatCompletion call
+// arrives as protobuf, is transcoded into a POST against the chat completions
+// endpoint, and the JSON response is shaped back into the protobuf response.
+type instance struct {
+	baseURL string
+	token   string
+	input   protoreflect.MessageDescriptor
+	output  protoreflect.MessageDescriptor
+	client  *http.Client
+}
+
+func (in *instance) Invoke(methodPath string, request []byte, headers map[string]string) ([]byte, error) {
+	if lastSegment(methodPath) != "ChatCompletion" {
+		return nil, fmt.Errorf("unknown method %q", methodPath)
+	}
+
+	reqMsg := dynamicpb.NewMessage(in.input)
+	if len(request) > 0 {
+		if err := proto.Unmarshal(request, reqMsg); err != nil {
+			return nil, fmt.Errorf("decoding request: %w", err)
+		}
+	}
+
+	body, err := in.buildRequestBody(reqMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	respJSON, err := in.call(body, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	respMsg := dynamicpb.NewMessage(in.output)
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respJSON, respMsg); err != nil {
+		return nil, fmt.Errorf("decoding response JSON: %w", err)
+	}
+	setReplyContent(respMsg)
+	return proto.Marshal(respMsg)
+}
+
+// buildRequestBody turns the decoded ChatCompletion request into the JSON body
+// the OpenAI chat completions endpoint expects: the system and user prompts are
+// folded into a messages array and the optional sampling fields are passed
+// through only when the caller set them.
+func (in *instance) buildRequestBody(reqMsg *dynamicpb.Message) ([]byte, error) {
+	fields := in.input.Fields()
+	getString := func(name string) string {
+		return reqMsg.Get(fields.ByName(protoreflect.Name(name))).String()
+	}
+
+	model := strings.TrimSpace(getString("model"))
+	if model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+
+	messages := []map[string]string{}
+	if system := getString("system_prompt"); system != "" {
+		messages = append(messages, map[string]string{"role": "system", "content": system})
+	}
+	messages = append(messages, map[string]string{"role": "user", "content": getString("user_prompt")})
+
+	payload := map[string]any{
+		"model":    model,
+		"messages": messages,
+	}
+	if fd := fields.ByName("temperature"); reqMsg.Has(fd) {
+		payload["temperature"] = reqMsg.Get(fd).Float()
+	}
+	if fd := fields.ByName("max_tokens"); reqMsg.Has(fd) {
+		payload["max_tokens"] = reqMsg.Get(fd).Int()
+	}
+	if fd := fields.ByName("top_p"); reqMsg.Has(fd) {
+		payload["top_p"] = reqMsg.Get(fd).Float()
+	}
+
+	return json.Marshal(payload)
+}
+
+// call POSTs the request body to <base_url>/chat/completions, returning the raw
+// JSON response body.
+func (in *instance) call(body []byte, headers map[string]string) ([]byte, error) {
+	endpoint := in.baseURL + "/chat/completions"
+	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	if in.token != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+in.token)
+	}
+
+	resp, err := in.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upstream %s returned %s: %s", endpoint, resp.Status, truncate(respBody, 500))
+	}
+	return respBody, nil
+}
+
+// setReplyContent copies the first choice's message content into the top-level
+// convenience "content" field of the response.
+func setReplyContent(respMsg *dynamicpb.Message) {
+	desc := respMsg.Descriptor()
+	choicesFd := desc.Fields().ByName("choices")
+	contentFd := desc.Fields().ByName("content")
+	if choicesFd == nil || contentFd == nil {
+		return
+	}
+	choices := respMsg.Get(choicesFd).List()
+	if choices.Len() == 0 {
+		return
+	}
+	choice := choices.Get(0).Message()
+	messageFd := choicesFd.Message().Fields().ByName("message")
+	if messageFd == nil || !choice.Has(messageFd) {
+		return
+	}
+	message := choice.Get(messageFd).Message()
+	msgContentFd := messageFd.Message().Fields().ByName("content")
+	if msgContentFd == nil {
+		return
+	}
+	respMsg.Set(contentFd, protoreflect.ValueOfString(message.Get(msgContentFd).String()))
+}
+
+func lastSegment(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+func truncate(b []byte, n int) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}

--- a/server/pkg/apps/openai/invoke.go
+++ b/server/pkg/apps/openai/invoke.go
@@ -18,11 +18,11 @@ import (
 // arrives as protobuf, is transcoded into a POST against the chat completions
 // endpoint, and the JSON response is shaped back into the protobuf response.
 type instance struct {
-	baseURL string
-	token   string
-	input   protoreflect.MessageDescriptor
-	output  protoreflect.MessageDescriptor
-	client  *http.Client
+	endpoint string
+	token    string
+	input    protoreflect.MessageDescriptor
+	output   protoreflect.MessageDescriptor
+	client   *http.Client
 }
 
 func (in *instance) Invoke(methodPath string, request []byte, headers map[string]string) ([]byte, error) {
@@ -113,13 +113,12 @@ func (in *instance) buildRequestBody(reqMsg *dynamicpb.Message) ([]byte, error) 
 	return json.Marshal(payload)
 }
 
-// call POSTs the request body to <base_url>/chat/completions, returning the raw
+// call POSTs the request body to the configured endpoint, returning the raw
 // response body and HTTP status code. An error is returned only for transport
 // failures (the upstream could not be reached); HTTP error responses are returned
 // with their status so the caller can shape them into a structured error.
 func (in *instance) call(body []byte, headers map[string]string) ([]byte, int, error) {
-	endpoint := in.baseURL + "/chat/completions"
-	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	httpReq, err := http.NewRequest(http.MethodPost, in.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, 0, fmt.Errorf("building request: %w", err)
 	}
@@ -134,7 +133,7 @@ func (in *instance) call(body []byte, headers map[string]string) ([]byte, int, e
 
 	resp, err := in.client.Do(httpReq)
 	if err != nil {
-		return nil, 0, fmt.Errorf("calling %s: %w", endpoint, err)
+		return nil, 0, fmt.Errorf("calling %s: %w", in.endpoint, err)
 	}
 	defer resp.Body.Close()
 

--- a/server/pkg/apps/openai/openai.go
+++ b/server/pkg/apps/openai/openai.go
@@ -68,6 +68,24 @@ message Choice {
   string finish_reason = 3 [json_name = "finish_reason"];
 }
 
+// Error carries the details of a failed upstream request. It mirrors the
+// standard OpenAI error envelope so the status code, message, type, code and raw
+// body are all visible on the response.
+message Error {
+  // HTTP status code returned by the upstream API, e.g. 401.
+  int32 status = 1 [json_name = "status"];
+  // Human-readable error message.
+  string message = 2 [json_name = "message"];
+  // Error category, e.g. "invalid_request_error".
+  string type = 3 [json_name = "type"];
+  // Machine-readable error code, e.g. "invalid_api_key".
+  string code = 4 [json_name = "code"];
+  // The request parameter the error relates to, if any.
+  string param = 5 [json_name = "param"];
+  // Raw response body, for any detail not captured above.
+  string body = 6 [json_name = "body"];
+}
+
 message ChatCompletionResponse {
   string id = 1 [json_name = "id"];
   string model = 2 [json_name = "model"];
@@ -75,6 +93,9 @@ message ChatCompletionResponse {
   string content = 3 [json_name = "content"];
   repeated Choice choices = 4 [json_name = "choices"];
   Usage usage = 5 [json_name = "usage"];
+  // Set when the upstream API returns an error (HTTP >= 400) instead of a
+  // completion. The other fields are empty in that case.
+  Error error = 6 [json_name = "error"];
 }
 
 service OpenAI {

--- a/server/pkg/apps/openai/openai.go
+++ b/server/pkg/apps/openai/openai.go
@@ -1,0 +1,162 @@
+// Package openai implements the built-in "openai" app: it exposes the standard
+// OpenAI chat completions API as a small gRPC surface kaja can render and invoke.
+//
+// The app has two creation parameters: "base_url" (the OpenAI-compatible API
+// base, defaulting to https://api.openai.com/v1) and "token" (the API key sent
+// as a Bearer token). Method calls arrive as protobuf, are transcoded into a
+// POST against <base_url>/chat/completions, and the JSON response is shaped back
+// into the method's protobuf response.
+package openai
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wham/kaja/v2/pkg/apps"
+	"github.com/wham/protoc-go/protoc"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	serviceTypeName = "openai.OpenAI"
+	defaultBaseURL  = "https://api.openai.com/v1"
+)
+
+// protoSource is the static proto surface the openai app renders: a single
+// ChatCompletion method exposing the most common chat completion inputs (model,
+// system/user prompt, temperature, ...) and a response carrying the assistant's
+// reply alongside the raw choices and token usage.
+const protoSource = `syntax = "proto3";
+
+package openai;
+
+message Message {
+  string role = 1 [json_name = "role"];
+  string content = 2 [json_name = "content"];
+}
+
+message ChatCompletionRequest {
+  // Model name, e.g. "gpt-4o-mini".
+  string model = 1 [json_name = "model"];
+  // System prompt that sets the assistant's behavior (optional).
+  string system_prompt = 2 [json_name = "system_prompt"];
+  // User prompt sent to the model.
+  string user_prompt = 3 [json_name = "user_prompt"];
+  // Sampling temperature between 0 and 2. Higher is more random.
+  optional float temperature = 4 [json_name = "temperature"];
+  // Maximum number of tokens to generate in the reply.
+  optional int32 max_tokens = 5 [json_name = "max_tokens"];
+  // Nucleus sampling probability mass between 0 and 1.
+  optional float top_p = 6 [json_name = "top_p"];
+}
+
+message Usage {
+  int32 prompt_tokens = 1 [json_name = "prompt_tokens"];
+  int32 completion_tokens = 2 [json_name = "completion_tokens"];
+  int32 total_tokens = 3 [json_name = "total_tokens"];
+}
+
+message Choice {
+  int32 index = 1 [json_name = "index"];
+  Message message = 2 [json_name = "message"];
+  string finish_reason = 3 [json_name = "finish_reason"];
+}
+
+message ChatCompletionResponse {
+  string id = 1 [json_name = "id"];
+  string model = 2 [json_name = "model"];
+  // The assistant's reply: the content of the first choice's message.
+  string content = 3 [json_name = "content"];
+  repeated Choice choices = 4 [json_name = "choices"];
+  Usage usage = 5 [json_name = "usage"];
+}
+
+service OpenAI {
+  // Create a chat completion using the standard OpenAI chat completions API.
+  rpc ChatCompletion(ChatCompletionRequest) returns (ChatCompletionResponse);
+}
+`
+
+// App is the openai app factory. Register it with the apps.Manager.
+type App struct{}
+
+func New() *App { return &App{} }
+
+func (a *App) Open(parameters map[string]string, protoDir string, log func(string)) (apps.Instance, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(parameters["base_url"]), "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	if err := requireHTTPScheme(baseURL); err != nil {
+		return nil, err
+	}
+	log("OpenAI base URL: " + baseURL)
+
+	token := strings.TrimSpace(parameters["token"])
+	if token == "" {
+		log("No token configured; requests will be sent without an Authorization header")
+	}
+
+	if err := os.WriteFile(filepath.Join(protoDir, "openai.proto"), []byte(protoSource), 0o644); err != nil {
+		return nil, fmt.Errorf("writing proto: %w", err)
+	}
+
+	input, output, err := compile(protoDir)
+	if err != nil {
+		return nil, err
+	}
+	log("Generated service " + serviceTypeName + " with method ChatCompletion")
+
+	return &instance{
+		baseURL: baseURL,
+		token:   token,
+		input:   input,
+		output:  output,
+		client:  &http.Client{Timeout: 120 * time.Second},
+	}, nil
+}
+
+// compile compiles the static proto and resolves ChatCompletion's request and
+// response descriptors, used to decode the request and encode the response.
+func compile(protoDir string) (protoreflect.MessageDescriptor, protoreflect.MessageDescriptor, error) {
+	result, err := protoc.New(protoc.WithProtoPaths(protoDir)).Compile("openai.proto")
+	if err != nil {
+		return nil, nil, fmt.Errorf("compiling generated proto: %w", err)
+	}
+	files, err := protodesc.NewFiles(result.AsFileDescriptorSet())
+	if err != nil {
+		return nil, nil, fmt.Errorf("building descriptors: %w", err)
+	}
+	descriptor, err := files.FindDescriptorByName(protoreflect.FullName(serviceTypeName))
+	if err != nil {
+		return nil, nil, fmt.Errorf("finding service %s: %w", serviceTypeName, err)
+	}
+	service, ok := descriptor.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s is not a service", serviceTypeName)
+	}
+	method := service.Methods().ByName("ChatCompletion")
+	if method == nil {
+		return nil, nil, fmt.Errorf("method ChatCompletion missing from compiled descriptors")
+	}
+	return method.Input(), method.Output(), nil
+}
+
+// requireHTTPScheme rejects URLs that are not plain HTTP(S), so a base URL can't
+// make the app issue requests over other schemes (file://, etc.).
+func requireHTTPScheme(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q in %q (only http and https are allowed)", u.Scheme, rawURL)
+	}
+	return nil
+}

--- a/server/pkg/apps/openai/openai.go
+++ b/server/pkg/apps/openai/openai.go
@@ -1,11 +1,11 @@
 // Package openai implements the built-in "openai" app: it exposes the standard
 // OpenAI chat completions API as a small gRPC surface kaja can render and invoke.
 //
-// The app has two creation parameters: "base_url" (the OpenAI-compatible API
-// base, defaulting to https://api.openai.com/v1) and "token" (the API key sent
-// as a Bearer token). Method calls arrive as protobuf, are transcoded into a
-// POST against <base_url>/chat/completions, and the JSON response is shaped back
-// into the method's protobuf response.
+// The app has two creation parameters: "endpoint" (the full chat completions URL,
+// e.g. https://api.openai.com/v1/chat/completions) and "token" (the API key sent
+// as a Bearer token). Method calls arrive as protobuf, are transcoded into a POST
+// against the endpoint, and the JSON response is shaped back into the method's
+// protobuf response.
 package openai
 
 import (
@@ -25,7 +25,7 @@ import (
 
 const (
 	serviceTypeName = "openai.OpenAI"
-	defaultBaseURL  = "https://api.openai.com/v1"
+	defaultEndpoint = "https://api.openai.com/v1/chat/completions"
 )
 
 // protoSource is the static proto surface the openai app renders: a single
@@ -110,14 +110,14 @@ type App struct{}
 func New() *App { return &App{} }
 
 func (a *App) Open(parameters map[string]string, protoDir string, log func(string)) (apps.Instance, error) {
-	baseURL := strings.TrimRight(strings.TrimSpace(parameters["base_url"]), "/")
-	if baseURL == "" {
-		baseURL = defaultBaseURL
+	endpoint := strings.TrimSpace(parameters["endpoint"])
+	if endpoint == "" {
+		endpoint = defaultEndpoint
 	}
-	if err := requireHTTPScheme(baseURL); err != nil {
+	if err := requireHTTPScheme(endpoint); err != nil {
 		return nil, err
 	}
-	log("OpenAI base URL: " + baseURL)
+	log("OpenAI endpoint: " + endpoint)
 
 	token := strings.TrimSpace(parameters["token"])
 	if token == "" {
@@ -135,11 +135,11 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 	log("Generated service " + serviceTypeName + " with method ChatCompletion")
 
 	return &instance{
-		baseURL: baseURL,
-		token:   token,
-		input:   input,
-		output:  output,
-		client:  &http.Client{Timeout: 120 * time.Second},
+		endpoint: endpoint,
+		token:    token,
+		input:    input,
+		output:   output,
+		client:   &http.Client{Timeout: 120 * time.Second},
 	}, nil
 }
 

--- a/server/pkg/apps/openai/openai_test.go
+++ b/server/pkg/apps/openai/openai_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 // openTestApp opens the app against a fake upstream and returns the live instance.
-func openTestApp(t *testing.T, baseURL, token string) *instance {
+func openTestApp(t *testing.T, endpoint, token string) *instance {
 	t.Helper()
-	inst, err := New().Open(map[string]string{"base_url": baseURL, "token": token}, t.TempDir(), func(string) {})
+	inst, err := New().Open(map[string]string{"endpoint": endpoint, "token": token}, t.TempDir(), func(string) {})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestChatCompletion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	in := openTestApp(t, server.URL, "secret-token")
+	in := openTestApp(t, server.URL+"/chat/completions", "secret-token")
 
 	req := encodeRequest(t, in, `{
 		"model": "gpt-4o-mini",
@@ -140,7 +140,7 @@ func TestChatCompletionOmitsSystemPromptWhenEmpty(t *testing.T) {
 	}))
 	defer server.Close()
 
-	in := openTestApp(t, server.URL, "")
+	in := openTestApp(t, server.URL+"/chat/completions", "")
 	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
 	if _, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil); err != nil {
 		t.Fatalf("Invoke: %v", err)
@@ -163,7 +163,7 @@ func TestChatCompletionUpstreamError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	in := openTestApp(t, server.URL, "nope")
+	in := openTestApp(t, server.URL+"/chat/completions", "nope")
 	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
 	resp, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil)
 	if err != nil {
@@ -199,7 +199,7 @@ func TestChatCompletionUpstreamErrorPlainBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	in := openTestApp(t, server.URL, "x")
+	in := openTestApp(t, server.URL+"/chat/completions", "x")
 	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
 	resp, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil)
 	if err != nil {
@@ -230,12 +230,12 @@ func TestChatCompletionTransportError(t *testing.T) {
 	}
 }
 
-func TestDefaultBaseURL(t *testing.T) {
+func TestDefaultEndpoint(t *testing.T) {
 	inst, err := New().Open(map[string]string{"token": "x"}, t.TempDir(), func(string) {})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	if got := inst.(*instance).baseURL; got != defaultBaseURL {
-		t.Errorf("baseURL = %q, want %q", got, defaultBaseURL)
+	if got := inst.(*instance).endpoint; got != defaultEndpoint {
+		t.Errorf("endpoint = %q, want %q", got, defaultEndpoint)
 	}
 }

--- a/server/pkg/apps/openai/openai_test.go
+++ b/server/pkg/apps/openai/openai_test.go
@@ -157,15 +157,76 @@ func TestChatCompletionOmitsSystemPromptWhenEmpty(t *testing.T) {
 
 func TestChatCompletionUpstreamError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
-		io.WriteString(w, `{"error":{"message":"bad key"}}`)
+		io.WriteString(w, `{"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key","param":null}}`)
 	}))
 	defer server.Close()
 
 	in := openTestApp(t, server.URL, "nope")
 	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
+	resp, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil)
+	if err != nil {
+		t.Fatalf("an HTTP error should be returned as a structured response, not a transport error: %v", err)
+	}
+
+	out := decodeResponse(t, in, resp)
+	errObj, ok := out["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a structured error field, got %v", out)
+	}
+	if errObj["status"].(float64) != 401 {
+		t.Errorf("status = %v, want 401", errObj["status"])
+	}
+	if errObj["message"] != "Incorrect API key provided" {
+		t.Errorf("message = %v", errObj["message"])
+	}
+	if errObj["type"] != "invalid_request_error" {
+		t.Errorf("type = %v", errObj["type"])
+	}
+	if errObj["code"] != "invalid_api_key" {
+		t.Errorf("code = %v", errObj["code"])
+	}
+	if body, _ := errObj["body"].(string); body == "" {
+		t.Errorf("expected the raw body to be included, got %v", errObj["body"])
+	}
+}
+
+func TestChatCompletionUpstreamErrorPlainBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		io.WriteString(w, "upstream unavailable")
+	}))
+	defer server.Close()
+
+	in := openTestApp(t, server.URL, "x")
+	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
+	resp, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	out := decodeResponse(t, in, resp)
+	errObj := out["error"].(map[string]any)
+	if errObj["status"].(float64) != 502 {
+		t.Errorf("status = %v, want 502", errObj["status"])
+	}
+	// No JSON envelope: message falls back to the HTTP status text, body keeps the raw text.
+	if errObj["message"] != "Bad Gateway" {
+		t.Errorf("message = %v, want Bad Gateway", errObj["message"])
+	}
+	if errObj["body"] != "upstream unavailable" {
+		t.Errorf("body = %v", errObj["body"])
+	}
+}
+
+func TestChatCompletionTransportError(t *testing.T) {
+	// Port 1 refuses connections, so the upstream cannot be reached at all and the
+	// call surfaces as a transport error rather than a structured response.
+	in := openTestApp(t, "http://127.0.0.1:1", "x")
+	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
 	if _, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil); err == nil {
-		t.Fatal("expected error on 401 upstream response")
+		t.Fatal("expected a transport error when the upstream is unreachable")
 	}
 }
 

--- a/server/pkg/apps/openai/openai_test.go
+++ b/server/pkg/apps/openai/openai_test.go
@@ -1,0 +1,180 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// openTestApp opens the app against a fake upstream and returns the live instance.
+func openTestApp(t *testing.T, baseURL, token string) *instance {
+	t.Helper()
+	inst, err := New().Open(map[string]string{"base_url": baseURL, "token": token}, t.TempDir(), func(string) {})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return inst.(*instance)
+}
+
+// encodeRequest builds the protobuf ChatCompletion request bytes from a JSON object.
+func encodeRequest(t *testing.T, in *instance, requestJSON string) []byte {
+	t.Helper()
+	msg := dynamicpb.NewMessage(in.input)
+	if err := protojson.Unmarshal([]byte(requestJSON), msg); err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	return b
+}
+
+// decodeResponse turns the protobuf response bytes back into JSON.
+func decodeResponse(t *testing.T, in *instance, response []byte) map[string]any {
+	t.Helper()
+	msg := dynamicpb.NewMessage(in.output)
+	if err := proto.Unmarshal(response, msg); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	j, err := protojson.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal response json: %v", err)
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(j, &out); err != nil {
+		t.Fatalf("decode response json: %v", err)
+	}
+	return out
+}
+
+func TestChatCompletion(t *testing.T) {
+	var gotBody map[string]any
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(b, &gotBody); err != nil {
+			t.Errorf("decode upstream body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{
+			"id": "chatcmpl-1",
+			"model": "gpt-4o-mini",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello there!"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 9, "completion_tokens": 3, "total_tokens": 12}
+		}`)
+	}))
+	defer server.Close()
+
+	in := openTestApp(t, server.URL, "secret-token")
+
+	req := encodeRequest(t, in, `{
+		"model": "gpt-4o-mini",
+		"system_prompt": "Be nice",
+		"user_prompt": "Hi",
+		"temperature": 0.5,
+		"max_tokens": 64
+	}`)
+	resp, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if gotAuth != "Bearer secret-token" {
+		t.Errorf("Authorization = %q, want Bearer secret-token", gotAuth)
+	}
+	if gotBody["model"] != "gpt-4o-mini" {
+		t.Errorf("upstream model = %v", gotBody["model"])
+	}
+	if gotBody["temperature"] != 0.5 {
+		t.Errorf("upstream temperature = %v", gotBody["temperature"])
+	}
+	if gotBody["max_tokens"].(float64) != 64 {
+		t.Errorf("upstream max_tokens = %v", gotBody["max_tokens"])
+	}
+	if _, ok := gotBody["top_p"]; ok {
+		t.Errorf("top_p should be omitted when unset, got %v", gotBody["top_p"])
+	}
+	messages, ok := gotBody["messages"].([]any)
+	if !ok || len(messages) != 2 {
+		t.Fatalf("messages = %v", gotBody["messages"])
+	}
+	system := messages[0].(map[string]any)
+	if system["role"] != "system" || system["content"] != "Be nice" {
+		t.Errorf("system message = %v", system)
+	}
+	user := messages[1].(map[string]any)
+	if user["role"] != "user" || user["content"] != "Hi" {
+		t.Errorf("user message = %v", user)
+	}
+
+	out := decodeResponse(t, in, resp)
+	if out["content"] != "Hello there!" {
+		t.Errorf("content = %v, want Hello there!", out["content"])
+	}
+	if out["id"] != "chatcmpl-1" {
+		t.Errorf("id = %v", out["id"])
+	}
+	usage, ok := out["usage"].(map[string]any)
+	if !ok || usage["total_tokens"].(float64) != 12 {
+		t.Errorf("usage = %v", out["usage"])
+	}
+}
+
+func TestChatCompletionOmitsSystemPromptWhenEmpty(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		json.Unmarshal(b, &gotBody)
+		io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
+	}))
+	defer server.Close()
+
+	in := openTestApp(t, server.URL, "")
+	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
+	if _, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	messages := gotBody["messages"].([]any)
+	if len(messages) != 1 {
+		t.Fatalf("expected only the user message, got %v", messages)
+	}
+	if messages[0].(map[string]any)["role"] != "user" {
+		t.Errorf("message = %v", messages[0])
+	}
+}
+
+func TestChatCompletionUpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		io.WriteString(w, `{"error":{"message":"bad key"}}`)
+	}))
+	defer server.Close()
+
+	in := openTestApp(t, server.URL, "nope")
+	req := encodeRequest(t, in, `{"model": "m", "user_prompt": "yo"}`)
+	if _, err := in.Invoke("openai.OpenAI/ChatCompletion", req, nil); err == nil {
+		t.Fatal("expected error on 401 upstream response")
+	}
+}
+
+func TestDefaultBaseURL(t *testing.T) {
+	inst, err := New().Open(map[string]string{"token": "x"}, t.TempDir(), func(string) {})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got := inst.(*instance).baseURL; got != defaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", got, defaultBaseURL)
+	}
+}

--- a/server/proto/api.proto
+++ b/server/proto/api.proto
@@ -131,6 +131,7 @@ message ConfigurationApp {
   // Built-in app type, e.g. "openapi" or "markdown".
   string type = 2;
   // App-specific creation parameters. For "openapi": {"spec_url": "<url>"};
+  // for "openai": {"base_url": "<url>", "token": "<key>"};
   // for "markdown": {"path": "<file>"}.
   map<string, string> parameters = 3;
   // Headers sent with each request the app makes to the upstream service.

--- a/server/proto/api.proto
+++ b/server/proto/api.proto
@@ -131,7 +131,7 @@ message ConfigurationApp {
   // Built-in app type, e.g. "openapi" or "markdown".
   string type = 2;
   // App-specific creation parameters. For "openapi": {"spec_url": "<url>"};
-  // for "openai": {"base_url": "<url>", "token": "<key>"};
+  // for "openai": {"endpoint": "<url>", "token": "<key>"};
   // for "markdown": {"path": "<file>"}.
   map<string, string> parameters = 3;
   // Headers sent with each request the app makes to the upstream service.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1100,10 +1100,13 @@ export function App() {
       return;
     }
 
-    // Update configuration to remove the project
+    // Update configuration to remove the project. Apps are rendered as projects
+    // in the sidebar but stored separately, so drop a matching app too (names are
+    // unique across both).
     const updatedConfiguration: Configuration = {
       ...configuration,
       projects: configuration.projects.filter((p) => p.name !== projectName),
+      apps: (configuration.apps || []).filter((a) => a.name !== projectName),
     };
 
     // Save configuration via API and apply changes through unified path

--- a/ui/src/appTypes.ts
+++ b/ui/src/appTypes.ts
@@ -52,11 +52,11 @@ export const appTypes: AppTypeDefinition[] = [
     icon: SparkleFillIcon,
     parameters: [
       {
-        key: "base_url",
-        label: "API base URL",
+        key: "endpoint",
+        label: "Chat completions endpoint",
         type: "url",
-        placeholder: "https://api.openai.com/v1",
-        caption: "Base URL of an OpenAI-compatible API. Calls are sent to <base_url>/chat/completions.",
+        placeholder: "https://api.openai.com/v1/chat/completions",
+        caption: "Full URL of the chat completions endpoint. Requests are POSTed directly to it.",
       },
       {
         key: "token",
@@ -67,9 +67,9 @@ export const appTypes: AppTypeDefinition[] = [
       },
     ],
     demo: {
-      label: "Use the OpenAI defaults",
+      label: "Use the OpenAI endpoint",
       name: "OpenAI",
-      parameters: { base_url: "https://api.openai.com/v1" },
+      parameters: { endpoint: "https://api.openai.com/v1/chat/completions" },
     },
   },
   {

--- a/ui/src/appTypes.ts
+++ b/ui/src/appTypes.ts
@@ -1,4 +1,4 @@
-import { GlobeIcon, Icon, MarkdownIcon } from "@primer/octicons-react";
+import { GlobeIcon, Icon, MarkdownIcon, SparkleFillIcon } from "@primer/octicons-react";
 
 // Parameter kinds an app exposes in the New App form. "file" renders a native
 // file picker on the desktop (and a plain text field everywhere else).
@@ -43,6 +43,33 @@ export const appTypes: AppTypeDefinition[] = [
       label: "Try the Swagger Petstore demo",
       name: "Petstore",
       parameters: { spec_url: "https://petstore3.swagger.io/api/v3/openapi.json" },
+    },
+  },
+  {
+    type: "openai",
+    label: "OpenAI",
+    description: "Call the standard OpenAI chat completions API.",
+    icon: SparkleFillIcon,
+    parameters: [
+      {
+        key: "base_url",
+        label: "API base URL",
+        type: "url",
+        placeholder: "https://api.openai.com/v1",
+        caption: "Base URL of an OpenAI-compatible API. Calls are sent to <base_url>/chat/completions.",
+      },
+      {
+        key: "token",
+        label: "API token",
+        type: "text",
+        placeholder: "sk-...",
+        caption: "Sent as a Bearer token in the Authorization header of each request.",
+      },
+    ],
+    demo: {
+      label: "Use the OpenAI defaults",
+      name: "OpenAI",
+      parameters: { base_url: "https://api.openai.com/v1" },
     },
   },
   {

--- a/ui/src/server/wails-transport.ts
+++ b/ui/src/server/wails-transport.ts
@@ -16,6 +16,20 @@ import { ProjectRef } from "../project";
 
 export type WailsTransportMode = "api" | "target";
 
+// Wails (v2) rejects a bound-method promise with the Go error string, not an
+// Error object. Pull a useful message out of whatever shape the rejection takes
+// so real failures (e.g. "model is required", an upstream 401) reach the UI
+// instead of a generic "Unknown error".
+function wailsErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string" && error) return error;
+  if (error && typeof error === "object") {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
+  }
+  return "Unknown error";
+}
+
 export interface WailsTransportOptions {
   mode: WailsTransportMode;
   projectRef?: ProjectRef; // Dynamic project reference for "target" mode
@@ -246,7 +260,7 @@ export class WailsTransport implements RpcTransport {
       return output;
     } catch (error) {
       console.error(`Wails ${this.mode} transport error:`, error);
-      throw new Error(`Wails ${this.mode} transport error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      throw new Error(`Wails ${this.mode} transport error: ${wailsErrorMessage(error)}`);
     }
   }
 }


### PR DESCRIPTION
Added an "openai" built-in app that's configured with an API base URL and token, then exposes a `ChatCompletion` gRPC method (model, system/user prompt, temperature, ...) which kaja transcodes into the standard OpenAI chat completions REST call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWcPHzzRr3KwzWn7FBF3Ds)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-302-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-302-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-302-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-302-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-302-newproject.png)

</details>
