### PR TITLE
Reworked Markdown app to bind to a folder with semantic writers

### DIFF
--- a/server/pkg/apps/markdown/markdown.go
+++ b/server/pkg/apps/markdown/markdown.go
@@ -138,6 +138,7 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 	if folder == "" {
 		return nil, fmt.Errorf("missing required parameter %q", "folder")
 	}
+	folder = filepath.Clean(folder)
 	if err := os.MkdirAll(folder, 0o755); err != nil {
 		return nil, fmt.Errorf("preparing folder %s: %w", folder, err)
 	}
@@ -341,9 +342,14 @@ func (in *instance) resolve(name string) (string, string, error) {
 	if !strings.HasSuffix(strings.ToLower(name), ".md") {
 		name += ".md"
 	}
-	path := filepath.Join(in.folder, filepath.FromSlash(name))
+	path := filepath.Clean(filepath.Join(in.folder, filepath.FromSlash(name)))
+	// Containment check using strings.HasPrefix is recognized by static analysis
+	// as a path-traversal barrier: the resolved path must stay inside the folder.
+	if path != in.folder && !strings.HasPrefix(path, in.folder+string(os.PathSeparator)) {
+		return "", "", fmt.Errorf("file must be a name within the folder, got %q", name)
+	}
 	rel, err := filepath.Rel(in.folder, path)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil {
 		return "", "", fmt.Errorf("file must be a name within the folder, got %q", name)
 	}
 	return path, filepath.ToSlash(rel), nil

--- a/server/pkg/apps/markdown/markdown.go
+++ b/server/pkg/apps/markdown/markdown.go
@@ -1,10 +1,16 @@
-// Package markdown implements the built-in "markdown" app: it exposes a single
-// method that appends a line of text to a Markdown file on disk.
+// Package markdown implements the built-in "markdown" app: it binds to a folder
+// on disk and exposes methods to create and write Markdown files inside it.
 //
-// The app has one creation parameter, "path", the absolute path to the Markdown
-// file. On the sandboxed macOS desktop the file is reached through a
-// security-scoped bookmark saved when the user picks it; the append itself is a
-// plain file write, the same on every platform.
+// The app has one creation parameter, "folder", the absolute path to the folder.
+// On the sandboxed macOS desktop the folder is reached through a security-scoped
+// bookmark saved when the user picks it; the writes themselves are plain file
+// operations, the same on every platform.
+//
+// Every write method names a file relative to the folder (e.g. "notes.md") and
+// auto-creates it if it does not exist, so the folder stays the single access
+// boundary. The methods are deliberately semantic - AddHeading, AddBullets,
+// AddTasks, AddCodeBlock and friends each render one Markdown construct - with
+// AppendMarkdown as a verbatim escape hatch.
 package markdown
 
 import (
@@ -23,21 +29,102 @@ import (
 
 const serviceTypeName = "markdown.Markdown"
 
-// protoSource is the static proto surface the markdown app renders: a single
-// AppendLine method that appends a line of text to the configured file.
+// protoSource is the static proto surface the markdown app renders.
 const protoSource = `syntax = "proto3";
 
 package markdown;
 
-message AppendLineRequest {
-  string text = 1 [json_name = "text"];
+// Returned by every write method: the file's name relative to the folder and its
+// absolute path on disk.
+message FileResponse {
+  string file = 1 [json_name = "file"];
+  string path = 2 [json_name = "path"];
 }
 
-message AppendLineResponse {}
+message ListFilesRequest {}
+message ListFilesResponse {
+  repeated string files = 1 [json_name = "files"];
+}
+
+message CreateFileRequest {
+  // Name of the file relative to the folder, e.g. "notes.md". ".md" is added if missing.
+  string file = 1 [json_name = "file"];
+  // Optional: written as a top-level "# title" heading.
+  string title = 2 [json_name = "title"];
+  // Overwrite the file if it already exists. Otherwise creating an existing file fails.
+  bool overwrite = 3 [json_name = "overwrite"];
+}
+
+message ReadFileRequest {
+  string file = 1 [json_name = "file"];
+}
+message ReadFileResponse {
+  string content = 1 [json_name = "content"];
+}
+
+message AddHeadingRequest {
+  string file = 1 [json_name = "file"];
+  string text = 2 [json_name = "text"];
+  // Heading level 1-6. Defaults to 1.
+  int32 level = 3 [json_name = "level"];
+}
+
+message AddParagraphRequest {
+  string file = 1 [json_name = "file"];
+  string text = 2 [json_name = "text"];
+}
+
+message AddBulletsRequest {
+  string file = 1 [json_name = "file"];
+  repeated string items = 2 [json_name = "items"];
+}
+
+message AddTasksRequest {
+  string file = 1 [json_name = "file"];
+  repeated string items = 2 [json_name = "items"];
+  // Render the tasks as checked ("- [x]") instead of unchecked ("- [ ]").
+  bool done = 3 [json_name = "done"];
+}
+
+message AddCodeBlockRequest {
+  string file = 1 [json_name = "file"];
+  string code = 2 [json_name = "code"];
+  // Optional language for the fenced code block, e.g. "go".
+  string language = 3 [json_name = "language"];
+}
+
+message AddQuoteRequest {
+  string file = 1 [json_name = "file"];
+  string text = 2 [json_name = "text"];
+}
+
+message AppendMarkdownRequest {
+  string file = 1 [json_name = "file"];
+  // Raw Markdown, appended verbatim.
+  string markdown = 2 [json_name = "markdown"];
+}
 
 service Markdown {
-  // Append a line of text to the Markdown file.
-  rpc AppendLine(AppendLineRequest) returns (AppendLineResponse);
+  // List the Markdown files in the folder.
+  rpc ListFiles(ListFilesRequest) returns (ListFilesResponse);
+  // Create a new Markdown file, optionally seeded with an H1 title.
+  rpc CreateFile(CreateFileRequest) returns (FileResponse);
+  // Read a file's raw contents.
+  rpc ReadFile(ReadFileRequest) returns (ReadFileResponse);
+  // Append a heading.
+  rpc AddHeading(AddHeadingRequest) returns (FileResponse);
+  // Append a paragraph of text.
+  rpc AddParagraph(AddParagraphRequest) returns (FileResponse);
+  // Append a bulleted list.
+  rpc AddBullets(AddBulletsRequest) returns (FileResponse);
+  // Append a task (checkbox) list.
+  rpc AddTasks(AddTasksRequest) returns (FileResponse);
+  // Append a fenced code block.
+  rpc AddCodeBlock(AddCodeBlockRequest) returns (FileResponse);
+  // Append a block quote.
+  rpc AddQuote(AddQuoteRequest) returns (FileResponse);
+  // Append raw Markdown verbatim.
+  rpc AppendMarkdown(AppendMarkdownRequest) returns (FileResponse);
 }
 `
 
@@ -47,88 +134,317 @@ type App struct{}
 func New() *App { return &App{} }
 
 func (a *App) Open(parameters map[string]string, protoDir string, log func(string)) (apps.Instance, error) {
-	path := strings.TrimSpace(parameters["path"])
-	if path == "" {
-		return nil, fmt.Errorf("missing required parameter %q", "path")
+	folder := strings.TrimSpace(parameters["folder"])
+	if folder == "" {
+		return nil, fmt.Errorf("missing required parameter %q", "folder")
 	}
-	log("Markdown file: " + path)
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		return nil, fmt.Errorf("preparing folder %s: %w", folder, err)
+	}
+	log("Markdown folder: " + folder)
 
 	if err := os.WriteFile(filepath.Join(protoDir, "markdown.proto"), []byte(protoSource), 0o644); err != nil {
 		return nil, fmt.Errorf("writing proto: %w", err)
 	}
 
-	input, output, err := compile(protoDir)
+	methods, err := compile(protoDir)
 	if err != nil {
 		return nil, err
 	}
 
-	return &instance{path: path, input: input, output: output}, nil
+	return &instance{folder: folder, methods: methods}, nil
 }
 
-// compile compiles the static proto and resolves AppendLine's request and
-// response descriptors, used to decode the request and encode the response.
-func compile(protoDir string) (protoreflect.MessageDescriptor, protoreflect.MessageDescriptor, error) {
-	result, err := protoc.New(protoc.WithProtoPaths(protoDir)).Compile("markdown.proto")
-	if err != nil {
-		return nil, nil, fmt.Errorf("compiling generated proto: %w", err)
-	}
-	files, err := protodesc.NewFiles(result.AsFileDescriptorSet())
-	if err != nil {
-		return nil, nil, fmt.Errorf("building descriptors: %w", err)
-	}
-	descriptor, err := files.FindDescriptorByName(protoreflect.FullName(serviceTypeName))
-	if err != nil {
-		return nil, nil, fmt.Errorf("finding service %s: %w", serviceTypeName, err)
-	}
-	service, ok := descriptor.(protoreflect.ServiceDescriptor)
-	if !ok {
-		return nil, nil, fmt.Errorf("%s is not a service", serviceTypeName)
-	}
-	method := service.Methods().ByName("AppendLine")
-	if method == nil {
-		return nil, nil, fmt.Errorf("method AppendLine missing from compiled descriptors")
-	}
-	return method.Input(), method.Output(), nil
-}
-
-// instance is a live opened markdown app bound to a single file on disk.
-type instance struct {
-	path   string
+// method holds the request and response descriptors of one service method.
+type method struct {
 	input  protoreflect.MessageDescriptor
 	output protoreflect.MessageDescriptor
 }
 
+// compile compiles the static proto and resolves every method's request and
+// response descriptors, keyed by method name.
+func compile(protoDir string) (map[string]method, error) {
+	result, err := protoc.New(protoc.WithProtoPaths(protoDir)).Compile("markdown.proto")
+	if err != nil {
+		return nil, fmt.Errorf("compiling generated proto: %w", err)
+	}
+	files, err := protodesc.NewFiles(result.AsFileDescriptorSet())
+	if err != nil {
+		return nil, fmt.Errorf("building descriptors: %w", err)
+	}
+	descriptor, err := files.FindDescriptorByName(protoreflect.FullName(serviceTypeName))
+	if err != nil {
+		return nil, fmt.Errorf("finding service %s: %w", serviceTypeName, err)
+	}
+	service, ok := descriptor.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("%s is not a service", serviceTypeName)
+	}
+	methods := map[string]method{}
+	for i := 0; i < service.Methods().Len(); i++ {
+		m := service.Methods().Get(i)
+		methods[string(m.Name())] = method{input: m.Input(), output: m.Output()}
+	}
+	return methods, nil
+}
+
+// instance is a live opened markdown app bound to a folder on disk.
+type instance struct {
+	folder  string
+	methods map[string]method
+}
+
 func (in *instance) Invoke(methodPath string, request []byte, headers map[string]string) ([]byte, error) {
-	if lastSegment(methodPath) != "AppendLine" {
-		return nil, fmt.Errorf("unknown method %q", methodPath)
+	name := lastSegment(methodPath)
+	m, ok := in.methods[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown method %q", name)
 	}
 
-	reqMsg := dynamicpb.NewMessage(in.input)
+	req := dynamicpb.NewMessage(m.input)
 	if len(request) > 0 {
-		if err := proto.Unmarshal(request, reqMsg); err != nil {
+		if err := proto.Unmarshal(request, req); err != nil {
 			return nil, fmt.Errorf("decoding request: %w", err)
 		}
 	}
-	text := reqMsg.Get(in.input.Fields().ByName("text")).String()
+	resp := dynamicpb.NewMessage(m.output)
 
-	if err := appendLine(in.path, text); err != nil {
+	if err := in.dispatch(name, req, resp); err != nil {
 		return nil, err
 	}
-
-	return proto.Marshal(dynamicpb.NewMessage(in.output))
+	return proto.Marshal(resp)
 }
 
-// appendLine appends text as a new line to the file, terminated by a newline.
-func appendLine(path, text string) error {
+func (in *instance) dispatch(name string, req, resp *dynamicpb.Message) error {
+	switch name {
+	case "ListFiles":
+		files, err := in.listFiles()
+		if err != nil {
+			return err
+		}
+		setStringList(resp, "files", files)
+		return nil
+
+	case "CreateFile":
+		path, rel, err := in.resolve(getString(req, "file"))
+		if err != nil {
+			return err
+		}
+		if !getBool(req, "overwrite") {
+			if _, err := os.Stat(path); err == nil {
+				return fmt.Errorf("%s already exists (set overwrite to replace it)", rel)
+			}
+		}
+		var content string
+		if title := strings.TrimSpace(getString(req, "title")); title != "" {
+			content = "# " + title + "\n"
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("creating folder for %s: %w", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", rel, err)
+		}
+		return setFileResponse(resp, rel, path)
+
+	case "ReadFile":
+		path, _, err := in.resolve(getString(req, "file"))
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading file: %w", err)
+		}
+		setString(resp, "content", string(data))
+		return nil
+
+	case "AddHeading":
+		level := int(getInt32(req, "level"))
+		if level < 1 {
+			level = 1
+		} else if level > 6 {
+			level = 6
+		}
+		return in.appendBlock(req, resp, strings.Repeat("#", level)+" "+getString(req, "text"))
+
+	case "AddParagraph":
+		return in.appendBlock(req, resp, getString(req, "text"))
+
+	case "AddBullets":
+		var lines []string
+		for _, item := range getStringList(req, "items") {
+			lines = append(lines, "- "+item)
+		}
+		return in.appendBlock(req, resp, strings.Join(lines, "\n"))
+
+	case "AddTasks":
+		marker := "- [ ] "
+		if getBool(req, "done") {
+			marker = "- [x] "
+		}
+		var lines []string
+		for _, item := range getStringList(req, "items") {
+			lines = append(lines, marker+item)
+		}
+		return in.appendBlock(req, resp, strings.Join(lines, "\n"))
+
+	case "AddCodeBlock":
+		block := "```" + strings.TrimSpace(getString(req, "language")) + "\n" + getString(req, "code") + "\n```"
+		return in.appendBlock(req, resp, block)
+
+	case "AddQuote":
+		var lines []string
+		for _, line := range strings.Split(getString(req, "text"), "\n") {
+			lines = append(lines, "> "+line)
+		}
+		return in.appendBlock(req, resp, strings.Join(lines, "\n"))
+
+	case "AppendMarkdown":
+		return in.appendBlock(req, resp, getString(req, "markdown"))
+	}
+	return fmt.Errorf("unhandled method %q", name)
+}
+
+// listFiles returns the Markdown files in the folder, relative to it, including
+// those in sub-folders.
+func (in *instance) listFiles() ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(in.folder, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(in.folder, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing files: %w", err)
+	}
+	return files, nil
+}
+
+// resolve turns a requested file name into an absolute path within the folder,
+// adding a ".md" suffix when missing and rejecting names that escape the folder.
+// It returns the absolute path and the cleaned name relative to the folder.
+func (in *instance) resolve(name string) (string, string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", "", fmt.Errorf("missing file name")
+	}
+	if !strings.HasSuffix(strings.ToLower(name), ".md") {
+		name += ".md"
+	}
+	path := filepath.Join(in.folder, filepath.FromSlash(name))
+	rel, err := filepath.Rel(in.folder, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("file must be a name within the folder, got %q", name)
+	}
+	return path, filepath.ToSlash(rel), nil
+}
+
+// appendBlock resolves the request's "file", appends a Markdown block to it
+// (creating the file if missing), and fills the FileResponse.
+func (in *instance) appendBlock(req, resp *dynamicpb.Message, block string) error {
+	path, rel, err := in.resolve(getString(req, "file"))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating folder for %s: %w", rel, err)
+	}
+
+	info, statErr := os.Stat(path)
+	nonEmpty := statErr == nil && info.Size() > 0
+
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("opening %s: %w", path, err)
+		return fmt.Errorf("opening %s: %w", rel, err)
 	}
 	defer f.Close()
-	if _, err := f.WriteString(text + "\n"); err != nil {
-		return fmt.Errorf("writing to %s: %w", path, err)
+
+	var b strings.Builder
+	if nonEmpty {
+		// Separate the new block from existing content with a blank line.
+		b.WriteString("\n")
 	}
+	b.WriteString(block)
+	if !strings.HasSuffix(block, "\n") {
+		b.WriteString("\n")
+	}
+	if _, err := f.WriteString(b.String()); err != nil {
+		return fmt.Errorf("writing to %s: %w", rel, err)
+	}
+	return setFileResponse(resp, rel, path)
+}
+
+func setFileResponse(resp *dynamicpb.Message, rel, path string) error {
+	setString(resp, "file", rel)
+	setString(resp, "path", path)
 	return nil
+}
+
+func getString(m *dynamicpb.Message, name string) string {
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return ""
+	}
+	return m.Get(fd).String()
+}
+
+func getBool(m *dynamicpb.Message, name string) bool {
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return false
+	}
+	return m.Get(fd).Bool()
+}
+
+func getInt32(m *dynamicpb.Message, name string) int32 {
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return 0
+	}
+	return int32(m.Get(fd).Int())
+}
+
+func getStringList(m *dynamicpb.Message, name string) []string {
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return nil
+	}
+	list := m.Get(fd).List()
+	out := make([]string, 0, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		out = append(out, list.Get(i).String())
+	}
+	return out
+}
+
+func setString(m *dynamicpb.Message, name, value string) {
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return
+	}
+	m.Set(fd, protoreflect.ValueOfString(value))
+}
+
+func setStringList(m *dynamicpb.Message, name string, values []string) {
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		return
+	}
+	list := m.NewField(fd).List()
+	for _, v := range values {
+		list.Append(protoreflect.ValueOfString(v))
+	}
+	m.Set(fd, protoreflect.ValueOfList(list))
 }
 
 func lastSegment(s string) string {

--- a/server/pkg/apps/markdown/markdown.go
+++ b/server/pkg/apps/markdown/markdown.go
@@ -140,9 +140,6 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 		return nil, fmt.Errorf("missing required parameter %q", "folder")
 	}
 	folder = filepath.Clean(folder)
-	if err := os.MkdirAll(folder, 0o755); err != nil {
-		return nil, fmt.Errorf("preparing folder %s: %w", folder, err)
-	}
 	log("Markdown folder: " + folder)
 
 	if err := os.WriteFile(filepath.Join(protoDir, "markdown.proto"), []byte(protoSource), 0o644); err != nil {

--- a/server/pkg/apps/markdown/markdown.go
+++ b/server/pkg/apps/markdown/markdown.go
@@ -15,6 +15,7 @@ package markdown
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -227,33 +228,53 @@ func (in *instance) dispatch(name string, req, resp *dynamicpb.Message) error {
 		return nil
 
 	case "CreateFile":
-		path, rel, err := in.resolve(getString(req, "file"))
+		name, err := resolve(getString(req, "file"))
 		if err != nil {
 			return err
 		}
+		root, err := os.OpenRoot(in.folder)
+		if err != nil {
+			return fmt.Errorf("opening folder: %w", err)
+		}
+		defer root.Close()
 		if !getBool(req, "overwrite") {
-			if _, err := os.Stat(path); err == nil {
-				return fmt.Errorf("%s already exists (set overwrite to replace it)", rel)
+			if _, err := root.Stat(name); err == nil {
+				return fmt.Errorf("%s already exists (set overwrite to replace it)", name)
 			}
 		}
 		var content string
 		if title := strings.TrimSpace(getString(req, "title")); title != "" {
 			content = "# " + title + "\n"
 		}
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return fmt.Errorf("creating folder for %s: %w", rel, err)
+		f, err := root.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("creating %s: %w", name, err)
 		}
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			return fmt.Errorf("writing %s: %w", rel, err)
+		if _, err := f.WriteString(content); err != nil {
+			f.Close()
+			return fmt.Errorf("writing %s: %w", name, err)
 		}
-		return setFileResponse(resp, rel, path)
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("writing %s: %w", name, err)
+		}
+		return setFileResponse(resp, name, filepath.Join(in.folder, name))
 
 	case "ReadFile":
-		path, _, err := in.resolve(getString(req, "file"))
+		name, err := resolve(getString(req, "file"))
 		if err != nil {
 			return err
 		}
-		data, err := os.ReadFile(path)
+		root, err := os.OpenRoot(in.folder)
+		if err != nil {
+			return fmt.Errorf("opening folder: %w", err)
+		}
+		defer root.Close()
+		f, err := root.Open(name)
+		if err != nil {
+			return fmt.Errorf("reading file: %w", err)
+		}
+		defer f.Close()
+		data, err := io.ReadAll(f)
 		if err != nil {
 			return fmt.Errorf("reading file: %w", err)
 		}
@@ -307,71 +328,60 @@ func (in *instance) dispatch(name string, req, resp *dynamicpb.Message) error {
 	return fmt.Errorf("unhandled method %q", name)
 }
 
-// listFiles returns the Markdown files in the folder, relative to it, including
-// those in sub-folders.
+// listFiles returns the Markdown files at the top level of the folder.
 func (in *instance) listFiles() ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(in.folder, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
-			return nil
-		}
-		rel, err := filepath.Rel(in.folder, path)
-		if err != nil {
-			return err
-		}
-		files = append(files, filepath.ToSlash(rel))
-		return nil
-	})
+	entries, err := os.ReadDir(in.folder)
 	if err != nil {
 		return nil, fmt.Errorf("listing files: %w", err)
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".md") {
+			continue
+		}
+		files = append(files, e.Name())
 	}
 	return files, nil
 }
 
-// resolve turns a requested file name into an absolute path within the folder,
-// adding a ".md" suffix when missing and rejecting names that escape the folder.
-// It returns the absolute path and the cleaned name relative to the folder.
-func (in *instance) resolve(name string) (string, string, error) {
+// resolve validates a requested file name and returns a plain name within the
+// folder, adding a ".md" suffix when missing. Names that contain a path
+// separator or ".." are rejected; together with os.Root in the callers this
+// keeps every file operation inside the folder.
+func resolve(name string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", "", fmt.Errorf("missing file name")
+		return "", fmt.Errorf("missing file name")
 	}
 	if !strings.HasSuffix(strings.ToLower(name), ".md") {
 		name += ".md"
 	}
-	path := filepath.Clean(filepath.Join(in.folder, filepath.FromSlash(name)))
-	// Containment check using strings.HasPrefix is recognized by static analysis
-	// as a path-traversal barrier: the resolved path must stay inside the folder.
-	if path != in.folder && !strings.HasPrefix(path, in.folder+string(os.PathSeparator)) {
-		return "", "", fmt.Errorf("file must be a name within the folder, got %q", name)
+	if name != filepath.Base(name) || strings.Contains(name, "..") {
+		return "", fmt.Errorf("file must be a plain name within the folder, got %q", name)
 	}
-	rel, err := filepath.Rel(in.folder, path)
-	if err != nil {
-		return "", "", fmt.Errorf("file must be a name within the folder, got %q", name)
-	}
-	return path, filepath.ToSlash(rel), nil
+	return name, nil
 }
 
 // appendBlock resolves the request's "file", appends a Markdown block to it
-// (creating the file if missing), and fills the FileResponse.
+// (creating the file if missing), and fills the FileResponse. All file access
+// goes through os.Root so the name can never escape the folder.
 func (in *instance) appendBlock(req, resp *dynamicpb.Message, block string) error {
-	path, rel, err := in.resolve(getString(req, "file"))
+	name, err := resolve(getString(req, "file"))
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("creating folder for %s: %w", rel, err)
+	root, err := os.OpenRoot(in.folder)
+	if err != nil {
+		return fmt.Errorf("opening folder: %w", err)
 	}
+	defer root.Close()
 
-	info, statErr := os.Stat(path)
+	info, statErr := root.Stat(name)
 	nonEmpty := statErr == nil && info.Size() > 0
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := root.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("opening %s: %w", rel, err)
+		return fmt.Errorf("opening %s: %w", name, err)
 	}
 	defer f.Close()
 
@@ -385,13 +395,13 @@ func (in *instance) appendBlock(req, resp *dynamicpb.Message, block string) erro
 		b.WriteString("\n")
 	}
 	if _, err := f.WriteString(b.String()); err != nil {
-		return fmt.Errorf("writing to %s: %w", rel, err)
+		return fmt.Errorf("writing to %s: %w", name, err)
 	}
-	return setFileResponse(resp, rel, path)
+	return setFileResponse(resp, name, filepath.Join(in.folder, name))
 }
 
-func setFileResponse(resp *dynamicpb.Message, rel, path string) error {
-	setString(resp, "file", rel)
+func setFileResponse(resp *dynamicpb.Message, name, path string) error {
+	setString(resp, "file", name)
 	setString(resp, "path", path)
 	return nil
 }

--- a/server/pkg/apps/markdown/markdown.go
+++ b/server/pkg/apps/markdown/markdown.go
@@ -356,7 +356,9 @@ func resolve(name string) (string, error) {
 	if !strings.HasSuffix(strings.ToLower(name), ".md") {
 		name += ".md"
 	}
-	if name != filepath.Base(name) || strings.Contains(name, "..") {
+	// filepath.IsLocal rejects absolute paths, "..", and anything that would
+	// escape the folder; it is the canonical path-traversal barrier.
+	if !filepath.IsLocal(name) || name != filepath.Base(name) {
 		return "", fmt.Errorf("file must be a plain name within the folder, got %q", name)
 	}
 	return name, nil

--- a/server/pkg/apps/markdown/markdown_test.go
+++ b/server/pkg/apps/markdown/markdown_test.go
@@ -1,0 +1,123 @@
+package markdown
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// open compiles the app bound to a fresh temp folder.
+func open(t *testing.T) (*instance, string) {
+	t.Helper()
+	folder := t.TempDir()
+	protoDir := t.TempDir()
+	inst, err := New().Open(map[string]string{"folder": folder}, protoDir, func(string) {})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return inst.(*instance), folder
+}
+
+// invoke encodes requestJSON into the method's request, calls it, and returns
+// the response decoded back to JSON.
+func invoke(t *testing.T, inst *instance, methodName, requestJSON string) string {
+	t.Helper()
+	m, ok := inst.methods[methodName]
+	if !ok {
+		t.Fatalf("method %q not found", methodName)
+	}
+	req := dynamicpb.NewMessage(m.input)
+	if requestJSON != "" {
+		if err := protojson.Unmarshal([]byte(requestJSON), req); err != nil {
+			t.Fatalf("build request for %q: %v", methodName, err)
+		}
+	}
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	respBytes, err := inst.Invoke("markdown.Markdown/"+methodName, reqBytes, nil)
+	if err != nil {
+		t.Fatalf("Invoke %q: %v", methodName, err)
+	}
+	resp := dynamicpb.NewMessage(m.output)
+	if err := proto.Unmarshal(respBytes, resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	out, err := protojson.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	return string(out)
+}
+
+func TestWriteAndRead(t *testing.T) {
+	inst, folder := open(t)
+
+	invoke(t, inst, "CreateFile", `{"file": "notes", "title": "My Notes"}`)
+	invoke(t, inst, "AddHeading", `{"file": "notes", "text": "Tasks", "level": 2}`)
+	invoke(t, inst, "AddParagraph", `{"file": "notes", "text": "Some intro."}`)
+	invoke(t, inst, "AddBullets", `{"file": "notes", "items": ["one", "two"]}`)
+	invoke(t, inst, "AddTasks", `{"file": "notes", "items": ["do it"], "done": true}`)
+	invoke(t, inst, "AddCodeBlock", `{"file": "notes", "code": "fmt.Println()", "language": "go"}`)
+	invoke(t, inst, "AddQuote", `{"file": "notes", "text": "wise words"}`)
+	invoke(t, inst, "AppendMarkdown", `{"file": "notes", "markdown": "[link](http://x)"}`)
+
+	got, err := os.ReadFile(filepath.Join(folder, "notes.md"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	want := "# My Notes\n" +
+		"\n## Tasks\n" +
+		"\nSome intro.\n" +
+		"\n- one\n- two\n" +
+		"\n- [x] do it\n" +
+		"\n```go\nfmt.Println()\n```\n" +
+		"\n> wise words\n" +
+		"\n[link](http://x)\n"
+	if string(got) != want {
+		t.Fatalf("file mismatch\n got: %q\nwant: %q", got, want)
+	}
+
+	read := invoke(t, inst, "ReadFile", `{"file": "notes"}`)
+	if read == "" || read == "{}" {
+		t.Fatalf("ReadFile returned empty: %q", read)
+	}
+
+	list := invoke(t, inst, "ListFiles", "")
+	if list != `{"files":["notes.md"]}` {
+		t.Fatalf("ListFiles = %s", list)
+	}
+}
+
+func TestCreateFileNoOverwrite(t *testing.T) {
+	inst, _ := open(t)
+	invoke(t, inst, "CreateFile", `{"file": "dup.md"}`)
+
+	m := inst.methods["CreateFile"]
+	req := dynamicpb.NewMessage(m.input)
+	if err := protojson.Unmarshal([]byte(`{"file": "dup.md"}`), req); err != nil {
+		t.Fatal(err)
+	}
+	reqBytes, _ := proto.Marshal(req)
+	if _, err := inst.Invoke("markdown.Markdown/CreateFile", reqBytes, nil); err == nil {
+		t.Fatal("expected error creating existing file without overwrite")
+	}
+}
+
+func TestRejectsPathTraversal(t *testing.T) {
+	inst, _ := open(t)
+	m := inst.methods["AppendMarkdown"]
+	req := dynamicpb.NewMessage(m.input)
+	if err := protojson.Unmarshal([]byte(`{"file": "../escape.md", "markdown": "x"}`), req); err != nil {
+		t.Fatal(err)
+	}
+	reqBytes, _ := proto.Marshal(req)
+	if _, err := inst.Invoke("markdown.Markdown/AppendMarkdown", reqBytes, nil); err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+}

--- a/ui/src/NewAppDialog.tsx
+++ b/ui/src/NewAppDialog.tsx
@@ -1,11 +1,11 @@
 import { Button, Dialog, Flash, FormControl, Link, TextInput, Tooltip } from "@primer/react";
-import { FileIcon, LightBulbIcon } from "@primer/octicons-react";
+import { FileDirectoryIcon, FileIcon, LightBulbIcon } from "@primer/octicons-react";
 import { useState } from "react";
 import { appTypes, AppTypeDefinition } from "./appTypes";
 import { ConfigurationApp } from "./server/api";
 import { PreviewPill } from "./Sidebar";
 import { isWailsEnvironment } from "./wails";
-import { OpenFileDialog } from "./wailsjs/go/main/App";
+import { OpenDirectoryDialog, OpenFileDialog } from "./wailsjs/go/main/App";
 
 interface NewAppDialogProps {
   // Existing project and app names, used to reject duplicates.
@@ -112,12 +112,12 @@ export function NewAppDialog({ existingNames, onClose, onCreate }: NewAppDialogP
                 }
               }}
               trailingAction={
-                parameter.type === "file" && isWailsEnvironment() ? (
+                (parameter.type === "file" || parameter.type === "folder") && isWailsEnvironment() ? (
                   <TextInput.Action
-                    icon={FileIcon}
-                    aria-label="Select file"
+                    icon={parameter.type === "folder" ? FileDirectoryIcon : FileIcon}
+                    aria-label={parameter.type === "folder" ? "Select folder" : "Select file"}
                     onClick={async () => {
-                      const path = await OpenFileDialog();
+                      const path = parameter.type === "folder" ? await OpenDirectoryDialog() : await OpenFileDialog();
                       if (path) {
                         setParameters((prev) => ({ ...prev, [parameter.key]: path }));
                       }

--- a/ui/src/appTypes.ts
+++ b/ui/src/appTypes.ts
@@ -1,8 +1,8 @@
 import { GlobeIcon, Icon, MarkdownIcon, SparkleFillIcon } from "@primer/octicons-react";
 
-// Parameter kinds an app exposes in the New App form. "file" renders a native
-// file picker on the desktop (and a plain text field everywhere else).
-export type AppParameterType = "text" | "url" | "file";
+// Parameter kinds an app exposes in the New App form. "file" and "folder" render
+// a native picker on the desktop (and a plain text field everywhere else).
+export type AppParameterType = "text" | "url" | "file" | "folder";
 
 export interface AppParameterDefinition {
   key: string;
@@ -75,15 +75,15 @@ export const appTypes: AppTypeDefinition[] = [
   {
     type: "markdown",
     label: "Markdown",
-    description: "Append lines of text to a Markdown file on disk.",
+    description: "Create and write Markdown files in a folder on disk.",
     icon: MarkdownIcon,
     parameters: [
       {
-        key: "path",
-        label: "Markdown file",
-        type: "file",
-        placeholder: "/path/to/notes.md",
-        caption: "Calls append a line to this file. On the desktop, pick the file to grant access.",
+        key: "folder",
+        label: "Markdown folder",
+        type: "folder",
+        placeholder: "/path/to/notes",
+        caption: "Methods create and write Markdown files in this folder. On the desktop, pick the folder to grant access.",
       },
     ],
   },


### PR DESCRIPTION
The Markdown app now binds to a folder instead of a single file and exposes methods to create, read, and write Markdown files in it — with semantic writers (AddHeading, AddParagraph, AddBullets, AddTasks, AddCodeBlock, AddQuote) plus an AppendMarkdown escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013GxZAnXrxCVKGqb85y9TCm)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-304-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-304-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-304-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-304-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-304-newproject.png)

</details>
