### PR TITLE
Transpiled scripts before running and surfaced script errors in the console

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -32,7 +32,7 @@ import { FeaturePreview } from "./FeaturePreviews";
 import { AppForm } from "./AppForm";
 import { registerKajaModule } from "./Editor";
 import { remapEditorCode, remapSourcesToNewName } from "./sources";
-import { Configuration, ConfigurationApp } from "./server/api";
+import { Configuration, ConfigurationApp, LogLevel } from "./server/api";
 import { getApiClient } from "./server/connection";
 import {
   addDefinitionTab,
@@ -204,6 +204,17 @@ export function App() {
       }
       const next = [...consoleItems, { ...methodCall }];
       // Cap history so a long session can't grow the console unbounded.
+      return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
+    });
+  }, []);
+
+  // Show a failed script run in the console; a script that dies silently looks
+  // like it succeeded. Mirrored to console.error so it also lands in kaja.log.
+  const onScriptError = useCallback((error: unknown) => {
+    console.error("Script error:", error);
+    const message = error instanceof Error ? (error.name === "Error" ? error.message : `${error.name}: ${error.message}`) : String(error);
+    setConsoleItems((consoleItems) => {
+      const next: ConsoleItem[] = [...consoleItems, [{ level: LogLevel.LEVEL_ERROR, message }]];
       return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
     });
   }, []);
@@ -714,12 +725,12 @@ export function App() {
         await onScriptSelect({ path: file.path, name: file.name });
         const kaja = kajaRef.current!;
         kaja.input = text;
-        runTask(file.content, kaja, apps);
+        runTask(file.content, kaja, apps, onScriptError);
       } catch (err) {
         showFileError(`Run failed: ${err}`);
       }
     },
-    [pinnedScriptPath, onScriptSelect, apps, showFileError],
+    [pinnedScriptPath, onScriptSelect, apps, showFileError, onScriptError],
   );
 
   const runContextMenuScriptRef = useRef(runContextMenuScript);
@@ -1036,12 +1047,12 @@ export function App() {
     if (!editor) {
       return;
     }
-    runTask(editor.getValue(), kajaRef.current!, apps);
+    runTask(editor.getValue(), kajaRef.current!, apps, onScriptError);
     if (tab.type === "task") {
       setTabs((tabs) => markInteraction(tabs, index));
       persistTabs();
     }
-  }, [apps, persistTabs]);
+  }, [apps, persistTabs, onScriptError]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -257,7 +257,7 @@ Console.LogRow = function ({ logs }: LogRowProps) {
 
   return (
     <div className="console-row" style={{ color, opacity: 0.8 }} title={logs.map((l) => l.message).join("\n")}>
-      <span style={{ marginRight: 8, fontSize: 10 }}>LOG</span>
+      <span style={{ marginRight: 8, fontSize: 10 }}>{labelForLogLevel(highestSeverity)}</span>
       <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
         {logs.length === 1 ? logs[0].message.trim() : `${logs.length} log messages`}
       </span>
@@ -537,6 +537,19 @@ Console.HeadersTable = function ({ headers }: HeadersTableProps) {
     </table>
   );
 };
+
+function labelForLogLevel(level: LogLevel): string {
+  switch (level) {
+    case LogLevel.LEVEL_DEBUG:
+      return "DEBUG";
+    case LogLevel.LEVEL_INFO:
+      return "LOG";
+    case LogLevel.LEVEL_WARN:
+      return "WARN";
+    case LogLevel.LEVEL_ERROR:
+      return "ERROR";
+  }
+}
 
 function colorForLogLevel(level: LogLevel): string {
   switch (level) {

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -33,6 +33,46 @@ describe("kaja.variables injection", () => {
   });
 });
 
+describe("TypeScript execution", () => {
+  it("runs scripts with type annotations and generics", async () => {
+    const kaja = makeKaja();
+
+    const run = await runTaskCaptured(
+      `import { kaja } from "kaja";
+function pick<T>(items: T[]): T {
+  return items[0];
+}
+const base: number = 41;
+return pick<number>([base]) + 1;`,
+      kaja,
+      [],
+    );
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe(42);
+  });
+
+  it("supports top-level await in scripts without imports", async () => {
+    const run = await runTaskCaptured(`const value: string = await Promise.resolve("ok");\nreturn value;`, makeKaja(), []);
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe("ok");
+  });
+
+  it("reports syntax errors with the line in the script", async () => {
+    const run = await runTaskCaptured(`const a = 1;\nconst b = ;`, makeKaja(), []);
+
+    expect(run.result).toBeUndefined();
+    expect(run.error).toContain("Line 2");
+  });
+
+  it("captures runtime errors", async () => {
+    const run = await runTaskCaptured(`const items: string[] = [];\nreturn items[0].length;`, makeKaja(), []);
+
+    expect(run.error).toBeDefined();
+  });
+});
+
 describe("kaja.uuid", () => {
   it("generates a version 4 UUID from scripts", async () => {
     const kaja = makeKaja();

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -3,14 +3,48 @@ import { AskCancelledError, Kaja } from "./kaja";
 import { Client, App, serviceId } from "./apps";
 import { printStatements } from "./appLoader";
 
+// Scripts are TypeScript but new Function only accepts JavaScript, so transpile
+// first. Parse errors are thrown with line numbers pointing into the user's
+// source. moduleDetection: Force keeps top-level await parseable even in a
+// script with no imports.
+function transpile(code: string): string {
+  const output = ts.transpileModule(code, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      moduleDetection: ts.ModuleDetectionKind.Force,
+    },
+    reportDiagnostics: true,
+  });
+  const errors = (output.diagnostics ?? []).filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+  if (errors.length > 0) {
+    throw new Error(errors.map(formatDiagnostic).join("\n"));
+  }
+  return output.outputText;
+}
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+  if (diagnostic.file && diagnostic.start !== undefined) {
+    const { line } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+    return `Line ${line + 1}: ${message}`;
+  }
+  return message;
+}
+
 // prepareTask resolves a script's imports against the loaded apps and splits
 // out the runnable body, returning the args every binding maps to plus the code.
 function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: string]: Client | Object }; runCode: string } {
-  const file = ts.createSourceFile("task.ts", code, ts.ScriptTarget.Latest);
+  const file = ts.createSourceFile("task.js", transpile(code), ts.ScriptTarget.Latest);
   const args: { [key: string]: Client | Object } = {};
   const runStatements: ts.Statement[] = [];
 
   file.statements.forEach((statement) => {
+    // moduleDetection: Force can make the transpiler emit a bare `export {};`,
+    // which new Function would reject.
+    if (ts.isExportDeclaration(statement)) {
+      return;
+    }
     if (ts.isImportDeclaration(statement)) {
       // slice(1, -1) - remove quotes
       const path = statement.moduleSpecifier.getText(file).slice(1, -1);
@@ -62,25 +96,31 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
   return { args, runCode: printStatements(runStatements) };
 }
 
-export function runTask(code: string, kaja: Kaja, apps: App[]) {
-  const { args, runCode } = prepareTask(code, kaja, apps);
+export function runTask(code: string, kaja: Kaja, apps: App[], onError: (error: unknown) => void) {
+  let result: any;
+  try {
+    const { args, runCode } = prepareTask(code, kaja, apps);
 
-  // Wrap the user's code in an async function so async keyword can be used
-  const func = new Function(
-    ...Object.keys(args),
-    `
-    return (async function() {
-      ${runCode}
-    })();
-  `,
-  );
+    // Wrap the user's code in an async function so async keyword can be used
+    const func = new Function(
+      ...Object.keys(args),
+      `
+      return (async function() {
+        ${runCode}
+      })();
+    `,
+    );
 
-  const result = func(...Object.values(args));
+    result = func(...Object.values(args));
+  } catch (err) {
+    onError(err);
+    return;
+  }
   if (result && typeof result.then === "function") {
     result.catch((err: unknown) => {
       // A cancelled prompt simply stops the script; surface everything else.
       if (err instanceof AskCancelledError) return;
-      throw err;
+      onError(err);
     });
   }
 }
@@ -95,7 +135,6 @@ export interface CapturedRun {
 // and any error instead of letting them escape. Used by the MCP server so an
 // agent can see what a script did.
 export async function runTaskCaptured(code: string, kaja: Kaja, apps: App[]): Promise<CapturedRun> {
-  const { args, runCode } = prepareTask(code, kaja, apps);
   const lines: string[] = [];
   const record = (level: string, parts: unknown[]) => {
     lines.push(parts.map(stringifyConsoleArg).join(" "));
@@ -110,17 +149,18 @@ export async function runTaskCaptured(code: string, kaja: Kaja, apps: App[]): Pr
     debug: (...parts: unknown[]) => record("debug", parts),
   };
 
-  const func = new Function(
-    ...Object.keys(args),
-    "console",
-    `
-    return (async function() {
-      ${runCode}
-    })();
-  `,
-  );
-
   try {
+    const { args, runCode } = prepareTask(code, kaja, apps);
+    const func = new Function(
+      ...Object.keys(args),
+      "console",
+      `
+      return (async function() {
+        ${runCode}
+      })();
+    `,
+    );
+
     const result = await func(...Object.values(args), captureConsole);
     return { console: lines, result };
   } catch (err) {


### PR DESCRIPTION
Scripts with TypeScript syntax (generics, type annotations) crashed with a cryptic SyntaxError that only reached kaja.log. The task runner now transpiles scripts before executing them and reports compile/runtime failures as an error row in the console pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LBX9dw3DqR1bmXCMV3GA8

---
_Generated by [Claude Code](https://claude.ai/code/session_011LBX9dw3DqR1bmXCMV3GA8)_