### PR TITLE
Unified sidebar to right-click context menus for projects and apps

### DIFF
--- a/ui/src/IconButtonXSmall.tsx
+++ b/ui/src/IconButtonXSmall.tsx
@@ -9,7 +9,7 @@ interface IconButtonXSmallProps extends React.ComponentPropsWithoutRef<"button">
 }
 
 export const IconButtonXSmall = React.forwardRef<HTMLButtonElement, IconButtonXSmallProps>(
-  function IconButtonXSmall({ icon, "aria-label": ariaLabel, onClick, rounded, ...rest }, ref) {
+  function IconButtonXSmall({ icon, "aria-label": ariaLabel, onClick, rounded, style, ...rest }, ref) {
     return (
       <IconButton
         ref={ref}
@@ -25,6 +25,7 @@ export const IconButtonXSmall = React.forwardRef<HTMLButtonElement, IconButtonXS
           padding: 0,
           borderRadius: rounded ? 4 : 0,
           color: "var(--fgColor-muted)",
+          ...style,
         }}
         {...rest}
       />

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   KebabHorizontalIcon,
 } from "@primer/octicons-react";
 import { appTypeLabel } from "./appTypes";
+import { IconButtonXSmall } from "./IconButtonXSmall";
 import { Method, Project, Script, Service, methodId } from "./project";
 import { RpcProtocol } from "./server/api";
 import { getPersistedValue, setPersistedValue } from "./storage";
@@ -467,11 +468,10 @@ export function Sidebar({
                         <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
                           {pinnedScriptPath === script.path && <PinIcon size={12} />}
                           {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
-                            <IconButton
+                            <IconButtonXSmall
                               aria-label={`Actions for ${script.name}`}
                               icon={KebabHorizontalIcon}
-                              size="small"
-                              variant="invisible"
+                              rounded
                               onClick={(e: React.MouseEvent) => {
                                 e.stopPropagation();
                                 setScriptMenu({ script, top: e.clientY, left: e.clientX });
@@ -547,11 +547,10 @@ export function Sidebar({
                     {project.app ? <AppPill type={project.app.type} /> : <ProtocolPill protocol={project.configuration.protocol} />}
                   </span>
                   {(hoveredProject === projectName || projectMenu?.projectName === projectName) && (
-                    <IconButton
+                    <IconButtonXSmall
                       aria-label={`Actions for ${projectName}`}
                       icon={KebabHorizontalIcon}
-                      size="small"
-                      variant="invisible"
+                      rounded
                       onClick={(e: React.MouseEvent) => {
                         e.stopPropagation();
                         setProjectMenu({ projectName, top: e.clientY, left: e.clientX });

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   UnfoldIcon,
   ChevronRightIcon,
   PackageIcon,
+  KebabHorizontalIcon,
 } from "@primer/octicons-react";
 import { appTypeLabel } from "./appTypes";
 import { Method, Project, Script, Service, methodId } from "./project";
@@ -147,6 +148,8 @@ export function Sidebar({
   // Right-click context menu for a project/app, anchored at the cursor.
   const [projectMenu, setProjectMenu] = useState<{ projectName: string; top: number; left: number } | null>(null);
   const projectMenuAnchorRef = useRef<HTMLDivElement>(null);
+  // Project/app row hovered, used to reveal the kebab actions button.
+  const [hoveredProject, setHoveredProject] = useState<string | null>(null);
 
   useEffect(() => {
     setPersistedValue("scriptsExpanded", scriptsExpanded);
@@ -489,13 +492,22 @@ export function Sidebar({
                     fontWeight: "bold",
                     marginLeft: -12,
                     paddingLeft: 4,
+                    paddingRight: 4,
+                    borderRadius: 6,
                     color: "var(--fgColor-muted)",
+                    backgroundColor:
+                      hoveredProject === projectName || projectMenu?.projectName === projectName
+                        ? "var(--control-transparent-bgColor-hover)"
+                        : "transparent",
                     display: "flex",
                     alignItems: "center",
+                    justifyContent: "space-between",
                     cursor: "pointer",
                     userSelect: "none",
                     height: 28,
                   }}
+                  onMouseEnter={() => setHoveredProject(projectName)}
+                  onMouseLeave={() => setHoveredProject((prev) => (prev === projectName ? null : prev))}
                   onClick={() => toggleProjectExpanded(projectName)}
                   onContextMenu={(e: React.MouseEvent) => {
                     e.preventDefault();
@@ -516,6 +528,18 @@ export function Sidebar({
                     {projectName}
                     {project.app ? <AppPill type={project.app.type} /> : <ProtocolPill protocol={project.configuration.protocol} />}
                   </span>
+                  {(hoveredProject === projectName || projectMenu?.projectName === projectName) && (
+                    <IconButton
+                      aria-label={`Actions for ${projectName}`}
+                      icon={KebabHorizontalIcon}
+                      size="small"
+                      variant="invisible"
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        setProjectMenu({ projectName, top: e.clientY, left: e.clientX });
+                      }}
+                    />
+                  )}
                 </div>
               )}
               {(isExpanded || !showProjectHeader) && (

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -463,25 +463,25 @@ export function Sidebar({
                     current={currentScriptPath === script.path}
                   >
                     {script.name}
-                    {(pinnedScriptPath === script.path || hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
-                      <TreeView.TrailingVisual>
-                        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                          {pinnedScriptPath === script.path && <PinIcon size={12} />}
-                          {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
-                            <IconButtonXSmall
-                              aria-label={`Actions for ${script.name}`}
-                              icon={KebabHorizontalIcon}
-                              rounded
-                              style={{ minHeight: 0, minWidth: 0 }}
-                              onClick={(e: React.MouseEvent) => {
-                                e.stopPropagation();
-                                setScriptMenu({ script, top: e.clientY, left: e.clientX });
-                              }}
-                            />
-                          )}
-                        </span>
-                      </TreeView.TrailingVisual>
-                    )}
+                    {/* Always render the trailing visual so its fixed height keeps the row from
+                        reflowing when the kebab appears on hover; only the contents toggle. */}
+                    <TreeView.TrailingVisual>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                        {pinnedScriptPath === script.path && <PinIcon size={12} />}
+                        {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
+                          <IconButtonXSmall
+                            aria-label={`Actions for ${script.name}`}
+                            icon={KebabHorizontalIcon}
+                            rounded
+                            style={{ minHeight: 0, minWidth: 0 }}
+                            onClick={(e: React.MouseEvent) => {
+                              e.stopPropagation();
+                              setScriptMenu({ script, top: e.clientY, left: e.clientX });
+                            }}
+                          />
+                        )}
+                      </span>
+                    </TreeView.TrailingVisual>
                   </TreeView.Item>
                 ))}
               </TreeView>

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -145,6 +145,8 @@ export function Sidebar({
   // Right-click context menu for a script, anchored at the cursor.
   const [scriptMenu, setScriptMenu] = useState<{ script: Script; top: number; left: number } | null>(null);
   const scriptMenuAnchorRef = useRef<HTMLDivElement>(null);
+  // Script row hovered, used to reveal the kebab actions button.
+  const [hoveredScript, setHoveredScript] = useState<string | null>(null);
   // Right-click context menu for a project/app, anchored at the cursor.
   const [projectMenu, setProjectMenu] = useState<{ projectName: string; top: number; left: number } | null>(null);
   const projectMenuAnchorRef = useRef<HTMLDivElement>(null);
@@ -446,21 +448,37 @@ export function Sidebar({
                     id={`script-${script.path}`}
                     key={script.path}
                     ref={(el: HTMLElement | null) => {
-                      // TreeView.Item doesn't forward onContextMenu, so attach it to the DOM node.
+                      // TreeView.Item doesn't forward these handlers, so attach them to the DOM node.
                       if (el) {
                         el.oncontextmenu = (e) => {
                           e.preventDefault();
                           setScriptMenu({ script, top: e.clientY, left: e.clientX });
                         };
+                        el.onmouseenter = () => setHoveredScript(script.path);
+                        el.onmouseleave = () => setHoveredScript((prev) => (prev === script.path ? null : prev));
                       }
                     }}
                     onSelect={() => onScriptSelect?.(script)}
                     current={currentScriptPath === script.path}
                   >
                     {script.name}
-                    {pinnedScriptPath === script.path && (
-                      <TreeView.TrailingVisual label="Pinned to context menu">
-                        <PinIcon size={12} />
+                    {(pinnedScriptPath === script.path || hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
+                      <TreeView.TrailingVisual>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                          {pinnedScriptPath === script.path && <PinIcon size={12} />}
+                          {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
+                            <IconButton
+                              aria-label={`Actions for ${script.name}`}
+                              icon={KebabHorizontalIcon}
+                              size="small"
+                              variant="invisible"
+                              onClick={(e: React.MouseEvent) => {
+                                e.stopPropagation();
+                                setScriptMenu({ script, top: e.clientY, left: e.clientX });
+                              }}
+                            />
+                          )}
+                        </span>
                       </TreeView.TrailingVisual>
                     )}
                   </TreeView.Item>

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -144,6 +144,9 @@ export function Sidebar({
   // Right-click context menu for a script, anchored at the cursor.
   const [scriptMenu, setScriptMenu] = useState<{ script: Script; top: number; left: number } | null>(null);
   const scriptMenuAnchorRef = useRef<HTMLDivElement>(null);
+  // Right-click context menu for a project/app, anchored at the cursor.
+  const [projectMenu, setProjectMenu] = useState<{ projectName: string; top: number; left: number } | null>(null);
+  const projectMenuAnchorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setPersistedValue("scriptsExpanded", scriptsExpanded);
@@ -489,12 +492,15 @@ export function Sidebar({
                     color: "var(--fgColor-muted)",
                     display: "flex",
                     alignItems: "center",
-                    justifyContent: "space-between",
                     cursor: "pointer",
                     userSelect: "none",
                     height: 28,
                   }}
                   onClick={() => toggleProjectExpanded(projectName)}
+                  onContextMenu={(e: React.MouseEvent) => {
+                    e.preventDefault();
+                    setProjectMenu({ projectName, top: e.clientY, left: e.clientX });
+                  }}
                 >
                   <span style={{ display: "flex", alignItems: "center", gap: 2 }}>
                     <span
@@ -510,32 +516,6 @@ export function Sidebar({
                     {projectName}
                     {project.app ? <AppPill type={project.app.type} /> : <ProtocolPill protocol={project.configuration.protocol} />}
                   </span>
-                  {isExpanded && (
-                    <span style={{ display: "flex", alignItems: "center", gap: 2 }}>
-                      <IconButton
-                        aria-label={`Edit ${projectName}`}
-                        icon={PencilIcon}
-                        size="small"
-                        variant="invisible"
-                        onClick={(e: React.MouseEvent) => {
-                          e.stopPropagation();
-                          onEditProject(projectName);
-                        }}
-                      />
-                      {canDeleteProjects && (
-                        <IconButton
-                          aria-label={`Delete ${projectName}`}
-                          icon={TrashIcon}
-                          size="small"
-                          variant="invisible"
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            onDeleteProject(projectName);
-                          }}
-                        />
-                      )}
-                    </span>
-                  )}
                 </div>
               )}
               {(isExpanded || !showProjectHeader) && (
@@ -686,6 +666,42 @@ export function Sidebar({
               </ActionList.LeadingVisual>
               Delete
             </ActionList.Item>
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+      {/* Invisible anchor positioned at the cursor for the project context menu. */}
+      <div
+        ref={projectMenuAnchorRef}
+        style={{ position: "fixed", top: projectMenu?.top ?? 0, left: projectMenu?.left ?? 0, width: 1, height: 1, pointerEvents: "none" }}
+      />
+      <ActionMenu open={!!projectMenu} onOpenChange={(open) => !open && setProjectMenu(null)} anchorRef={projectMenuAnchorRef}>
+        <ActionMenu.Overlay width="small">
+          <ActionList>
+            <ActionList.Item
+              onSelect={() => {
+                const projectName = projectMenu?.projectName;
+                if (projectName) onEditProject(projectName);
+              }}
+            >
+              <ActionList.LeadingVisual>
+                <PencilIcon />
+              </ActionList.LeadingVisual>
+              Edit
+            </ActionList.Item>
+            {canDeleteProjects && (
+              <ActionList.Item
+                variant="danger"
+                onSelect={() => {
+                  const projectName = projectMenu?.projectName;
+                  if (projectName) onDeleteProject(projectName);
+                }}
+              >
+                <ActionList.LeadingVisual>
+                  <TrashIcon />
+                </ActionList.LeadingVisual>
+                Delete
+              </ActionList.Item>
+            )}
           </ActionList>
         </ActionMenu.Overlay>
       </ActionMenu>

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -472,6 +472,7 @@ export function Sidebar({
                               aria-label={`Actions for ${script.name}`}
                               icon={KebabHorizontalIcon}
                               rounded
+                              style={{ minHeight: 0, minWidth: 0 }}
                               onClick={(e: React.MouseEvent) => {
                                 e.stopPropagation();
                                 setScriptMenu({ script, top: e.clientY, left: e.clientX });
@@ -551,6 +552,7 @@ export function Sidebar({
                       aria-label={`Actions for ${projectName}`}
                       icon={KebabHorizontalIcon}
                       rounded
+                      style={{ minHeight: 0, minWidth: 0 }}
                       onClick={(e: React.MouseEvent) => {
                         e.stopPropagation();
                         setProjectMenu({ projectName, top: e.clientY, left: e.clientX });


### PR DESCRIPTION
Replaced the inline edit/delete icons on expanded projects and apps with a right-click context menu, matching how scripts already work for a consistent interaction across the sidebar.

<img width="557" height="138" alt="image" src="https://github.com/user-attachments/assets/2fdbfe2d-5c19-4d86-aea0-049a90753961" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQZ3PQqjK4QHypLxi5viZv)_




<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-305-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-305-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-305-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-305-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-305-newproject.png)

</details>
