### PR TITLE
Added CI-driven release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "open a new version, or ship the current one"
+        required: true
+        type: choice
+        options:
+          - open
+          - ship
+        default: open
+      bump:
+        description: "version bump (only used by 'open')"
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: minor
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Open new version
+        if: ${{ inputs.action == 'open' }}
+        run: scripts/release open "${{ inputs.bump }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Ship current version
+        if: ${{ inputs.action == 'ship' }}
+        run: scripts/release ship
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -140,3 +140,10 @@ The development scripts require [Go](https://go.dev/doc/install) and [Bun](https
 - TSC UI: `(cd ui && bun run tsc)`
 - Test server: `(cd server && go test ./... -v)`
 - Update demo protos: `scripts/demo-protos` (The demo services are deployed via [kaja/tools/website](github.com/kaja-tools/website))
+
+### Releases
+
+Releases are cut from GitHub — no local build needed. Every push to `main` uploads a new build to TestFlight. To ship a version, run the **release** workflow (Actions → Run workflow):
+
+- `open` (with `patch`/`minor`/`major`) — bumps the version, tags it, and drafts a GitHub Release. TestFlight builds now carry the new version.
+- `ship` — publishes the draft Release. Run it when you promote that TestFlight build to the App Store.

--- a/scripts/desktop
+++ b/scripts/desktop
@@ -3,21 +3,6 @@ set -e
 
 source "$(dirname "$0")/common"
 
-# Parse arguments
-BUILD_MODE=""
-for arg in "$@"; do
-    case $arg in
-        --build=store)
-            BUILD_MODE="store"
-            shift
-            ;;
-    esac
-done
-
-# Hardcoded signing profiles
-STORE_APP_PROFILE="Apple Distribution: Tomas Vesely (U5DMD247UW)"
-STORE_INSTALLER_PROFILE="3rd Party Mac Developer Installer: Tomas Vesely (U5DMD247UW)"
-
 # Check if Wails is installed
 if ! command -v wails &> /dev/null
 then
@@ -34,7 +19,7 @@ then
     brew install wails
 fi
 
-# Check if Bun is installed (wails dev/build invokes it via frontend:install)
+# Check if Bun is installed (wails dev invokes it via frontend:install)
 if ! command -v bun &> /dev/null
 then
     if [ -t 0 ]; then
@@ -57,75 +42,16 @@ export PATH=$GOBIN:$PATH
 
 # Frontend prep (bun install + bundle UI + copy static assets) is now driven
 # by Wails via the frontend:install / frontend:build / frontend:dev:watcher
-# hooks declared in desktop/wails.json. `wails dev` and `wails build` invoke
-# them automatically with cwd = ../ui.
+# hooks declared in desktop/wails.json. `wails dev` invokes them automatically
+# with cwd = ../ui.
 
 cd ./desktop
 
-if [ "$BUILD_MODE" = "store" ]; then
-    # Releases are cut from CI — see scripts/release and .github/workflows/release.yml.
-    # This local store build is for debugging the signed .pkg only: it never bumps
-    # the version, tags, commits, or pushes. It builds whatever version is currently
-    # in wails.json.
-    GIT_TAG=$(jq -r '.info.productVersion' wails.json)
-    echo "Building store package for version $GIT_TAG (local debug; no version bump)"
-
-    echo "Building desktop app (store)..."
-    export MACOSX_DEPLOYMENT_TARGET=12.0
-    export CGO_LDFLAGS="-mmacosx-version-min=12.0"
-    export CGO_CFLAGS="-mmacosx-version-min=12.0"
-    wails build -ldflags "-X main.GitRef=$GIT_TAG"
-
-    APP_BUNDLE="./build/bin/Kaja.app"
-    if [ -d "$APP_BUNDLE" ]; then
-        # Embed provisioning profile for App Store builds
-        PROVISION_PROFILE="./build/darwin/embedded.provisionprofile"
-        if [ ! -f "$PROVISION_PROFILE" ]; then
-            echo "Error: $PROVISION_PROFILE not found."
-            echo "Download your Mac App Store provisioning profile from Apple Developer portal"
-            echo "and save it as $PROVISION_PROFILE"
-            exit 1
-        fi
-        cp "$PROVISION_PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"
-        echo "Embedded provisioning profile"
-
-        # Strip com.apple.quarantine (and any other xattrs) the downloaded
-        # profile carries — the App Store rejects packages whose files have
-        # quarantine attributes. Must run before signing so it's sealed in.
-        xattr -cr "$APP_BUNDLE"
-
-        # Store builds must sign with the real identity — no ad-hoc fallback
-        codesign --force --options runtime --deep \
-            --sign "$STORE_APP_PROFILE" \
-            --entitlements "./build/darwin/entitlements.plist" \
-            "$APP_BUNDLE"
-        echo "App signed with: $STORE_APP_PROFILE"
-
-        # Build .pkg for App Store submission
-        echo ""
-        echo "Creating App Store package..."
-        PKG_PATH="./build/bin/Kaja.pkg"
-        rm -f "$PKG_PATH"
-
-        productbuild \
-            --component "$APP_BUNDLE" /Applications \
-            --sign "$STORE_INSTALLER_PROFILE" \
-            "$PKG_PATH"
-
-        echo ""
-        echo "App Store package complete: $PKG_PATH"
-        echo "Upload with Transporter or: xcrun altool --upload-app -f $PKG_PATH -t macos"
-        echo ""
-        echo "Build complete: $APP_BUNDLE"
-    fi
-
-else
-    # Dev mode. wails.json handles the entire frontend pipeline:
-    #   - frontend:install runs `bun install` in ../ui
-    #   - frontend:build performs the initial bundle into frontend/dist
-    #   - frontend:dev:watcher keeps that dir live via esbuild's watch mode
-    #   - assetdir + reloaddirs make Wails reload on UI changes and rebuild on
-    #     shared Go edits
-    GIT_REF=$(git rev-parse HEAD 2>/dev/null || echo "")
-    wails dev -ldflags "-X main.GitRef=$GIT_REF"
-fi
+# Dev mode. wails.json handles the entire frontend pipeline:
+#   - frontend:install runs `bun install` in ../ui
+#   - frontend:build performs the initial bundle into frontend/dist
+#   - frontend:dev:watcher keeps that dir live via esbuild's watch mode
+#   - assetdir + reloaddirs make Wails reload on UI changes and rebuild on
+#     shared Go edits
+GIT_REF=$(git rev-parse HEAD 2>/dev/null || echo "")
+wails dev -ldflags "-X main.GitRef=$GIT_REF"

--- a/scripts/desktop
+++ b/scripts/desktop
@@ -5,28 +5,10 @@ source "$(dirname "$0")/common"
 
 # Parse arguments
 BUILD_MODE=""
-VERSION_BUMP=""
-NO_BUMP=""
 for arg in "$@"; do
     case $arg in
         --build=store)
             BUILD_MODE="store"
-            shift
-            ;;
-        --no-bump)
-            NO_BUMP="1"
-            shift
-            ;;
-        --version=patch)
-            VERSION_BUMP="patch"
-            shift
-            ;;
-        --version=minor)
-            VERSION_BUMP="minor"
-            shift
-            ;;
-        --version=major)
-            VERSION_BUMP="major"
             shift
             ;;
     esac
@@ -81,57 +63,12 @@ export PATH=$GOBIN:$PATH
 cd ./desktop
 
 if [ "$BUILD_MODE" = "store" ]; then
-    if [ -n "$NO_BUMP" ]; then
-        # Reuse the current release tag without bumping, committing, or pushing
-        GIT_TAG=$(git tag --list '[0-9]*' --sort=-v:refname | head -1)
-        echo "Reusing current version: ${GIT_TAG:-none} (no bump)"
-    else
-        # Bump the version, update wails.json, and create a git tag
-        if [ -z "$VERSION_BUMP" ]; then
-            VERSION_BUMP="minor"
-        fi
-
-        # Get the latest version tag (format: major.minor.patch)
-        LATEST_TAG=$(git tag --list '[0-9]*' --sort=-v:refname | head -1)
-        if [ -n "$LATEST_TAG" ]; then
-            CURRENT_MAJOR="${LATEST_TAG%%.*}"
-            REMAINDER="${LATEST_TAG#*.}"
-            CURRENT_MINOR="${REMAINDER%%.*}"
-            CURRENT_PATCH="${REMAINDER#*.}"
-            CURRENT_PATCH="${CURRENT_PATCH%%.*}"
-        else
-            CURRENT_MAJOR=0
-            CURRENT_MINOR=0
-            CURRENT_PATCH=0
-        fi
-
-        if [ "$VERSION_BUMP" = "major" ]; then
-            NEW_MAJOR=$((CURRENT_MAJOR + 1))
-            NEW_MINOR=0
-            NEW_PATCH=0
-        elif [ "$VERSION_BUMP" = "minor" ]; then
-            NEW_MAJOR=$CURRENT_MAJOR
-            NEW_MINOR=$((CURRENT_MINOR + 1))
-            NEW_PATCH=0
-        else
-            NEW_MAJOR=$CURRENT_MAJOR
-            NEW_MINOR=$CURRENT_MINOR
-            NEW_PATCH=$((CURRENT_PATCH + 1))
-        fi
-
-        GIT_TAG="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
-        echo "Bumping version: ${LATEST_TAG:-none} -> $GIT_TAG"
-
-        # Update productVersion in wails.json
-        jq --arg version "$GIT_TAG" '.info.productVersion = $version' wails.json > wails.json.tmp && mv wails.json.tmp wails.json
-        echo "Set productVersion to $GIT_TAG"
-
-        # Commit version update, create tag, and push
-        git add wails.json
-        git diff --cached --quiet || git commit -m "Updated productVersion to $GIT_TAG"
-        git tag -f "$GIT_TAG"
-        git push origin HEAD "$GIT_TAG" --force
-    fi
+    # Releases are cut from CI — see scripts/release and .github/workflows/release.yml.
+    # This local store build is for debugging the signed .pkg only: it never bumps
+    # the version, tags, commits, or pushes. It builds whatever version is currently
+    # in wails.json.
+    GIT_TAG=$(jq -r '.info.productVersion' wails.json)
+    echo "Building store package for version $GIT_TAG (local debug; no version bump)"
 
     echo "Building desktop app (store)..."
     export MACOSX_DEPLOYMENT_TARGET=12.0

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Manage Kaja release versions entirely from CI — no local run required.
+# Driven by .github/workflows/release.yml (manual "Run workflow" button).
+#
+# Lifecycle of a version:
+#   1. open  — bump productVersion, commit, tag, draft a GitHub Release. The
+#              commit lands on main, which triggers the testflight workflow, so a
+#              build carrying the new version shows up in TestFlight automatically.
+#   2. ...    — keep merging to main; each push yields a new TestFlight build of
+#              this version (build number = workflow run number).
+#   3. ship  — when you promote that TestFlight build to the App Store, publish
+#              the draft Release so the GitHub Releases page mirrors what is live.
+#
+# Usage:
+#   scripts/release open <patch|minor|major>
+#   scripts/release ship
+#
+# Requires the GitHub CLI (gh) with GH_TOKEN set (both provided on CI runners).
+# The version source of truth is desktop/wails.json's info.productVersion.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WAILS_JSON="$REPO_ROOT/desktop/wails.json"
+
+current_version() {
+    jq -r '.info.productVersion' "$WAILS_JSON"
+}
+
+next_version() {
+    local bump="$1"
+    local current major minor patch rest
+    current="$(current_version)"
+    major="${current%%.*}"
+    rest="${current#*.}"
+    minor="${rest%%.*}"
+    patch="${rest#*.}"
+    patch="${patch%%.*}"
+
+    case "$bump" in
+        major) major=$((major + 1)); minor=0; patch=0 ;;
+        minor) minor=$((minor + 1)); patch=0 ;;
+        patch) patch=$((patch + 1)) ;;
+        *) echo "error: unknown bump '$bump' (want patch|minor|major)" >&2; exit 1 ;;
+    esac
+    echo "${major}.${minor}.${patch}"
+}
+
+cmd_open() {
+    local bump="${1:-minor}"
+    local version
+    version="$(next_version "$bump")"
+    echo "Opening version $version (bump: $bump, from $(current_version))"
+
+    jq --arg v "$version" '.info.productVersion = $v' "$WAILS_JSON" > "$WAILS_JSON.tmp"
+    mv "$WAILS_JSON.tmp" "$WAILS_JSON"
+
+    git add "$WAILS_JSON"
+    git commit -m "Opened version $version"
+    git tag -f "$version"
+    git push origin HEAD
+    git push origin "$version" --force
+
+    gh release create "$version" \
+        --draft \
+        --title "$version" \
+        --generate-notes
+
+    echo "Drafted GitHub Release $version."
+    echo "New pushes to main now produce TestFlight builds of $version."
+}
+
+cmd_ship() {
+    local version
+    version="$(current_version)"
+    echo "Shipping version $version"
+    gh release edit "$version" --draft=false --latest
+    echo "Published GitHub Release $version."
+}
+
+case "${1:-}" in
+    open) shift; cmd_open "$@" ;;
+    ship) shift; cmd_ship "$@" ;;
+    *)
+        echo "usage: scripts/release <open <patch|minor|major>|ship>" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Cut releases from GitHub (manual "Run workflow" button) instead of a local store build: `open` bumps the version, tags, and drafts a Release; `ship` publishes the draft when you promote the TestFlight build to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017QBTn16CXvS2UXLPC7XgPR)_


<details>
<summary>🎬 Demo</summary>

### Video
![Demo](https://github.com/wham/kaja/releases/download/demo-assets/pr-316-demo.gif)

### Home
![Home](https://github.com/wham/kaja/releases/download/demo-assets/pr-316-home.png)

### Call
![Call](https://github.com/wham/kaja/releases/download/demo-assets/pr-316-call.png)

### Compiler
![Compiler](https://github.com/wham/kaja/releases/download/demo-assets/pr-316-compiler.png)

### New Project
![New Project](https://github.com/wham/kaja/releases/download/demo-assets/pr-316-newproject.png)

</details>
