### PR TITLE
Defaulted repeated scalars to empty arrays in example input

### DIFF
--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -35,6 +35,25 @@ test("defaultInput terminates on self-referential message with valid output", ()
   expect(expr).not.toContain("not:");
 });
 
+// A repeated scalar defaults to an empty array, not a placeholder element like
+// [""]: that placeholder would be sent verbatim as an invalid value. Repeated
+// message and enum fields keep one element, where it carries real structure.
+test("defaultInput uses empty arrays for repeated scalars, one element for messages", () => {
+  const item: MessageType<any> = new MessageType("openapi.demo.Item", [{ no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }]);
+  const request: MessageType<any> = new MessageType("openapi.demo.Request", [
+    { no: 1, name: "ids", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+    { no: 2, name: "items", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => item },
+  ]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
+
+  // Repeated scalar: empty array, no placeholder element.
+  expect(expr).toContain("ids: []");
+  // Repeated message: one element revealing the nested shape.
+  expect(expr).toContain("name:");
+});
+
 // A cycle across two messages (A -> B -> A) must also terminate.
 test("defaultInput terminates on mutually recursive messages", () => {
   const a: MessageType<any> = new MessageType("openapi.demo.A", [{ no: 1, name: "b", kind: "message", T: () => b }]);

--- a/ui/src/defaultInput.ts
+++ b/ui/src/defaultInput.ts
@@ -30,11 +30,19 @@ export function defaultMessage<T extends object>(
       return;
     }
 
-    let value = defaultMessageField(field, sources, imports, nested, typeName);
+    let value: ts.Expression;
 
     if (field.repeat) {
-      const arrayValue = defaultMessageField(field, sources, imports, nested, typeName);
-      value = ts.factory.createArrayLiteralExpression([arrayValue]);
+      // A repeated scalar defaults to an empty array. A single placeholder element
+      // (e.g. [""] or [0]) is sent verbatim as an invalid value, and for request
+      // bodies that accept at most one of several array-valued operators it also
+      // makes multiple operators look "set". Repeated message and enum fields keep
+      // one element: there the element carries a nested shape or a concrete valid
+      // value that the field name alone doesn't convey.
+      const elements = field.kind === "scalar" ? [] : [defaultMessageField(field, sources, imports, nested, typeName)];
+      value = ts.factory.createArrayLiteralExpression(elements);
+    } else {
+      value = defaultMessageField(field, sources, imports, nested, typeName);
     }
 
     properties.push(ts.factory.createPropertyAssignment(field.localName, value));


### PR DESCRIPTION
Repeated scalar fields in the generated example input now default to `[]` instead of a single placeholder element like `[""]`, which was sent verbatim as an invalid value and made "pick-one-of-many" array operators look set. Repeated message and enum fields still keep one element, where it reveals a nested shape or a valid value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KECBU927Wpf4BFeuAu1hsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KECBU927Wpf4BFeuAu1hsu)_