### PR TITLE
Fixed MCP server failing silently in the sandboxed desktop build

### DIFF
--- a/desktop/build/darwin/entitlements.plist
+++ b/desktop/build/darwin/entitlements.plist
@@ -14,6 +14,9 @@
     <key>com.apple.security.network.client</key>
     <true/>
 
+    <key>com.apple.security.network.server</key>
+    <true/>
+
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
 

--- a/desktop/logging.go
+++ b/desktop/logging.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// setupLogging routes slog to <kajaHome>/logs/kaja.log so server-side logs land
+// in the same shareable file as the UI logs (see LogFromUI). Without this, slog
+// only writes to stderr, which a Finder-launched .app discards — so failures
+// like the MCP server not starting were invisible. Output is also mirrored to
+// stderr for the dev build.
+func setupLogging(kajaDir string) {
+	dir := filepath.Join(kajaDir, "logs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "kaja.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	w := io.MultiWriter(os.Stderr, f)
+	slog.SetDefault(slog.New(newServerLogHandler(w, slog.LevelInfo)))
+}
+
+// serverLogHandler writes single-line records as "<time> [server] [LEVEL] msg
+// key=value ...", matching the format LogFromUI uses for "[ui]" lines.
+type serverLogHandler struct {
+	mu    *sync.Mutex
+	w     io.Writer
+	level slog.Level
+	attrs []slog.Attr
+}
+
+func newServerLogHandler(w io.Writer, level slog.Level) *serverLogHandler {
+	return &serverLogHandler{mu: &sync.Mutex{}, w: w, level: level}
+}
+
+func (h *serverLogHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level
+}
+
+func (h *serverLogHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s [server] [%s] %s", r.Time.Format(time.RFC3339), r.Level.String(), r.Message)
+	for _, a := range h.attrs {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value.Any())
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value.Any())
+		return true
+	})
+	b.WriteByte('\n')
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.w, b.String())
+	return err
+}
+
+func (h *serverLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	nh := *h
+	nh.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &nh
+}
+
+func (h *serverLogHandler) WithGroup(_ string) slog.Handler {
+	return h
+}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -633,6 +633,8 @@ func main() {
 		return
 	}
 
+	setupLogging(kajaDir)
+
 	configurationPath := filepath.Join(kajaDir, "kaja.json")
 
 	// Ensure the global scripts directory exists so it's discoverable.


### PR DESCRIPTION
Added the `com.apple.security.network.server` entitlement so the sandboxed macOS app can bind the localhost MCP port, and routed `slog` to `kaja.log` so server-side failures actually show up in "Show Logs in Finder".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DArSHUkcvHxCEfWqdhg5Yy)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-309-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-309-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-309-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-309-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-309-newproject.png)

</details>
