### PR TITLE
Resolved OpenAPI parameter refs and mapped additionalProperties to proto maps

### DIFF
--- a/server/pkg/apps/openapi/openapi_test.go
+++ b/server/pkg/apps/openapi/openapi_test.go
@@ -273,6 +273,147 @@ paths:
 	}
 }
 
+// meteringSpec mirrors the OpenMeter API shapes: parameters declared as
+// "#/components/parameters" references, map-typed properties
+// (additionalProperties), and "allOf: [$ref]" wrappers around enums and maps.
+const meteringSpec = `
+openapi: 3.0.0
+info:
+  title: Metering
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /meters:
+    get:
+      operationId: listMeters
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/order"
+        - $ref: "#/components/parameters/missing"
+        - name: includeDeleted
+          in: query
+          schema: { type: boolean }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Meter"
+components:
+  parameters:
+    page:
+      name: page
+      in: query
+      schema: { type: integer }
+    order:
+      name: order
+      in: query
+      schema:
+        allOf:
+          - $ref: "#/components/schemas/SortOrder"
+        default: ASC
+  schemas:
+    SortOrder:
+      type: string
+      enum: [ASC, DESC]
+    Metadata:
+      type: object
+      additionalProperties: { type: string }
+    Meter:
+      type: object
+      properties:
+        slug: { type: string }
+        groupBy:
+          type: object
+          additionalProperties: { type: string }
+        metadata:
+          type: object
+          allOf:
+            - $ref: "#/components/schemas/Metadata"
+          nullable: true
+        aggregation:
+          allOf:
+            - $ref: "#/components/schemas/SortOrder"
+`
+
+// TestParameterRefsAndMaps locks in that referenced parameters land in the
+// request message (an unresolvable reference is dropped), additionalProperties
+// objects become proto maps, and references to enum/map schemas are expanded in
+// place instead of producing empty messages.
+func TestParameterRefsAndMaps(t *testing.T) {
+	s, err := parseSpec([]byte(meteringSpec))
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	gen, err := generateProto(s)
+	if err != nil {
+		t.Fatalf("generateProto: %v", err)
+	}
+
+	for _, frag := range []string{
+		`int32 page = 1 [json_name = "page"];`,
+		`string order = 2 [json_name = "order"];`,
+		`bool include_deleted = 3 [json_name = "includeDeleted"];`,
+		`string aggregation = 1 [json_name = "aggregation"];`,
+		`map<string, string> group_by = 2 [json_name = "groupBy"];`,
+		`map<string, string> metadata = 3 [json_name = "metadata"];`,
+	} {
+		if !strings.Contains(gen.proto, frag) {
+			t.Errorf("generated proto missing %q\n---\n%s", frag, gen.proto)
+		}
+	}
+	for _, frag := range []string{"message SortOrder", "message Metadata"} {
+		if strings.Contains(gen.proto, frag) {
+			t.Errorf("generated proto should not contain %q\n---\n%s", frag, gen.proto)
+		}
+	}
+
+	b := gen.bindings["openapi.metering.Metering/ListMeters"]
+	if b == nil {
+		t.Fatal("missing ListMeters binding")
+	}
+	if want := []string{"page", "order", "includeDeleted"}; strings.Join(b.queryParams, ",") != strings.Join(want, ",") {
+		t.Errorf("queryParams = %q, want %q", b.queryParams, want)
+	}
+}
+
+// TestInvokeMapField reproduces calling List Meters with empty parameters: the
+// upstream response carries map-valued and null map fields, which must decode
+// into the generated map<string, string> fields.
+func TestInvokeMapField(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openapi.yaml", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, meteringSpec)
+	})
+	mux.HandleFunc("/meters", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("unexpected query %q for empty request", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[{"slug":"tokens","groupBy":{"model":"$.model"},"metadata":null,"aggregation":"SUM"}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	opened, err := New().Open(map[string]string{"spec_url": srv.URL + "/openapi.yaml"}, t.TempDir(), func(string) {})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	inst := opened.Instance.(*instance)
+
+	const method = "openapi.metering.Metering/ListMeters"
+	out, err := inst.Invoke(method, encodeRequest(t, inst, method, `{}`), nil)
+	if err != nil {
+		t.Fatalf("ListMeters: %v", err)
+	}
+	assertJSONEq(t, decodeResponse(t, inst, method, out),
+		`{"items":[{"slug":"tokens","groupBy":{"model":"$.model"},"aggregation":"SUM"}]}`)
+}
+
 // TestOpenAndInvoke exercises the full path: a fake upstream serves both the spec
 // and the REST API; we open the app and invoke each generated method.
 func TestOpenAndInvoke(t *testing.T) {

--- a/server/pkg/apps/openapi/protogen.go
+++ b/server/pkg/apps/openapi/protogen.go
@@ -61,8 +61,9 @@ type generator struct {
 	pkg                string
 	defaultServiceName string
 
-	messages []*messageDef
-	seenMsg  map[string]bool
+	messages     []*messageDef
+	seenMsg      map[string]bool
+	resolvingRef map[string]bool
 
 	services     []*serviceDef
 	serviceIndex map[string]*serviceDef
@@ -82,6 +83,7 @@ func generateProto(s *spec) (*generated, error) {
 		pkg:                "openapi." + lowerSnake(title),
 		defaultServiceName: ensureName(pascal(title), "Api"),
 		seenMsg:            map[string]bool{},
+		resolvingRef:       map[string]bool{},
 		seenRPC:            map[string]bool{},
 		serviceIndex:       map[string]*serviceDef{},
 		bindingByMethod:    map[string]*methodBinding{},
@@ -172,7 +174,7 @@ func (g *generator) addOperation(path string, item *pathItem, vo verbOp) {
 	// Request message: path + query params, then an optional body field.
 	req := &messageDef{name: reqName}
 	num := 1
-	for _, param := range mergedParameters(item, op) {
+	for _, param := range g.mergedParameters(item, op) {
 		switch param.In {
 		case "path":
 			req.fields = append(req.fields, g.paramField(param, num))
@@ -295,20 +297,41 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 		return "string", false
 	}
 	if s.Ref != "" {
-		return g.refMessage(s.Ref), false
+		return g.refType(parent, hint, s.Ref)
+	}
+	// "allOf: [$ref]" plus sibling annotations is a common way to reference a
+	// schema; delegate when the schema declares nothing structural itself.
+	if len(s.Properties) == 0 && s.AdditionalProperties == nil && len(s.AllOf) > 0 {
+		return g.protoType(parent, hint, s.AllOf[0])
 	}
 	switch s.Type {
 	case "array":
 		elem, _ := g.protoType(parent, hint+"Item", s.Items)
-		return elem, true
-	case "object":
-		if len(s.Properties) == 0 {
-			// Free-form object: fall back to string for the minimal happy path.
-			return "string", false
+		if strings.HasPrefix(elem, "map<") {
+			// proto has no repeated maps; fall back to string elements.
+			return "string", true
 		}
-		name := g.uniqueMessageName(parent + hint)
-		g.addMessage(&messageDef{name: name, fields: g.fieldsFromProperties(name, s)})
-		return name, false
+		return elem, true
+	case "object", "":
+		if len(s.Properties) > 0 {
+			name := g.uniqueMessageName(parent + hint)
+			g.addMessage(&messageDef{name: name, fields: g.fieldsFromProperties(name, s)})
+			return name, false
+		}
+		if ap := s.AdditionalProperties; ap != nil && ap.Allowed {
+			value := "string"
+			if ap.Schema != nil {
+				value, _ = g.protoType(parent, hint+"Value", ap.Schema)
+				if strings.HasPrefix(value, "map<") {
+					// proto map values cannot be maps themselves.
+					value = "string"
+				}
+			}
+			return "map<string, " + value + ">", false
+		}
+		// Free-form object (or untyped schema): fall back to string for the
+		// minimal happy path.
+		return "string", false
 	case "integer":
 		if s.Format == "int64" {
 			return "int64", false
@@ -321,11 +344,33 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 		return "double", false
 	case "boolean":
 		return "bool", false
-	case "string", "":
+	case "string":
 		return "string", false
 	default:
 		return "string", false
 	}
+}
+
+// refType maps a "#/components/schemas/X" reference to a proto type. Schemas
+// with properties become named messages; string/enum, number, map, array, and
+// allOf targets are expanded in place so their fields keep the scalar or map
+// shape the REST JSON uses (an empty message would reject those values).
+func (g *generator) refType(parent, hint, ref string) (string, bool) {
+	name := refName(ref)
+	var target *schema
+	if g.spec.Components.Schemas != nil {
+		target = g.spec.Components.Schemas[name]
+	}
+	expandable := target != nil && len(target.Properties) == 0 &&
+		(target.Ref != "" || len(target.AllOf) > 0 ||
+			(target.AdditionalProperties != nil && target.AdditionalProperties.Allowed) ||
+			(target.Type != "" && target.Type != "object"))
+	if !expandable || g.resolvingRef[name] {
+		return g.refMessage(ref), false
+	}
+	g.resolvingRef[name] = true
+	defer delete(g.resolvingRef, name)
+	return g.protoType(parent, hint, target)
 }
 
 func (g *generator) addMessage(m *messageDef) {
@@ -389,12 +434,13 @@ func (g *generator) render() string {
 }
 
 // mergedParameters combines path-item-level and operation-level parameters,
-// with operation-level taking precedence on (name, in) collisions.
-func mergedParameters(item *pathItem, op *operation) []*parameter {
+// with operation-level taking precedence on (name, in) collisions. Parameters
+// declared as "#/components/parameters/<name>" references are resolved first.
+func (g *generator) mergedParameters(item *pathItem, op *operation) []*parameter {
 	seen := map[string]bool{}
 	var out []*parameter
 	for _, p := range op.Parameters {
-		if p == nil {
+		if p = g.resolveParameter(p); p == nil {
 			continue
 		}
 		key := p.In + ":" + p.Name
@@ -402,7 +448,7 @@ func mergedParameters(item *pathItem, op *operation) []*parameter {
 		out = append(out, p)
 	}
 	for _, p := range item.Parameters {
-		if p == nil {
+		if p = g.resolveParameter(p); p == nil {
 			continue
 		}
 		key := p.In + ":" + p.Name
@@ -411,6 +457,16 @@ func mergedParameters(item *pathItem, op *operation) []*parameter {
 		}
 	}
 	return out
+}
+
+func (g *generator) resolveParameter(p *parameter) *parameter {
+	if p == nil || p.Ref == "" {
+		return p
+	}
+	if resolved, ok := g.spec.Components.Parameters[refName(p.Ref)]; ok && resolved != nil && resolved.Ref == "" {
+		return resolved
+	}
+	return nil
 }
 
 func successResponse(op *operation) *response {

--- a/server/pkg/apps/openapi/spec.go
+++ b/server/pkg/apps/openapi/spec.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,6 +71,7 @@ type operation struct {
 }
 
 type parameter struct {
+	Ref      string  `json:"$ref"` // reference to #/components/parameters/<name>
 	Name     string  `json:"name"`
 	In       string  `json:"in"` // path | query | header | cookie
 	Required bool    `json:"required"`
@@ -92,6 +94,7 @@ type mediaType struct {
 
 type components struct {
 	Schemas         map[string]*schema         `json:"schemas"`
+	Parameters      map[string]*parameter      `json:"parameters"`
 	SecuritySchemes map[string]*securityScheme `json:"securitySchemes"`
 }
 
@@ -106,13 +109,29 @@ type securityScheme struct {
 }
 
 type schema struct {
-	Ref        string             `json:"$ref"`
-	Type       string             `json:"type"`
-	Format     string             `json:"format"`
-	Items      *schema            `json:"items"`
-	Properties map[string]*schema `json:"properties"`
-	Required   []string           `json:"required"`
-	Enum       []interface{}      `json:"enum"`
+	Ref                  string                `json:"$ref"`
+	Type                 string                `json:"type"`
+	Format               string                `json:"format"`
+	Items                *schema               `json:"items"`
+	Properties           map[string]*schema    `json:"properties"`
+	AdditionalProperties *additionalProperties `json:"additionalProperties"`
+	AllOf                []*schema             `json:"allOf"`
+	Required             []string              `json:"required"`
+	Enum                 []interface{}         `json:"enum"`
+}
+
+// additionalProperties is either a boolean or a schema in OpenAPI documents.
+type additionalProperties struct {
+	Allowed bool
+	Schema  *schema
+}
+
+func (a *additionalProperties) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &a.Allowed); err == nil {
+		return nil
+	}
+	a.Allowed = true
+	return json.Unmarshal(b, &a.Schema)
 }
 
 // jsonContent returns the application/json media type, if present.


### PR DESCRIPTION
Fixed the OpenAPI app dropping parameters declared as `#/components/parameters` references (empty request messages, e.g. OpenMeter's List Meters) and failing to decode map-shaped response fields like `groupBy` by generating `map<string, string>` for `additionalProperties` schemas. Also expanded `allOf: [$ref]` wrappers and enum/scalar refs in place instead of emitting empty messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhxHB5CTpvkycDFXAhdaUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhxHB5CTpvkycDFXAhdaUZ)_