### PR TITLE
Preserved OpenAPI spec snippets as proto comments

### DIFF
--- a/server/pkg/apps/openapi/kitchensink_test.go
+++ b/server/pkg/apps/openapi/kitchensink_test.go
@@ -43,6 +43,13 @@ func TestKitchenSinkSpec(t *testing.T) {
 		"message IngestSignalsRequest {",
 		`Signal body = `,
 		"message Signal {",
+		// Origin + description snippets from the spec surface as proto comments.
+		"// from #/components/schemas/Signal",
+		"// A single observed signal.",
+		"// Comments preserve special chars like */ and <html>.",
+		"// Stable identifier.",
+		"// POST /signals",
+		"// Zero-based page index.",
 		`string id = `,
 		`string source = `,
 		`uint64 total = `,

--- a/server/pkg/apps/openapi/openapi_test.go
+++ b/server/pkg/apps/openapi/openapi_test.go
@@ -187,6 +187,73 @@ func TestGenerateProto(t *testing.T) {
 	}
 }
 
+// TestGenerateProtoComments locks in that the generator preserves origin and
+// description snippets from the spec as proto comments: an RPC gets a
+// "VERB /path" origin plus its summary/description, a component-derived message
+// gets a "from #/components/schemas/X" origin plus its description, and both
+// property and parameter descriptions surface on their fields.
+func TestGenerateProtoComments(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info:
+  title: Docs
+  version: 1.0.0
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      summary: Fetch one pet
+      description: Returns a single pet by id.
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The pet's unique id.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      description: A pet in the store.
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: The pet's display name.
+`
+	s, err := parseSpec([]byte(spec))
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	gen, err := generateProto(s)
+	if err != nil {
+		t.Fatalf("generateProto: %v", err)
+	}
+
+	for _, frag := range []string{
+		"// from #/components/schemas/Pet",
+		"// A pet in the store.",
+		"// The pet's display name.",
+		"// GET /pets/{petId}",
+		"// Fetch one pet",
+		"// Returns a single pet by id.",
+		"// The pet's unique id.",
+	} {
+		if !strings.Contains(gen.proto, frag) {
+			t.Errorf("generated proto missing comment %q\n---\n%s", frag, gen.proto)
+		}
+	}
+}
+
 // TestGenerateProtoTagGrouping checks that operations are split into one service
 // per OpenAPI tag, with untagged operations falling into the title-named service.
 func TestGenerateProtoTagGrouping(t *testing.T) {

--- a/server/pkg/apps/openapi/protogen.go
+++ b/server/pkg/apps/openapi/protogen.go
@@ -53,18 +53,38 @@ type fieldDef struct {
 	number   int
 	jsonName string
 	repeated bool
+	doc      []string
 }
 
 type messageDef struct {
 	name   string
 	fields []fieldDef
+	doc    []string
 }
 
 type rpcDef struct {
-	name    string
-	input   string
-	output  string
-	summary string
+	name   string
+	input  string
+	output string
+	doc    []string
+}
+
+// docLines turns a spec description into sanitized proto comment lines: CRLF is
+// normalized, trailing whitespace stripped, and an all-blank description drops
+// to nothing. Each line is later emitted as a "// ..." comment, so the origin of
+// a generated type is visible in "Go to Definition".
+func docLines(text string) []string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	text = strings.TrimRight(text, " \t\n")
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	lines := strings.Split(text, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	return lines
 }
 
 // serviceDef is a single generated proto service. Operations are grouped into
@@ -225,8 +245,12 @@ func (g *generator) addOperation(path string, item *pathItem, vo verbOp) {
 	output, wrap := g.responseType(methodName, op)
 	binding.responseWrap = wrap
 
+	doc := []string{vo.verb + " " + path}
+	doc = append(doc, docLines(op.Summary)...)
+	doc = append(doc, docLines(op.Description)...)
+
 	svc := g.serviceFor(op)
-	svc.rpcs = append(svc.rpcs, &rpcDef{name: methodName, input: reqName, output: output, summary: op.Summary})
+	svc.rpcs = append(svc.rpcs, &rpcDef{name: methodName, input: reqName, output: output, doc: doc})
 	g.bindingByMethod[methodName] = binding
 }
 
@@ -282,7 +306,11 @@ func (g *generator) paramField(param *parameter, number int) fieldDef {
 		}
 	}
 	typ, repeated := g.protoType("Param", pascal(param.Name), s)
-	return fieldDef{typ: typ, name: ensureName(lowerSnake(param.Name), fmt.Sprintf("field%d", number)), number: number, jsonName: param.Name, repeated: repeated}
+	desc := param.Description
+	if desc == "" && s != nil {
+		desc = s.Description
+	}
+	return fieldDef{typ: typ, name: ensureName(lowerSnake(param.Name), fmt.Sprintf("field%d", number)), number: number, jsonName: param.Name, repeated: repeated, doc: docLines(desc)}
 }
 
 // refMessage ensures a message exists for a "#/components/schemas/X" reference
@@ -298,11 +326,12 @@ func (g *generator) refMessage(ref string) string {
 	// Reserve the name before recursing to break self-referential cycles.
 	g.refMsgName[refName(ref)] = name
 	g.seenMsg[name] = true
-	placeholder := &messageDef{name: name}
+	placeholder := &messageDef{name: name, doc: []string{"from #/components/schemas/" + refName(ref)}}
 	g.messages = append(g.messages, placeholder)
 
 	if s := g.lookupRef(ref); s != nil {
 		placeholder.fields = g.fieldsFromSchema(name, s)
+		placeholder.doc = append(placeholder.doc, docLines(s.Description)...)
 	}
 	return name
 }
@@ -395,10 +424,23 @@ func (g *generator) fieldsFromSchema(parent string, s *schema) []fieldDef {
 			number:   num,
 			jsonName: propName,
 			repeated: repeated,
+			doc:      docLines(propertyDescription(props[propName])),
 		})
 		num++
 	}
 	return fields
+}
+
+// propertyDescription returns the first non-empty description among the schemas
+// declared for a property (a property merged from several union variants can
+// carry the description on any of them).
+func propertyDescription(schemas []*schema) string {
+	for _, s := range schemas {
+		if s != nil && strings.TrimSpace(s.Description) != "" {
+			return s.Description
+		}
+	}
+	return ""
 }
 
 // collectProperties gathers the flattened property set of a schema, keeping
@@ -468,7 +510,7 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 			// All variants are objects (a discriminated union): merge their
 			// properties into one message so any variant can be expressed.
 			name := g.uniqueMessageName(parent + hint)
-			g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s)})
+			g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s), doc: docLines(s.Description)})
 			return name, false
 		}
 		// Variants disagree on JSON shape (e.g. a single object vs an array of
@@ -483,7 +525,7 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 		}
 		// Composition: merge every entry's properties with the schema's own.
 		name := g.uniqueMessageName(parent + hint)
-		g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s)})
+		g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s), doc: docLines(s.Description)})
 		return name, false
 	}
 	switch s.Type {
@@ -497,7 +539,7 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 	case "object", "":
 		if len(s.Properties) > 0 {
 			name := g.uniqueMessageName(parent + hint)
-			g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s)})
+			g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s), doc: docLines(s.Description)})
 			return name, false
 		}
 		if ap := s.AdditionalProperties; ap != nil && ap.Allowed {
@@ -599,8 +641,14 @@ func (g *generator) render() string {
 	fmt.Fprintf(&b, "package %s;\n\n", g.pkg)
 
 	for _, m := range g.messages {
+		for _, line := range m.doc {
+			fmt.Fprintf(&b, "// %s\n", line)
+		}
 		fmt.Fprintf(&b, "message %s {\n", m.name)
 		for _, f := range m.fields {
+			for _, line := range f.doc {
+				fmt.Fprintf(&b, "  // %s\n", line)
+			}
 			prefix := ""
 			if f.repeated {
 				prefix = "repeated "
@@ -616,8 +664,8 @@ func (g *generator) render() string {
 		}
 		fmt.Fprintf(&b, "service %s {\n", svc.name)
 		for _, r := range svc.rpcs {
-			if r.summary != "" {
-				fmt.Fprintf(&b, "  // %s\n", strings.ReplaceAll(r.summary, "\n", " "))
+			for _, line := range r.doc {
+				fmt.Fprintf(&b, "  // %s\n", line)
 			}
 			fmt.Fprintf(&b, "  rpc %s(%s) returns (%s);\n", r.name, r.input, r.output)
 		}

--- a/server/pkg/apps/openapi/spec.go
+++ b/server/pkg/apps/openapi/spec.go
@@ -73,14 +73,15 @@ type operation struct {
 }
 
 type parameter struct {
-	Ref      string               `json:"$ref"` // reference to #/components/parameters/<name>
-	Name     string               `json:"name"`
-	In       string               `json:"in"` // path | query | header | cookie
-	Required bool                 `json:"required"`
-	Schema   *schema              `json:"schema"`
-	Style    string               `json:"style"`   // form (default) | deepObject | ...
-	Explode  *bool                `json:"explode"` // default true for form style
-	Content  map[string]mediaType `json:"content"` // alternative to schema: a serialized media type
+	Ref         string               `json:"$ref"` // reference to #/components/parameters/<name>
+	Name        string               `json:"name"`
+	In          string               `json:"in"` // path | query | header | cookie
+	Description string               `json:"description"`
+	Required    bool                 `json:"required"`
+	Schema      *schema              `json:"schema"`
+	Style       string               `json:"style"`   // form (default) | deepObject | ...
+	Explode     *bool                `json:"explode"` // default true for form style
+	Content     map[string]mediaType `json:"content"` // alternative to schema: a serialized media type
 }
 
 type requestBody struct {
@@ -116,6 +117,7 @@ type securityScheme struct {
 type schema struct {
 	Ref                  string                `json:"$ref"`
 	Type                 string                `json:"type"`
+	Description          string                `json:"description"`
 	Format               string                `json:"format"`
 	Items                *schema               `json:"items"`
 	Properties           map[string]*schema    `json:"properties"`

--- a/server/pkg/apps/openapi/testdata/kitchensink.yaml
+++ b/server/pkg/apps/openapi/testdata/kitchensink.yaml
@@ -16,6 +16,8 @@
 #   response, and a 204 empty response
 # - uint32/uint64 integer formats, maps, free-form objects, self-references
 # - an http security scheme with a capitalized "Bearer" scheme name
+# - schema/property/parameter descriptions preserved as proto comments,
+#   including multi-line text and special chars
 openapi: 3.0.0
 info:
   title: Kaja Kitchen Sink
@@ -181,6 +183,7 @@ components:
       in: query
       style: form
       explode: false
+      description: Zero-based page index.
       schema: { type: integer }
     order:
       name: order
@@ -206,9 +209,14 @@ components:
       description: A single signal or a batch of signals.
     Signal:
       type: object
+      description: |
+        A single observed signal.
+        Comments preserve special chars like */ and <html>.
       required: [id, source, kind]
       properties:
-        id: { type: string }
+        id:
+          type: string
+          description: Stable identifier.
         source: { type: string }
         kind: { type: string }
         reading: { type: number, format: double }


### PR DESCRIPTION
The OpenAPI-generated proto now carries origins and descriptions from the spec as comments, so they show up when you Go to Definition: RPCs get a `VERB /path` origin plus summary/description, component-derived messages get a `from #/components/schemas/X` origin plus description, and property/parameter descriptions become field comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GiaeyZErrZRqvknjFjWhs)_