### PR TITLE
Added kaja.uuid.v4() helper

### DIFF
--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -42,6 +42,7 @@ Scripts can import a `kaja` object with `import { kaja } from "kaja";`:
   input in a dialog. Resolves with the entered text; if the user cancels, the
   script quietly stops. Avoid `kaja.ask` in scripts you run via MCP unless the
   user is present, since it blocks on a human.
+- `kaja.uuid.v4(): string` — generate a random version 4 UUID.
 
 ## Working effectively
 

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -70,6 +70,15 @@ export declare const kaja: {
    *   const name = await kaja.ask("What's your name?");
    */
   ask(message: string): Promise<string>;
+  /** UUID helpers. */
+  uuid: {
+    /**
+     * Generate a random version 4 UUID, e.g. "9b2b1a94-3c6e-4f6e-9d2a-0f6b7c8d9e0f".
+     *
+     *   const id = kaja.uuid.v4();
+     */
+    v4(): string;
+  };
 };
 `;
   const uri = monaco.Uri.parse("ts:/kaja.ts");

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -23,6 +23,21 @@ export class Kaja {
   // User-defined variables from the configuration, readable as
   // `kaja.variables.<name>`. Kept in sync with the loaded configuration.
   variables: { [key: string]: string } = {};
+  // UUID helpers for scripts, e.g. `kaja.uuid.v4()`.
+  readonly uuid = {
+    v4(): string {
+      if (typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+      }
+      // crypto.randomUUID is only available in secure contexts; fall back to
+      // building a v4 UUID from random bytes.
+      const bytes = crypto.getRandomValues(new Uint8Array(16));
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    },
+  };
   #onAsk: AskRequest;
 
   constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest) {

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -32,3 +32,19 @@ describe("kaja.variables injection", () => {
     expect(run.result).toBe("new");
   });
 });
+
+describe("kaja.uuid", () => {
+  it("generates a version 4 UUID from scripts", async () => {
+    const kaja = makeKaja();
+
+    const run = await runTaskCaptured(`import { kaja } from "kaja";\nreturn kaja.uuid.v4();`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("generates unique values", () => {
+    const kaja = makeKaja();
+    expect(kaja.uuid.v4()).not.toBe(kaja.uuid.v4());
+  });
+});


### PR DESCRIPTION
Added a `kaja.uuid.v4()` helper that generates a random version 4 UUID in scripts, with editor autocomplete, MCP guide docs, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BebMVHmvAnDMZ6v5wXcToF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BebMVHmvAnDMZ6v5wXcToF)_