### PR TITLE
Auto-expanded newly added projects and apps in the sidebar

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -178,6 +178,8 @@ export function App() {
   } | null>(null);
   // Whether the New App dialog is open.
   const [newAppOpen, setNewAppOpen] = useState(false);
+  // One-shot signal to auto-expand a just-added project/app in the sidebar.
+  const [autoExpandProject, setAutoExpandProject] = useState<{ name: string }>();
   // Rename dialog and delete confirmation for scripts (right-click menu).
   const [renameScript, setRenameScript] = useState<{ script: Script; name: string } | null>(null);
   const [renameError, setRenameError] = useState<string>();
@@ -1103,6 +1105,7 @@ export function App() {
     }
     setNewAppOpen(false);
     onCompilerClick();
+    setAutoExpandProject({ name: app.name });
   };
 
   const onEditProject = (projectName: string) => {
@@ -1161,6 +1164,10 @@ export function App() {
     // Show compiler tab for new projects or when recompilation is needed
     if (isNewProject || needsRecompilation) {
       onCompilerClick();
+    }
+
+    if (isNewProject) {
+      setAutoExpandProject({ name: project.name });
     }
   };
 
@@ -1254,6 +1261,7 @@ export function App() {
                   onCompilerClick={onCompilerClick}
                   onNewProjectClick={onNewProjectClick}
                   onNewAppClick={onNewAppClick}
+                  autoExpandProject={autoExpandProject}
                   appsPreviewEnabled={previewApps}
                   reserveTrafficLights={isDesktopMac}
                   onEditProject={onEditProject}

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -116,6 +116,8 @@ interface SidebarProps {
   onCompilerClick: () => void;
   onNewProjectClick: () => void;
   onNewAppClick: () => void;
+  // One-shot signal to auto-expand a just-added project/app (and its first service).
+  autoExpandProject?: { name: string };
   // Experimental "Apps" feature preview; gates the New App entry in the "+" menu.
   appsPreviewEnabled?: boolean;
   // macOS desktop: inset the header row to clear the window traffic lights and make
@@ -141,6 +143,7 @@ export function Sidebar({
   onCompilerClick,
   onNewProjectClick,
   onNewAppClick,
+  autoExpandProject,
   appsPreviewEnabled = false,
   reserveTrafficLights = false,
   onEditProject,
@@ -270,6 +273,48 @@ export function Sidebar({
       if (pruned.size !== prev.size) return pruned;
       return prev;
     });
+  }, [projects]);
+
+  // Auto-expand a just-added project/app. The project is expanded immediately;
+  // its first service (and first package, when several exist) is expanded once
+  // compilation finishes and services become available.
+  const pendingFirstServiceExpand = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!autoExpandProject) return;
+    const { name } = autoExpandProject;
+    setExpandedProjects((prev) => {
+      if (prev.has(name)) return prev;
+      const next = new Set(prev);
+      next.add(name);
+      return next;
+    });
+    pendingFirstServiceExpand.current.add(name);
+    pendingScrollRef.current = name;
+  }, [autoExpandProject]);
+
+  useEffect(() => {
+    if (pendingFirstServiceExpand.current.size === 0) return;
+    const idsToExpand: string[] = [];
+    const ready: string[] = [];
+    for (const name of pendingFirstServiceExpand.current) {
+      const project = projects.find((p) => p.configuration.name === name);
+      if (project && project.services.length > 0) {
+        if (hasMultiplePackages(project.services)) {
+          idsToExpand.push(getPackageElementId(name, project.services[0].packageName));
+        }
+        idsToExpand.push(getServiceElementId(name, project.services[0]));
+        ready.push(name);
+      }
+    }
+    if (idsToExpand.length > 0) {
+      setExpandedServices((prev) => {
+        const next = new Set(prev);
+        idsToExpand.forEach((id) => next.add(id));
+        return next;
+      });
+      ready.forEach((n) => pendingFirstServiceExpand.current.delete(n));
+    }
   }, [projects]);
 
   // Scroll expanded element into view after DOM updates


### PR DESCRIPTION
Newly added projects and apps now auto-expand in the sidebar, and their first service (and first package, when several exist) expands once compilation finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014NbBEhUkdgDMKfmgAM1sdL)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-308-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-308-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-308-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-308-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-308-newproject.png)

</details>
