### PR TITLE
Fixed Go to Definition landing on the wrong line

### DIFF
--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor";
 import { useEffect, useRef } from "react";
-import { formatTypeScript } from "./formatter";
+import { formatTypeScript, formatTypeScriptWithCursor } from "./formatter";
 import { findTimestamps, timestampToDate, formatDateForDisplay } from "./timestampPicker";
 import { TimestampPickerContentWidget } from "./TimestampPickerWidget";
 
@@ -266,17 +266,28 @@ export function Editor({ model, onMount, onGoToDefinition, readOnly = false, sta
       onMount?.(editorRef.current);
     }
 
-    formatTypeScript(model.getValue()).then((formattedCode) => {
-      if (!isDisposing && editorRef.current) {
-        editorRef.current.setValue(formattedCode);
-        if (viewState) {
-          editorRef.current.restoreViewState(viewState);
-        } else if (startLineNumber > 0) {
-          editorRef.current.revealLineInCenter(startLineNumber);
-          editorRef.current.setPosition({ lineNumber: startLineNumber, column: startColumn });
+    if (!viewState && startLineNumber > 0) {
+      // startLineNumber/startColumn were resolved against the unformatted model
+      // text; formatting reflows lines, so remap the position through prettier.
+      const cursorOffset = model.getOffsetAt({ lineNumber: startLineNumber, column: Math.max(startColumn, 1) });
+      formatTypeScriptWithCursor(model.getValue(), cursorOffset).then((result) => {
+        if (!isDisposing && editorRef.current) {
+          editorRef.current.setValue(result.code);
+          const position = model.getPositionAt(result.cursorOffset);
+          editorRef.current.revealLineInCenter(position.lineNumber);
+          editorRef.current.setPosition(position);
         }
-      }
-    });
+      });
+    } else {
+      formatTypeScript(model.getValue()).then((formattedCode) => {
+        if (!isDisposing && editorRef.current) {
+          editorRef.current.setValue(formattedCode);
+          if (viewState) {
+            editorRef.current.restoreViewState(viewState);
+          }
+        }
+      });
+    }
 
     editorRef.current?.setModel(model);
 

--- a/ui/src/formatter.test.ts
+++ b/ui/src/formatter.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { formatJson, formatTypeScript } from "./formatter";
+import { formatJson, formatTypeScript, formatTypeScriptWithCursor } from "./formatter";
 
 test("formatJson", async () => {
   expect(await formatJson(`{hello: "json"}`)).toEqual(`{ "hello": "json" }\n`);
@@ -9,4 +9,13 @@ test("formatJson", async () => {
 test("formatTypeScript", async () => {
   expect(await formatTypeScript(`let i=1;++i`)).toEqual(`let i = 1;\n++i;\n`);
   expect(await formatTypeScript("} invalid_typescript")).toEqual("} invalid_typescript");
+});
+
+test("formatTypeScriptWithCursor", async () => {
+  const code = `export const Meters = { ListMeters: async (input: { name: string; page: number; filter: string[] }): Promise<void> => {}, GetMeter: async (input: { id: string }): Promise<void> => {} };`;
+  const result = await formatTypeScriptWithCursor(code, code.indexOf("GetMeter"));
+  expect(result.code.slice(result.cursorOffset, result.cursorOffset + "GetMeter".length)).toEqual("GetMeter");
+
+  const invalid = "} invalid_typescript";
+  expect(await formatTypeScriptWithCursor(invalid, 5)).toEqual({ code: invalid, cursorOffset: 5 });
 });

--- a/ui/src/formatter.ts
+++ b/ui/src/formatter.ts
@@ -11,6 +11,22 @@ export async function formatTypeScript(code: string): Promise<string> {
   return format(code, "typescript", [prettierPluginTypescript, prettierPluginEsTree]);
 }
 
+// Formats and remaps an offset in the original code to the corresponding offset
+// in the formatted code, so positions survive the reformatting.
+export async function formatTypeScriptWithCursor(code: string, cursorOffset: number): Promise<{ code: string; cursorOffset: number }> {
+  try {
+    const result = await prettier.formatWithCursor(code, {
+      parser: "typescript",
+      plugins: [prettierPluginTypescript, prettierPluginEsTree],
+      cursorOffset,
+    });
+    return { code: result.formatted, cursorOffset: result.cursorOffset };
+  } catch {
+    console.warn("Failed to format typescript", code);
+    return { code, cursorOffset };
+  }
+}
+
 function format(code: string, parser: string, plugins: prettier.Plugin[]): Promise<string> {
   return prettier
     .format(code, { parser, plugins })


### PR DESCRIPTION
Go to Definition resolved positions against the unformatted model text, but the definition editor reformats the content with prettier before revealing it, shifting line numbers in long files. The position is now remapped through formatting with prettier's `formatWithCursor` so the reveal lands on the symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQr25MtmFeKZPexVPcz8Tv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQr25MtmFeKZPexVPcz8Tv)_