### PR TITLE
Kept recursive-message default input type-correct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Use pure Primer when possible, avoid custom wrappers and abstractions.
 - Ask me before creating custom UI components; prefer direct use of Primer components.
 - Keep pull-request descriptions super short - one or two sentences summarizing the change.
+- Don't reference specific example services (e.g. names of APIs used to reproduce a bug) in code, comments, or tests. Keep them generic — they are just random examples.
 
 ## Experimental (Preview)
 

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -16,19 +16,23 @@ test("defaultInput", () => {
 });
 
 // A self-referential message (as generated for recursive OpenAPI schemas such as
-// OpenMeter's filter/expression types) must not recurse until the stack overflows.
-test("defaultInput terminates on self-referential message", () => {
+// OpenMeter's filter/expression types) must terminate and still produce valid code:
+// a repeated self-reference defaults to an empty array, a singular one is omitted.
+test("defaultInput terminates on self-referential message with valid output", () => {
   const filter: MessageType<any> = new MessageType("openapi.demo.Filter", [
     { no: 1, name: "field", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
     { no: 2, name: "and", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => filter },
+    { no: 3, name: "not", kind: "message", T: () => filter },
   ]);
 
   const sources: Sources = [];
   const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(filter, sources, {}))]);
 
-  // The nested "and" element stops at an empty object literal instead of recursing.
+  // The repeated self-reference becomes an empty array, not an unfillable element.
   expect(expr).toContain("field:");
-  expect(expr).toContain("and: [{}]");
+  expect(expr).toContain("and: []");
+  // The singular self-reference is optional in the generated type, so it is omitted.
+  expect(expr).not.toContain("not:");
 });
 
 // A cycle across two messages (A -> B -> A) must also terminate.
@@ -38,4 +42,16 @@ test("defaultInput terminates on mutually recursive messages", () => {
 
   const sources: Sources = [];
   expect(() => defaultMessage(a, sources, {})).not.toThrow();
+});
+
+// A map whose value type is self-referential defaults to an empty map.
+test("defaultInput terminates on recursive map value", () => {
+  const node: MessageType<any> = new MessageType("openapi.demo.Node", [
+    { no: 1, name: "children", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "message", T: () => node } },
+  ]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(node, sources, {}))]);
+
+  expect(expr).toContain("children: {}");
 });

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -16,7 +16,7 @@ test("defaultInput", () => {
 });
 
 // A self-referential message (as generated for recursive OpenAPI schemas such as
-// OpenMeter's filter/expression types) must terminate and still produce valid code:
+// filter/expression types) must terminate and still produce valid code:
 // a repeated self-reference defaults to an empty array, a singular one is omitted.
 test("defaultInput terminates on self-referential message with valid output", () => {
   const filter: MessageType<any> = new MessageType("openapi.demo.Filter", [

--- a/ui/src/defaultInput.ts
+++ b/ui/src/defaultInput.ts
@@ -18,6 +18,18 @@ export function defaultMessage<T extends object>(
   const nested = new Set(visiting).add(typeName);
 
   message.fields.forEach((field) => {
+    // Break recursive message cycles. A field whose message type is already on
+    // the current path can't be filled in without recursing forever: a repeated
+    // field defaults to an empty array and a singular (optional) field is omitted
+    // entirely, so the generated code stays type-correct instead of holding an
+    // unfillable placeholder.
+    if (field.kind === "message" && nested.has(field.T().typeName)) {
+      if (field.repeat) {
+        properties.push(ts.factory.createPropertyAssignment(field.localName, ts.factory.createArrayLiteralExpression([])));
+      }
+      return;
+    }
+
     let value = defaultMessageField(field, sources, imports, nested, typeName);
 
     if (field.repeat) {
@@ -66,6 +78,11 @@ function defaultMessageField(field: FieldInfo, sources: Sources, imports: Import
   }
 
   if (field.kind === "map") {
+    // An empty map is valid; if the value type would recurse into the current
+    // path, leave the map empty rather than emit an unfillable entry.
+    if (field.V.kind === "message" && visiting.has(field.V.T().typeName)) {
+      return ts.factory.createObjectLiteralExpression([]);
+    }
     const properties: ts.PropertyAssignment[] = [];
     properties.push(ts.factory.createPropertyAssignment(defaultMapKey(field.K), defaultMapValue(field.V, sources, imports, visiting)));
 
@@ -78,11 +95,6 @@ function defaultMessageField(field: FieldInfo, sources: Sources, imports: Import
 
   if (field.kind === "message") {
     const messageType = field.T();
-    // Break recursive message cycles: a field whose type is already on the
-    // current path gets an empty object literal instead of recursing forever.
-    if (visiting.has(messageType.typeName)) {
-      return ts.factory.createObjectLiteralExpression([]);
-    }
     // Special case for Timestamp - default to current time
     if (messageType.typeName === "google.protobuf.Timestamp") {
       const now = new Date();
@@ -184,13 +196,8 @@ function defaultMapValue(value: mapValueType, sources: Sources, imports: Imports
       return defaultScalar(value.T);
     case "enum":
       return defaultEnum(value.T(), sources, imports);
-    case "message": {
-      const messageType = value.T();
-      if (visiting.has(messageType.typeName)) {
-        return ts.factory.createObjectLiteralExpression([]);
-      }
-      return defaultMessage(messageType, sources, imports, visiting);
-    }
+    case "message":
+      return defaultMessage(value.T(), sources, imports, visiting);
   }
 }
 


### PR DESCRIPTION
Follow-up to #334. The cycle break for self-referential messages emitted an empty object literal, which fails to type-check because the message's scalar fields are required. It now terminates precisely: a repeated self-reference defaults to an empty array, a singular (optional) one is omitted, and a map with a recursive value type defaults to an empty map — so the generated request code stays valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqgSJfxC41DgSDfjjpm6Ss)_