### PR TITLE
Mapped free-form and mixed-scalar OpenAPI schemas to google.protobuf.Value

### DIFF
--- a/server/pkg/apps/openapi/kitchensink_test.go
+++ b/server/pkg/apps/openapi/kitchensink_test.go
@@ -48,9 +48,16 @@ func TestKitchenSinkSpec(t *testing.T) {
 		`uint64 total = `,
 		`uint32 count = `,
 		`map<string, string> labels = `,
-		// Interval is "anyOf: [string, IntervalEnum]" - a scalar union expands
-		// to its first variant in place.
+		// Interval is "anyOf: [string, IntervalEnum]" - a same-category (all
+		// string) scalar union expands to its first variant in place.
 		`string interval = `,
+		// A union mixing incompatible scalars and a bare free-form property both
+		// map to google.protobuf.Value so any JSON value round-trips.
+		`import "google/protobuf/struct.proto";`,
+		`google.protobuf.Value data = `,
+		`google.protobuf.Value value = `,
+		// A free-form map value (additionalProperties: {}) carries any JSON.
+		`map<string, google.protobuf.Value> payload = `,
 		// Gauge is "oneOf: [GaugeFlat, GaugeTiered]" - the merged message
 		// exposes the union's fields, and the variants' differing "scale"
 		// schemas merge into a union of their own.

--- a/server/pkg/apps/openapi/openapi.go
+++ b/server/pkg/apps/openapi/openapi.go
@@ -94,7 +94,10 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 // compileMethods compiles the generated proto and resolves each method's input
 // and output message descriptors, keyed by the gRPC method path.
 func compileMethods(protoDir string, gen *generated) (map[string]*boundMethod, error) {
-	result, err := protoc.New(protoc.WithProtoPaths(protoDir)).Compile("service.proto")
+	// WithIncludeImports keeps imported descriptors (google/protobuf/struct.proto,
+	// pulled in when a field maps to google.protobuf.Value) in the set so
+	// protodesc.NewFiles can resolve them.
+	result, err := protoc.New(protoc.WithProtoPaths(protoDir), protoc.WithIncludeImports()).Compile("service.proto")
 	if err != nil {
 		return nil, fmt.Errorf("compiling generated proto: %w", err)
 	}

--- a/server/pkg/apps/openapi/openapi_test.go
+++ b/server/pkg/apps/openapi/openapi_test.go
@@ -811,6 +811,75 @@ func TestIngestEventsInvoke(t *testing.T) {
 	assertJSONEq(t, decodeResponse(t, inst, svc+"/GetMetrics", out), `{"value":"events_total 42"}`)
 }
 
+// TestFreeFormResponseDecode reproduces the reported failure: a response whose
+// schema types a field loosely (a bare free-form property, or a union that mixes
+// scalars) must decode whatever JSON the API actually returns — a boolean, a
+// nested object, an array — instead of being forced into a string and rejected
+// by protojson.
+func TestFreeFormResponseDecode(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info:
+  title: Loose
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /events:
+    get:
+      operationId: listEvents
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Event"
+components:
+  schemas:
+    Event:
+      type: object
+      properties:
+        id: { type: string }
+        value:
+          oneOf:
+            - type: string
+            - type: boolean
+            - type: number
+        data:
+          description: arbitrary JSON payload
+`
+	// The upstream returns events whose "value" is a boolean and a number, and a
+	// "data" payload that is a nested object — none of which a string field would
+	// accept.
+	const upstreamBody = `[{"id":"1","value":true,"data":{"nested":[1,true,"x"]}},{"id":"2","value":42.5,"data":"plain string"}]`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openapi.yaml", func(w http.ResponseWriter, r *http.Request) { io.WriteString(w, spec) })
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, upstreamBody)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	opened, err := New().Open(map[string]string{"spec_url": srv.URL + "/openapi.yaml"}, t.TempDir(), func(string) {})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	inst := opened.Instance.(*instance)
+	const method = "openapi.loose.Loose/ListEvents"
+
+	out, err := inst.Invoke(method, encodeRequest(t, inst, method, `{}`), nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	assertJSONEq(t, decodeResponse(t, inst, method, out),
+		`{"items":[{"id":"1","value":true,"data":{"nested":[1,true,"x"]}},{"id":"2","value":42.5,"data":"plain string"}]}`)
+}
+
 // TestTranscodeArrayQuery checks that an array-typed query parameter is expanded
 // into repeated query values (tags=a&tags=b) rather than a single JSON literal.
 func TestTranscodeArrayQuery(t *testing.T) {

--- a/server/pkg/apps/openapi/protogen.go
+++ b/server/pkg/apps/openapi/protogen.go
@@ -91,6 +91,20 @@ type generator struct {
 	seenRPC      map[string]bool
 
 	bindingByMethod map[string]*methodBinding
+
+	usesValue bool // a field maps to google.protobuf.Value, so struct.proto is imported
+}
+
+// anyValueType is the proto type for a schema that admits arbitrary JSON (a
+// free-form object, an untyped schema, or a union mixing primitive and other
+// shapes). google.protobuf.Value round-trips any JSON through protojson, so the
+// upstream response decodes whether the value is an object, string, number,
+// bool, or array — where a plain "string" field would reject everything else.
+const anyValueType = "google.protobuf.Value"
+
+func (g *generator) anyValue() string {
+	g.usesValue = true
+	return anyValueType
 }
 
 // generateProto converts an OpenAPI spec into a single proto file plus bindings.
@@ -359,6 +373,49 @@ func (g *generator) allObjectLike(vs []*schema) bool {
 	return true
 }
 
+// unionMapsToValue reports whether a mixed-shape union must be modeled as
+// google.protobuf.Value: it mixes categories (so no single variant fits) and at
+// least one variant is a primitive scalar (so a proto message can't hold it).
+// A union of one category — all strings (string|enum), or all structured
+// (object vs array of it) — is still modeled by its first variant.
+func (g *generator) unionMapsToValue(vs []*schema) bool {
+	categories := map[string]bool{}
+	hasScalar := false
+	for _, v := range vs {
+		c := g.jsonCategory(v, 0)
+		categories[c] = true
+		if c != "complex" {
+			hasScalar = true
+		}
+	}
+	return hasScalar && len(categories) > 1
+}
+
+// jsonCategory classifies a schema's JSON shape into "string", "number",
+// "boolean", or "complex" (object, array, free-form, or unknown), following
+// refs and single-entry allOf wrappers.
+func (g *generator) jsonCategory(s *schema, depth int) string {
+	if s == nil || depth > 16 {
+		return "complex"
+	}
+	s = unwrapAllOf(s)
+	if s == nil {
+		return "complex"
+	}
+	if s.Ref != "" {
+		return g.jsonCategory(g.lookupRef(s.Ref), depth+1)
+	}
+	switch s.Type {
+	case "string":
+		return "string"
+	case "number", "integer":
+		return "number"
+	case "boolean":
+		return "boolean"
+	}
+	return "complex"
+}
+
 // fieldsFromSchema flattens a schema's effective object properties into proto
 // fields: its own properties, those of every allOf entry, and — when every
 // oneOf/anyOf variant is an object — the superset of the variants' properties,
@@ -471,8 +528,14 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 			g.addMessage(&messageDef{name: name, fields: g.fieldsFromSchema(name, s)})
 			return name, false
 		}
-		// Variants disagree on JSON shape (e.g. a single object vs an array of
-		// them); model the first variant as the happy path.
+		if g.unionMapsToValue(vs) {
+			// Variants mix categories including a primitive (e.g. string|bool or
+			// string|object): no single proto type accepts them all, so any JSON
+			// value is decoded through Value.
+			return g.anyValue(), false
+		}
+		// Variants are all structured but disagree on shape (e.g. a single object
+		// vs an array of them); model the first variant as the happy path.
 		return g.protoType(parent, hint, vs[0])
 	}
 	if len(s.AllOf) > 0 {
@@ -508,12 +571,15 @@ func (g *generator) protoType(parent, hint string, s *schema) (string, bool) {
 					// proto map values cannot be maps themselves.
 					value = "string"
 				}
+			} else {
+				// additionalProperties: true — values hold any JSON.
+				value = g.anyValue()
 			}
 			return "map<string, " + value + ">", false
 		}
-		// Free-form object (or untyped schema): fall back to string for the
-		// minimal happy path.
-		return "string", false
+		// Free-form object (or untyped schema): any JSON value round-trips through
+		// google.protobuf.Value instead of being forced into a string.
+		return g.anyValue(), false
 	case "integer":
 		switch s.Format {
 		case "int64":
@@ -597,6 +663,9 @@ func (g *generator) render() string {
 	var b strings.Builder
 	b.WriteString("syntax = \"proto3\";\n\n")
 	fmt.Fprintf(&b, "package %s;\n\n", g.pkg)
+	if g.usesValue {
+		b.WriteString("import \"google/protobuf/struct.proto\";\n\n")
+	}
 
 	for _, m := range g.messages {
 		fmt.Fprintf(&b, "message %s {\n", m.name)

--- a/server/pkg/apps/openapi/testdata/kitchensink.yaml
+++ b/server/pkg/apps/openapi/testdata/kitchensink.yaml
@@ -6,6 +6,8 @@
 # - oneOf discriminated unions of object variants, including a property the
 #   variants declare with different schemas
 # - anyOf of scalar variants (string vs enum reference)
+# - a union mixing incompatible scalars (string|bool|number) and a bare
+#   free-form property, both mapping to google.protobuf.Value
 # - multi-entry allOf composition with sibling properties
 # - "allOf: [$ref]" wrappers carrying only annotations (nullable, default)
 # - a component schema named exactly like an operation's request wrapper
@@ -222,6 +224,13 @@ components:
           type: object
           additionalProperties: {}
           nullable: true
+        value:
+          oneOf:
+            - type: string
+            - type: boolean
+            - type: number
+        data:
+          description: Arbitrary JSON payload with no declared type.
         interval:
           $ref: "#/components/schemas/Interval"
     Interval:

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -54,6 +54,26 @@ test("defaultInput uses empty arrays for repeated scalars, one element for messa
   expect(expr).toContain("name:");
 });
 
+// google.protobuf.Value (used for free-form / polymorphic OpenAPI fields) must
+// not recurse into its "kind" oneof — that would emit every member at once, an
+// invalid shape. It renders as an empty, editable placeholder instead.
+test("defaultInput renders google.protobuf.Value as an empty placeholder", () => {
+  const value: MessageType<any> = new MessageType("google.protobuf.Value", [
+    { no: 1, name: "null_value", kind: "enum", oneof: "kind", T: () => ["google.protobuf.NullValue", {}] },
+    { no: 3, name: "string_value", kind: "scalar", oneof: "kind", T: 9 /*ScalarType.STRING*/ },
+    { no: 4, name: "bool_value", kind: "scalar", oneof: "kind", T: 8 /*ScalarType.BOOL*/ },
+  ]);
+  const request: MessageType<any> = new MessageType("openapi.demo.Request", [{ no: 1, name: "data", kind: "message", T: () => value }]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
+
+  expect(expr).toContain("kind: { oneofKind: undefined }");
+  // No flat oneof members leaked out.
+  expect(expr).not.toContain("stringValue");
+  expect(expr).not.toContain("boolValue");
+});
+
 // A cycle across two messages (A -> B -> A) must also terminate.
 test("defaultInput terminates on mutually recursive messages", () => {
   const a: MessageType<any> = new MessageType("openapi.demo.A", [{ no: 1, name: "b", kind: "message", T: () => b }]);

--- a/ui/src/defaultInput.ts
+++ b/ui/src/defaultInput.ts
@@ -113,6 +113,17 @@ function defaultMessageField(field: FieldInfo, sources: Sources, imports: Import
         ts.factory.createPropertyAssignment("nanos", ts.factory.createNumericLiteral(nanos)),
       ]);
     }
+    // google.protobuf.Value holds arbitrary JSON through a "kind" oneof (used for
+    // free-form / polymorphic fields). Recursing would emit every oneof member at
+    // once, an invalid shape; an empty value is a valid, editable placeholder.
+    if (messageType.typeName === "google.protobuf.Value") {
+      return ts.factory.createObjectLiteralExpression([
+        ts.factory.createPropertyAssignment(
+          "kind",
+          ts.factory.createObjectLiteralExpression([ts.factory.createPropertyAssignment("oneofKind", ts.factory.createIdentifier("undefined"))]),
+        ),
+      ]);
+    }
     // For nested message types, recurse with the nested type name
     return defaultMessage(messageType, sources, imports, visiting);
   }


### PR DESCRIPTION
OpenAPI response fields with no proto3 representation (free-form/untyped objects, `additionalProperties: true`, or unions mixing incompatible scalars like `string|bool`) fell back to a proto `string`, so `protojson` rejected any non-string value the API returned. They now map to `google.protobuf.Value`, which round-trips any JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KECBU927Wpf4BFeuAu1hsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KECBU927Wpf4BFeuAu1hsu)_