### PR TITLE
Moved pinned-script indicator to the leading slot

### DIFF
--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -529,25 +529,27 @@ export function Sidebar({
                     onSelect={() => onScriptSelect?.(script)}
                     current={currentScriptPath === script.path}
                   >
+                    {/* Pin lives in the leading slot so it never shifts when the kebab appears on
+                        hover, and it lines a pinned script up with the package/expand icons above. */}
+                    {pinnedScriptPath === script.path && (
+                      <TreeView.LeadingVisual>
+                        <PinIcon size={12} />
+                      </TreeView.LeadingVisual>
+                    )}
                     {script.name}
-                    {/* Always render the trailing visual so its fixed height keeps the row from
-                        reflowing when the kebab appears on hover; only the contents toggle. */}
                     <TreeView.TrailingVisual>
-                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                        {pinnedScriptPath === script.path && <PinIcon size={12} />}
-                        {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
-                          <IconButtonXSmall
-                            aria-label={`Actions for ${script.name}`}
-                            icon={KebabHorizontalIcon}
-                            rounded
-                            style={{ minHeight: 0, minWidth: 0 }}
-                            onClick={(e: React.MouseEvent) => {
-                              e.stopPropagation();
-                              setScriptMenu({ script, top: e.clientY, left: e.clientX });
-                            }}
-                          />
-                        )}
-                      </span>
+                      {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
+                        <IconButtonXSmall
+                          aria-label={`Actions for ${script.name}`}
+                          icon={KebabHorizontalIcon}
+                          rounded
+                          style={{ minHeight: 0, minWidth: 0 }}
+                          onClick={(e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            setScriptMenu({ script, top: e.clientY, left: e.clientX });
+                          }}
+                        />
+                      )}
                     </TreeView.TrailingVisual>
                   </TreeView.Item>
                 ))}


### PR DESCRIPTION
Moves the script pin into the `TreeView.LeadingVisual` so it no longer jumps left when the hover kebab appears, and aligns pinned scripts with the package/expand icons above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxN8DqpChQvmzVK9jrEgFB)_

<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-312-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-312-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-312-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-312-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-312-newproject.png)

</details>
