### PR TITLE
Grouped OpenAPI operations into one service per tag

### DIFF
--- a/server/pkg/apps/openapi/invoke.go
+++ b/server/pkg/apps/openapi/invoke.go
@@ -155,6 +155,15 @@ func lastSegment(s string) string {
 	return s
 }
 
+// serviceOfMethodPath returns the service-type portion of a "<service>/<Method>"
+// gRPC method path.
+func serviceOfMethodPath(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
 // jsonScalar renders a JSON value as a plain string for use in a path or query.
 func jsonScalar(raw json.RawMessage) string {
 	if len(raw) == 0 {

--- a/server/pkg/apps/openapi/openapi.go
+++ b/server/pkg/apps/openapi/openapi.go
@@ -43,7 +43,7 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 	if err != nil {
 		return nil, err
 	}
-	log(fmt.Sprintf("Generated service %s with %d method(s)", gen.serviceTypeName, len(gen.bindings)))
+	log(fmt.Sprintf("Generated %d service(s) with %d method(s)", len(gen.serviceTypeNames), len(gen.bindings)))
 
 	if err := os.WriteFile(filepath.Join(protoDir, "service.proto"), []byte(gen.proto), 0o644); err != nil {
 		return nil, fmt.Errorf("writing proto: %w", err)
@@ -84,17 +84,25 @@ func compileMethods(protoDir string, gen *generated) (map[string]*boundMethod, e
 		return nil, fmt.Errorf("building descriptors: %w", err)
 	}
 
-	descriptor, err := files.FindDescriptorByName(protoreflect.FullName(gen.serviceTypeName))
-	if err != nil {
-		return nil, fmt.Errorf("finding service %s: %w", gen.serviceTypeName, err)
-	}
-	service, ok := descriptor.(protoreflect.ServiceDescriptor)
-	if !ok {
-		return nil, fmt.Errorf("%s is not a service", gen.serviceTypeName)
+	services := make(map[string]protoreflect.ServiceDescriptor, len(gen.serviceTypeNames))
+	for _, serviceTypeName := range gen.serviceTypeNames {
+		descriptor, err := files.FindDescriptorByName(protoreflect.FullName(serviceTypeName))
+		if err != nil {
+			return nil, fmt.Errorf("finding service %s: %w", serviceTypeName, err)
+		}
+		service, ok := descriptor.(protoreflect.ServiceDescriptor)
+		if !ok {
+			return nil, fmt.Errorf("%s is not a service", serviceTypeName)
+		}
+		services[serviceTypeName] = service
 	}
 
 	methods := make(map[string]*boundMethod, len(gen.bindings))
 	for key, binding := range gen.bindings {
+		service := services[serviceOfMethodPath(key)]
+		if service == nil {
+			return nil, fmt.Errorf("no service for method path %s", key)
+		}
 		name := lastSegment(key)
 		method := service.Methods().ByName(protoreflect.Name(name))
 		if method == nil {

--- a/server/pkg/apps/openapi/openapi_test.go
+++ b/server/pkg/apps/openapi/openapi_test.go
@@ -132,8 +132,8 @@ func TestGenerateProto(t *testing.T) {
 		t.Fatalf("generateProto: %v", err)
 	}
 
-	if want := "openapi.swagger_petstore.SwaggerPetstore"; gen.serviceTypeName != want {
-		t.Errorf("serviceTypeName = %q, want %q", gen.serviceTypeName, want)
+	if want := []string{"openapi.swagger_petstore.SwaggerPetstore"}; len(gen.serviceTypeNames) != 1 || gen.serviceTypeNames[0] != want[0] {
+		t.Errorf("serviceTypeNames = %q, want %q", gen.serviceTypeNames, want)
 	}
 
 	for _, frag := range []string{
@@ -179,6 +179,95 @@ func TestGenerateProto(t *testing.T) {
 	if b := gen.bindings["openapi.swagger_petstore.SwaggerPetstore/ListPets"]; b != nil {
 		if b.responseWrap != "array" || len(b.queryParams) != 1 || b.queryParams[0] != "limit" {
 			t.Errorf("ListPets binding unexpected: %+v", b)
+		}
+	}
+}
+
+// TestGenerateProtoTagGrouping checks that operations are split into one service
+// per OpenAPI tag, with untagged operations falling into the title-named service.
+func TestGenerateProtoTagGrouping(t *testing.T) {
+	const taggedSpec = `
+openapi: 3.0.0
+info:
+  title: Store
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      tags: ["Pets"]
+      responses:
+        "200": { description: ok }
+  /pets/{id}:
+    delete:
+      operationId: deletePet
+      tags: ["Pets"]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "204": { description: gone }
+  /orders:
+    post:
+      operationId: createOrder
+      tags: ["Orders"]
+      responses:
+        "201": { description: created }
+  /health:
+    get:
+      operationId: health
+      responses:
+        "200": { description: ok }
+`
+	s, err := parseSpec([]byte(taggedSpec))
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	gen, err := generateProto(s)
+	if err != nil {
+		t.Fatalf("generateProto: %v", err)
+	}
+
+	// Services follow first-appearance order: /health (untagged -> Store) sorts
+	// before /orders and /pets.
+	want := []string{
+		"openapi.store.Store",
+		"openapi.store.Orders",
+		"openapi.store.Pets",
+	}
+	if len(gen.serviceTypeNames) != len(want) {
+		t.Fatalf("serviceTypeNames = %q, want %q", gen.serviceTypeNames, want)
+	}
+	for i, w := range want {
+		if gen.serviceTypeNames[i] != w {
+			t.Errorf("serviceTypeNames[%d] = %q, want %q", i, gen.serviceTypeNames[i], w)
+		}
+	}
+
+	for _, frag := range []string{
+		"service Store {",
+		"service Pets {",
+		"service Orders {",
+		"rpc Health(HealthRequest) returns (HealthResponse);",
+		"rpc ListPets(ListPetsRequest) returns (ListPetsResponse);",
+		"rpc DeletePet(DeletePetRequest) returns (DeletePetResponse);",
+		"rpc CreateOrder(CreateOrderRequest) returns (CreateOrderResponse);",
+	} {
+		if !strings.Contains(gen.proto, frag) {
+			t.Errorf("generated proto missing %q\n---\n%s", frag, gen.proto)
+		}
+	}
+
+	for _, key := range []string{
+		"openapi.store.Store/Health",
+		"openapi.store.Pets/ListPets",
+		"openapi.store.Pets/DeletePet",
+		"openapi.store.Orders/CreateOrder",
+	} {
+		if _, ok := gen.bindings[key]; !ok {
+			t.Errorf("missing binding %q", key)
 		}
 	}
 }

--- a/server/pkg/apps/openapi/protogen.go
+++ b/server/pkg/apps/openapi/protogen.go
@@ -18,13 +18,13 @@ type methodBinding struct {
 	responseWrap string   // object | array | scalar | empty
 }
 
-// generated is the output of converting a spec: the proto file text, the service
-// type name (package-qualified), and the per-method HTTP bindings keyed by the
-// Twirp method path "<serviceTypeName>/<MethodName>".
+// generated is the output of converting a spec: the proto file text, the
+// package-qualified type names of every generated service, and the per-method
+// HTTP bindings keyed by the gRPC method path "<serviceTypeName>/<MethodName>".
 type generated struct {
-	proto           string
-	serviceTypeName string
-	bindings        map[string]*methodBinding
+	proto            string
+	serviceTypeNames []string
+	bindings         map[string]*methodBinding
 }
 
 type fieldDef struct {
@@ -47,16 +47,28 @@ type rpcDef struct {
 	summary string
 }
 
+// serviceDef is a single generated proto service. Operations are grouped into
+// services by their first OpenAPI tag (untagged operations fall into a default
+// service named after the spec title), so the catalog mirrors how the upstream
+// API documents its resources instead of one crowded flat service.
+type serviceDef struct {
+	name string
+	rpcs []*rpcDef
+}
+
 type generator struct {
-	spec        *spec
-	pkg         string
-	serviceName string
+	spec               *spec
+	pkg                string
+	defaultServiceName string
 
 	messages []*messageDef
 	seenMsg  map[string]bool
-	rpcs     []*rpcDef
-	seenRPC  map[string]bool
-	bindings map[string]*methodBinding
+
+	services     []*serviceDef
+	serviceIndex map[string]*serviceDef
+	seenRPC      map[string]bool
+
+	bindingByMethod map[string]*methodBinding
 }
 
 // generateProto converts an OpenAPI spec into a single proto file plus bindings.
@@ -66,12 +78,13 @@ func generateProto(s *spec) (*generated, error) {
 		title = "Api"
 	}
 	g := &generator{
-		spec:        s,
-		pkg:         "openapi." + lowerSnake(title),
-		serviceName: ensureName(pascal(title), "Api"),
-		seenMsg:     map[string]bool{},
-		seenRPC:     map[string]bool{},
-		bindings:    map[string]*methodBinding{},
+		spec:               s,
+		pkg:                "openapi." + lowerSnake(title),
+		defaultServiceName: ensureName(pascal(title), "Api"),
+		seenMsg:            map[string]bool{},
+		seenRPC:            map[string]bool{},
+		serviceIndex:       map[string]*serviceDef{},
+		bindingByMethod:    map[string]*methodBinding{},
 	}
 
 	paths := make([]string, 0, len(s.Paths))
@@ -87,22 +100,65 @@ func generateProto(s *spec) (*generated, error) {
 		}
 	}
 
-	if len(g.rpcs) == 0 {
+	if len(g.services) == 0 {
 		return nil, fmt.Errorf("spec has no operations to expose")
 	}
 
-	serviceTypeName := g.pkg + "." + g.serviceName
-	// Re-key bindings by full Twirp method path now that the service name is known.
+	g.resolveServiceNameCollisions()
+
+	// Key bindings by full gRPC method path now that service names are settled.
 	bindings := map[string]*methodBinding{}
-	for methodName, b := range g.bindings {
-		bindings[serviceTypeName+"/"+methodName] = b
+	serviceTypeNames := make([]string, 0, len(g.services))
+	for _, svc := range g.services {
+		serviceTypeName := g.pkg + "." + svc.name
+		serviceTypeNames = append(serviceTypeNames, serviceTypeName)
+		for _, r := range svc.rpcs {
+			bindings[serviceTypeName+"/"+r.name] = g.bindingByMethod[r.name]
+		}
 	}
 
 	return &generated{
-		proto:           g.render(),
-		serviceTypeName: serviceTypeName,
-		bindings:        bindings,
+		proto:            g.render(),
+		serviceTypeNames: serviceTypeNames,
+		bindings:         bindings,
 	}, nil
+}
+
+// serviceFor returns the service an operation belongs to, creating it on first
+// use. Grouping is by the operation's first tag; untagged operations land in the
+// default (title-named) service.
+func (g *generator) serviceFor(op *operation) *serviceDef {
+	name := g.defaultServiceName
+	if len(op.Tags) > 0 {
+		if n := pascal(op.Tags[0]); n != "" {
+			name = n
+		}
+	}
+	if svc, ok := g.serviceIndex[name]; ok {
+		return svc
+	}
+	svc := &serviceDef{name: name}
+	g.serviceIndex[name] = svc
+	g.services = append(g.services, svc)
+	return svc
+}
+
+// resolveServiceNameCollisions renames any service whose name clashes with a
+// generated message, since proto services and messages share one namespace.
+func (g *generator) resolveServiceNameCollisions() {
+	for _, svc := range g.services {
+		if !g.seenMsg[svc.name] {
+			continue
+		}
+		base := svc.name + "Service"
+		candidate := base
+		for i := 2; g.seenMsg[candidate] || g.serviceIndex[candidate] != nil; i++ {
+			candidate = fmt.Sprintf("%s%d", base, i)
+		}
+		delete(g.serviceIndex, svc.name)
+		g.serviceIndex[candidate] = svc
+		svc.name = candidate
+	}
 }
 
 func (g *generator) addOperation(path string, item *pathItem, vo verbOp) {
@@ -142,8 +198,9 @@ func (g *generator) addOperation(path string, item *pathItem, vo verbOp) {
 	output, wrap := g.responseType(methodName, op)
 	binding.responseWrap = wrap
 
-	g.rpcs = append(g.rpcs, &rpcDef{name: methodName, input: reqName, output: output, summary: op.Summary})
-	g.bindings[methodName] = binding
+	svc := g.serviceFor(op)
+	svc.rpcs = append(svc.rpcs, &rpcDef{name: methodName, input: reqName, output: output, summary: op.Summary})
+	g.bindingByMethod[methodName] = binding
 }
 
 // responseType resolves a method's output message name and how the HTTP response
@@ -315,14 +372,19 @@ func (g *generator) render() string {
 		b.WriteString("}\n\n")
 	}
 
-	fmt.Fprintf(&b, "service %s {\n", g.serviceName)
-	for _, r := range g.rpcs {
-		if r.summary != "" {
-			fmt.Fprintf(&b, "  // %s\n", strings.ReplaceAll(r.summary, "\n", " "))
+	for i, svc := range g.services {
+		if i > 0 {
+			b.WriteString("\n")
 		}
-		fmt.Fprintf(&b, "  rpc %s(%s) returns (%s);\n", r.name, r.input, r.output)
+		fmt.Fprintf(&b, "service %s {\n", svc.name)
+		for _, r := range svc.rpcs {
+			if r.summary != "" {
+				fmt.Fprintf(&b, "  // %s\n", strings.ReplaceAll(r.summary, "\n", " "))
+			}
+			fmt.Fprintf(&b, "  rpc %s(%s) returns (%s);\n", r.name, r.input, r.output)
+		}
+		b.WriteString("}\n")
 	}
-	b.WriteString("}\n")
 	return b.String()
 }
 


### PR DESCRIPTION
OpenAPI apps now split operations into one proto service per tag (mirroring how an API documents its resources) instead of one crowded flat service; untagged operations fall back to a title-named service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019KxZqt3F5jDn6mAcMFF7h6)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-310-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-310-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-310-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-310-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-310-newproject.png)

</details>
