### PR TITLE
Surfaced proto doc comments as JSDoc in Monaco

### DIFF
--- a/ui/src/appLoader.docs.test.ts
+++ b/ui/src/appLoader.docs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "bun:test";
+import { loadApp } from "./appLoader";
+import type { Source as ApiSource } from "./server/api";
+
+// createClients reads window.location for the base URL; provide it as the browser would.
+(globalThis as any).window = { location: { href: "http://localhost/" } };
+
+// A generated service source (.ts) + its client interface (.client.ts) with the
+// JSDoc protoc-gen-kaja emits from proto doc comments. Verifies the doc survives
+// into the kaja service model that Monaco reads for hover/autocomplete.
+const serviceTs = `
+import { ServiceType } from "@protobuf-ts/runtime-rpc";
+export interface SumRequest { a: number; b: number; }
+export interface SumResponse { v: number; }
+export const Add = new ServiceType("Add", []);
+`;
+
+const clientTs = `
+import type { RpcOptions, UnaryCall } from "@protobuf-ts/runtime-rpc";
+import type { SumRequest, SumResponse } from "./addsvc";
+/**
+ * @generated from protobuf service Add
+ */
+export interface IAddClient {
+    /**
+     * Sums two integers.
+     *
+     * @generated from protobuf rpc: Sum
+     */
+    sum(input: SumRequest, options?: RpcOptions): UnaryCall<SumRequest, SumResponse>;
+}
+`;
+
+// Minimal stub module exporting a ServiceInfo-like object keyed by stubModuleId.
+const stubCode = `
+export const proto$addsvc = {
+  Add: { typeName: "addsvc.Add", methods: [{ name: "Sum", serverStreaming: false, clientStreaming: false }] },
+};
+export const proto$addsvc$client = { AddClient: class { sum() {} } };
+`;
+
+describe("proto doc comments in service model", () => {
+  it("carries method JSDoc into the generated kaja service source", async () => {
+    const apiSources: ApiSource[] = [
+      { path: "proto/addsvc.ts", content: serviceTs },
+      { path: "proto/addsvc.client.ts", content: clientTs },
+    ] as ApiSource[];
+
+    const app = await loadApp(apiSources, stubCode, { name: "grpcbin" } as any, "kaja-app://x", "grpc" as any);
+    const serviceSource = app.sources.find((s) => s.serviceNames.includes("Add"));
+    expect(serviceSource).toBeDefined();
+    const text = serviceSource!.file.text;
+
+    expect(text).toContain("Sums two integers.");
+    expect(text).toContain("Sum: async (input: SumRequest)");
+    // JSDoc must be attached to the method, not floating elsewhere.
+    const idx = text.indexOf("Sum: async");
+    const before = text.slice(Math.max(0, idx - 200), idx);
+    expect(before).toContain("Sums two integers.");
+  });
+});

--- a/ui/src/appLoader.ts
+++ b/ui/src/appLoader.ts
@@ -136,6 +136,30 @@ function createClients(services: Service[], stub: Stub, appRef: AppRef): Clients
   return clients;
 }
 
+// Copy a node's leading comments (proto docs the generator emits as JSDoc) from
+// the original source onto a freshly synthesized node as synthetic comments, so
+// the printer re-emits them. Interior lines are re-indented to a single ` *`
+// since the source indentation would otherwise be preserved verbatim.
+function copyLeadingComments(sourceFile: ts.SourceFile, fromNode: ts.Node, toNode: ts.Node): void {
+  const fullText = sourceFile.getFullText();
+  const ranges = ts.getLeadingCommentRanges(fullText, fromNode.getFullStart());
+  if (!ranges) {
+    return;
+  }
+
+  ranges.forEach((range) => {
+    if (range.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+      const text = fullText
+        .slice(range.pos + 2, range.end - 2)
+        .replace(/\n[ \t]*\*/g, "\n *")
+        .replace(/\n[ \t]+$/, "\n ");
+      ts.addSyntheticLeadingComment(toNode, range.kind, text, range.hasTrailingNewLine);
+    } else {
+      ts.addSyntheticLeadingComment(toNode, range.kind, fullText.slice(range.pos + 2, range.end), range.hasTrailingNewLine);
+    }
+  });
+}
+
 function getInputParameter(method: ts.MethodSignature, sourceFile: ts.SourceFile): ts.ParameterDeclaration | undefined {
   return method.parameters.find((parameter) => parameter.name.getText(sourceFile) == "input");
 }
@@ -259,6 +283,9 @@ function createServiceInterfaceDefinition(
         ts.factory.createBlock([]),
       ),
     );
+    // Carry the proto doc comment (emitted as JSDoc on the generated I<Service>Client
+    // member) onto the synthesized method so Monaco shows it on hover/autocomplete.
+    copyLeadingComments(sourceFile, member, func);
     funcs.push(func);
   });
 


### PR DESCRIPTION
Proto doc comments on service methods now show up on hover/autocomplete in the script editor. `appLoader` re-synthesized each method without its generated JSDoc; it now copies the leading comment from the client interface member onto the synthesized method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQ9PEUsEZYjZ8fqKidzUYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQ9PEUsEZYjZ8fqKidzUYb)_