### PR TITLE
Loaded kaja.json with best effort instead of dropping all apps on parse errors

### DIFF
--- a/server/pkg/api/configuration.go
+++ b/server/pkg/api/configuration.go
@@ -59,7 +59,54 @@ func loadConfigurationFile(configurationPath string, logger *Logger) *Configurat
 	fileContent = migrateConfiguration(fileContent, logger)
 
 	if err := protojson.Unmarshal(fileContent, configuration); err != nil {
-		logger.error(fmt.Sprintf("Failed to unmarshal configuration file %s", configurationPath), err)
+		logger.warn(fmt.Sprintf("Configuration file %s did not parse cleanly (%s). Loading it with best effort.", configurationPath, err))
+		return salvageConfiguration(fileContent, logger)
+	}
+
+	return configuration
+}
+
+// salvageConfiguration loads as much of a configuration as possible when the
+// strict parse fails: unknown fields (e.g. a kaja.json written by a newer Kaja)
+// are ignored, and an app that still fails to decode is skipped with an error,
+// so one bad entry can't silently hide every other app.
+func salvageConfiguration(content []byte, logger *Logger) *Configuration {
+	configuration := &Configuration{
+		Apps: []*ConfigurationApp{},
+	}
+	lenient := protojson.UnmarshalOptions{DiscardUnknown: true}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(content, &raw); err != nil {
+		logger.error("Failed to parse configuration file as JSON", err)
+		return configuration
+	}
+
+	appsRaw, hasApps := raw["apps"]
+	delete(raw, "apps")
+	if rest, err := json.Marshal(raw); err == nil {
+		if err := lenient.Unmarshal(rest, configuration); err != nil {
+			logger.error("Failed to read configuration settings", err)
+		}
+	}
+	configuration.Apps = []*ConfigurationApp{}
+
+	if !hasApps {
+		return configuration
+	}
+
+	var appList []json.RawMessage
+	if err := json.Unmarshal(appsRaw, &appList); err != nil {
+		logger.error("Failed to read apps list", err)
+		return configuration
+	}
+	for i, appRaw := range appList {
+		app := &ConfigurationApp{}
+		if err := lenient.Unmarshal(appRaw, app); err != nil {
+			logger.error(fmt.Sprintf("Skipping app #%d that could not be read", i+1), err)
+			continue
+		}
+		configuration.Apps = append(configuration.Apps, app)
 	}
 
 	return configuration

--- a/server/pkg/api/configuration.go
+++ b/server/pkg/api/configuration.go
@@ -112,27 +112,18 @@ func salvageConfiguration(content []byte, logger *Logger) *Configuration {
 	return configuration
 }
 
-// migrateConfiguration upgrades the pre-unification config shape - a top-level
-// "projects" list of gRPC/Twirp services - into the typed "apps" model in place, so
-// existing files keep working. Each project becomes an app whose set field is its
-// type, e.g. { "name", "grpc": { "url", ... } }; protojson would otherwise reject
-// the removed "projects" field. (The earlier "apps" form never shipped, so only
-// "projects" needs migrating.)
+// migrateConfiguration upgrades the pre-unification config shapes into the typed
+// "apps" model in place, so existing files keep working:
+//   - a top-level "projects" list of gRPC/Twirp services; each project becomes an
+//     app whose set field is its type, e.g. { "name", "grpc": { "url", ... } }
+//   - built-in apps in the generic { "name", "type", "parameters" } form; the type
+//     becomes the set field, e.g. { "name", "markdown": { "folder": ... } }
+//
+// protojson would otherwise reject the removed "projects" and "type" fields.
 func migrateConfiguration(content []byte, logger *Logger) []byte {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(content, &raw); err != nil {
 		// Leave it to protojson to report the parse error.
-		return content
-	}
-
-	projectsRaw, ok := raw["projects"]
-	if !ok {
-		return content
-	}
-
-	var projects []map[string]any
-	if err := json.Unmarshal(projectsRaw, &projects); err != nil {
-		logger.error("Failed to read legacy projects list", err)
 		return content
 	}
 
@@ -144,11 +135,34 @@ func migrateConfiguration(content []byte, logger *Logger) []byte {
 		}
 	}
 
-	for _, project := range projects {
-		apps = append(apps, legacyProjectToApp(project))
+	legacyApps := 0
+	for i, app := range apps {
+		if _, ok := app["type"].(string); ok {
+			apps[i] = legacyGenericAppToApp(app)
+			legacyApps++
+		}
 	}
-	if len(projects) > 0 {
-		logger.info(fmt.Sprintf("Migrated %d legacy project(s) to apps", len(projects)))
+	if legacyApps > 0 {
+		logger.info(fmt.Sprintf("Migrated %d legacy app(s) to the typed format", legacyApps))
+	}
+
+	projectsRaw, hasProjects := raw["projects"]
+	if hasProjects {
+		var projects []map[string]any
+		if err := json.Unmarshal(projectsRaw, &projects); err != nil {
+			logger.error("Failed to read legacy projects list", err)
+			return content
+		}
+		for _, project := range projects {
+			apps = append(apps, legacyProjectToApp(project))
+		}
+		if len(projects) > 0 {
+			logger.info(fmt.Sprintf("Migrated %d legacy project(s) to apps", len(projects)))
+		}
+	}
+
+	if legacyApps == 0 && !hasProjects {
+		return content
 	}
 
 	delete(raw, "projects")
@@ -165,6 +179,27 @@ func migrateConfiguration(content []byte, logger *Logger) []byte {
 		return content
 	}
 	return migrated
+}
+
+// legacyGenericAppToApp converts a pre-unification built-in app - { name, type,
+// parameters, headers } - into the typed shape { name, <type>: { <parameters>,
+// headers } }. Parameter keys already match the typed block's proto field names
+// (e.g. "spec_url", "folder").
+func legacyGenericAppToApp(app map[string]any) map[string]any {
+	appType, _ := app["type"].(string)
+
+	variant := map[string]any{}
+	if parameters, ok := app["parameters"].(map[string]any); ok {
+		for key, value := range parameters {
+			variant[key] = value
+		}
+	}
+	// The local Markdown app is the only type without a headers field.
+	if headers, ok := app["headers"]; ok && appType != "markdown" {
+		variant["headers"] = headers
+	}
+
+	return map[string]any{"name": app["name"], appType: variant}
 }
 
 // legacyProjectToApp converts a pre-unification gRPC/Twirp project into the typed

--- a/server/pkg/api/configuration_test.go
+++ b/server/pkg/api/configuration_test.go
@@ -156,6 +156,67 @@ func TestLoadGetConfigurationResponse_MigratesLegacyProjects(t *testing.T) {
 	}
 }
 
+// Built-in apps used to be configured in a generic { name, type, parameters }
+// shape before the typed oneof model. Files from that era must be migrated
+// transparently on load.
+func TestLoadGetConfigurationResponse_MigratesLegacyTypedApps(t *testing.T) {
+	configContent := `{
+		"system": {
+			"canUpdateConfiguration": true
+		},
+		"apps": [
+			{
+				"name": "work-os",
+				"type": "markdown",
+				"parameters": {
+					"folder": "/Users/tomas.vesely/My Drive/work-os"
+				}
+			},
+			{
+				"name": "benchling",
+				"type": "openapi",
+				"parameters": {
+					"spec_url": "https://benchling.com/api/v2/openapi.yaml"
+				},
+				"headers": {"X-Api-Key": "secret"}
+			}
+		]
+	}`
+
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	configuration := LoadGetConfigurationResponse(tmpfile.Name(), false).Configuration
+	if len(configuration.Apps) != 2 {
+		t.Fatalf("expected 2 migrated apps, got %d", len(configuration.Apps))
+	}
+
+	markdownType, markdownParams := flattenApp(configuration.Apps[0])
+	if configuration.Apps[0].Name != "work-os" || markdownType != "markdown" {
+		t.Errorf("expected markdown app 'work-os', got %q/%q", configuration.Apps[0].Name, markdownType)
+	}
+	if markdownParams["folder"] != "/Users/tomas.vesely/My Drive/work-os" {
+		t.Errorf("unexpected markdown parameters: %v", markdownParams)
+	}
+
+	openapiType, openapiParams := flattenApp(configuration.Apps[1])
+	if configuration.Apps[1].Name != "benchling" || openapiType != "openapi" {
+		t.Errorf("expected openapi app 'benchling', got %q/%q", configuration.Apps[1].Name, openapiType)
+	}
+	if openapiParams["spec_url"] != "https://benchling.com/api/v2/openapi.yaml" {
+		t.Errorf("unexpected openapi parameters: %v", openapiParams)
+	}
+	if configuration.Apps[1].GetOpenapi().GetHeaders()["X-Api-Key"] != "secret" {
+		t.Errorf("expected migrated headers, got %v", configuration.Apps[1].GetOpenapi().GetHeaders())
+	}
+}
+
 // A kaja.json written by a newer Kaja can contain fields this build doesn't know
 // about. They must be ignored instead of silently dropping the configuration.
 func TestLoadGetConfigurationResponse_IgnoresUnknownFields(t *testing.T) {

--- a/server/pkg/api/configuration_test.go
+++ b/server/pkg/api/configuration_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -152,6 +153,109 @@ func TestLoadGetConfigurationResponse_MigratesLegacyProjects(t *testing.T) {
 	teamsType, teamsParams := flattenApp(configuration.Apps[2])
 	if teamsType != "grpc" || teamsParams["reflection"] != "true" {
 		t.Errorf("expected reflection grpc app, got %q %v", teamsType, teamsParams)
+	}
+}
+
+// A kaja.json written by a newer Kaja can contain fields this build doesn't know
+// about. They must be ignored instead of silently dropping the configuration.
+func TestLoadGetConfigurationResponse_IgnoresUnknownFields(t *testing.T) {
+	configContent := `{
+		"some_future_setting": true,
+		"system": {"canUpdateConfiguration": true},
+		"apps": [
+			{
+				"name": "openmeter",
+				"openapi": {
+					"spec_url": "https://openmeter.io/api/openapi.json",
+					"some_future_field": "x"
+				}
+			},
+			{
+				"name": "grpc-quirks",
+				"grpc": {"url": "dns:kaja.tools:443", "proto_dir": "quirks/proto"}
+			}
+		]
+	}`
+
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	response := LoadGetConfigurationResponse(tmpfile.Name(), false)
+	configuration := response.Configuration
+
+	if len(configuration.Apps) != 2 {
+		t.Fatalf("expected 2 apps, got %d", len(configuration.Apps))
+	}
+	openmeterType, openmeterParams := flattenApp(configuration.Apps[0])
+	if configuration.Apps[0].Name != "openmeter" || openmeterType != "openapi" {
+		t.Errorf("expected openapi app 'openmeter', got %q/%q", configuration.Apps[0].Name, openmeterType)
+	}
+	if openmeterParams["spec_url"] != "https://openmeter.io/api/openapi.json" {
+		t.Errorf("unexpected openapi parameters: %v", openmeterParams)
+	}
+	if grpcType, _ := flattenApp(configuration.Apps[1]); grpcType != "grpc" {
+		t.Errorf("expected grpc app, got %q", grpcType)
+	}
+	if !configuration.System.CanUpdateConfiguration {
+		t.Error("expected system settings to survive the best-effort load")
+	}
+
+	foundWarn := false
+	for _, log := range response.Logs {
+		if log.Level == LogLevel_LEVEL_WARN && strings.Contains(log.Message, "best effort") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Error("expected a warning about the best-effort load")
+	}
+}
+
+// One app that can't be decoded (here: a wrong value type) must not hide the
+// other apps.
+func TestLoadGetConfigurationResponse_SkipsUnreadableApp(t *testing.T) {
+	configContent := `{
+		"apps": [
+			{"name": "broken", "grpc": {"url": "dns:kaja.tools:443", "reflection": "yes"}},
+			{"name": "grpc-quirks", "grpc": {"url": "dns:kaja.tools:443", "proto_dir": "quirks/proto"}}
+		]
+	}`
+
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	response := LoadGetConfigurationResponse(tmpfile.Name(), false)
+	configuration := response.Configuration
+
+	if len(configuration.Apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(configuration.Apps))
+	}
+	if configuration.Apps[0].Name != "grpc-quirks" {
+		t.Errorf("expected the readable app to survive, got %q", configuration.Apps[0].Name)
+	}
+
+	foundError := false
+	for _, log := range response.Logs {
+		if log.Level == LogLevel_LEVEL_ERROR && strings.Contains(log.Message, "Skipping app #1") {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Error("expected an error log about the skipped app")
 	}
 }
 

--- a/server/pkg/api/logger.go
+++ b/server/pkg/api/logger.go
@@ -24,6 +24,11 @@ func (l *Logger) info(message string) {
 	l.log(LogLevel_LEVEL_INFO, message)
 }
 
+func (l *Logger) warn(message string) {
+	slog.Warn(message)
+	l.log(LogLevel_LEVEL_WARN, message)
+}
+
 func (l *Logger) error(message string, err error) {
 	slog.Error(message, "error", err)
 	// Include the error details in the UI message

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -617,7 +617,7 @@ export function App() {
     }
   };
 
-  const { configurationLoaded } = useCompilation(apps, onCompilationUpdate, setConfiguration);
+  const { configurationLoaded, configurationLogs } = useCompilation(apps, onCompilationUpdate, setConfiguration);
 
   const onMethodSelect = (method: Method, service: Service, app: AppModel) => {
     captureActiveViewState();
@@ -1330,7 +1330,12 @@ export function App() {
                         if (tab.type === "compiler") {
                           return (
                             <Tab tabId="compiler" tabLabel="Compiler" key="compiler">
-                              <Compiler apps={apps} configurationLoaded={configurationLoaded} onNewAppClick={onNewAppClick} />
+                              <Compiler
+                                apps={apps}
+                                configurationLoaded={configurationLoaded}
+                                configurationLogs={configurationLogs}
+                                onNewAppClick={onNewAppClick}
+                              />
                             </Tab>
                           );
                         }

--- a/ui/src/Compiler.tsx
+++ b/ui/src/Compiler.tsx
@@ -1,13 +1,17 @@
 import { CheckIcon, ChevronRightIcon, XIcon } from "@primer/octicons-react";
-import { ActionList, Spinner } from "@primer/react";
+import { ActionList, Flash, Spinner } from "@primer/react";
 import { FirstAppBlankslate } from "./FirstAppBlankslate";
 import { useState } from "react";
 import { CompilationStatus, App } from "./apps";
 import { appType, appTypeLabel } from "./appTypes";
+import { Log, LogLevel } from "./server/api";
 
 interface CompilerProps {
   apps: App[];
   configurationLoaded: boolean;
+  // Logs from loading the configuration file, shown when they contain problems
+  // and no apps loaded - otherwise a broken kaja.json would fail invisibly.
+  configurationLogs?: Log[];
   onNewAppClick?: () => void;
 }
 
@@ -20,7 +24,7 @@ const LOG_PADDING = "12px 16px";
 const LINE_NUMBER_WIDTH = "40px";
 const LINE_NUMBER_MARGIN = 16;
 
-export function Compiler({ apps, configurationLoaded, onNewAppClick }: CompilerProps) {
+export function Compiler({ apps, configurationLoaded, configurationLogs, onNewAppClick }: CompilerProps) {
   const [expandedApps, setExpandedApps] = useState<Set<string>>(new Set());
 
   const toggleExpand = (appName: string) => {
@@ -98,6 +102,24 @@ export function Compiler({ apps, configurationLoaded, onNewAppClick }: CompilerP
           <div>
             <Spinner size="medium" />
             <div style={{ marginTop: 12 }}>Loading configuration...</div>
+          </div>
+        </div>
+      );
+    }
+
+    const problems = (configurationLogs || []).filter((log) => log.level === LogLevel.LEVEL_WARN || log.level === LogLevel.LEVEL_ERROR);
+    if (problems.length > 0) {
+      return (
+        <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, backgroundColor: "var(--bgColor-muted)" }}>
+          <div style={{ padding: 16 }}>
+            <Flash variant="danger">Failed to load the configuration.</Flash>
+          </div>
+          <div style={{ flex: 1, overflowY: "auto", minHeight: 0, fontFamily: "monospace", fontSize: LOG_FONT_SIZE, padding: LOG_PADDING }}>
+            {problems.map((log, index) => (
+              <div key={index} style={{ marginBottom: 1, lineHeight: `${LOG_LINE_HEIGHT}px` }}>
+                <span style={{ color: getLogColor(log.level), whiteSpace: "pre-wrap" }}>{log.message}</span>
+              </div>
+            ))}
           </div>
         </div>
       );

--- a/ui/src/useCompilation.ts
+++ b/ui/src/useCompilation.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createAppRef, App, Transport, transportFromProtocol, updateAppRef } from "./apps";
 import { loadApp } from "./appLoader";
-import { CompileStatus as ApiCompileStatus, Configuration, OpenStatus } from "./server/api";
+import { CompileStatus as ApiCompileStatus, Configuration, Log, OpenStatus } from "./server/api";
 import { getApiClient } from "./server/connection";
 
 const POLL_INTERVAL_MS = 1000;
@@ -15,8 +15,9 @@ export function useCompilation(
   apps: App[],
   onUpdate: (apps: App[] | ((prev: App[]) => App[])) => void,
   onConfigurationLoaded: (configuration: Configuration) => void,
-): { configurationLoaded: boolean } {
+): { configurationLoaded: boolean; configurationLogs: Log[] } {
   const [configurationLoaded, setConfigurationLoaded] = useState(false);
+  const [configurationLogs, setConfigurationLogs] = useState<Log[]>([]);
   const client = getApiClient();
   const abortControllers = useRef<{ [key: string]: AbortController }>({});
   const appsRef = useRef(apps);
@@ -223,6 +224,7 @@ export function useCompilation(
           onConfigurationLoaded(response.configuration);
         }
 
+        setConfigurationLogs(response.logs || []);
         setConfigurationLoaded(true);
 
         if (configApps.length === 0) return;
@@ -267,5 +269,5 @@ export function useCompilation(
     };
   }, []);
 
-  return { configurationLoaded };
+  return { configurationLoaded, configurationLogs };
 }


### PR DESCRIPTION
A `kaja.json` containing anything the running build's strict protojson parse rejects — e.g. a field written by a newer Kaja, or one malformed app — silently dropped every app, so after a restart the sidebar came up empty even though the file looked correct. Loading now ignores unknown fields, skips only the unreadable app, and surfaces configuration load problems in the Compiler tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiPQQJaJdHe17tCKuDdnCt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiPQQJaJdHe17tCKuDdnCt)_