### PR TITLE
Skipped reformatting very large editor models to avoid UI freeze

### DIFF
--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -206,6 +206,12 @@ export interface onGoToDefinition {
 
 const UNIFIED_BG = "var(--bgColor-muted)";
 
+// Prettier runs synchronously on the main thread, so reformatting a very large
+// model (e.g. the generated stub for a huge OpenAPI spec, which can be millions
+// of characters in a single file) freezes the UI. Generated stubs are already
+// formatted, so above this size we show them as-is instead of reflowing them.
+const MAX_FORMAT_CHARS = 300_000;
+
 export function Editor({ model, onMount, onGoToDefinition, readOnly = false, startLineNumber = 0, startColumn = 0, viewState }: EditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -275,18 +281,31 @@ export function Editor({ model, onMount, onGoToDefinition, readOnly = false, sta
       onMount?.(editorRef.current);
     }
 
+    const skipFormat = model.getValue().length > MAX_FORMAT_CHARS;
+
     if (!viewState && startLineNumber > 0) {
-      // startLineNumber/startColumn were resolved against the unformatted model
-      // text; formatting reflows lines, so remap the position through prettier.
-      const cursorOffset = model.getOffsetAt({ lineNumber: startLineNumber, column: Math.max(startColumn, 1) });
-      formatTypeScriptWithCursor(model.getValue(), cursorOffset).then((result) => {
-        if (!isDisposing && editorRef.current) {
-          editorRef.current.setValue(result.code);
-          const position = model.getPositionAt(result.cursorOffset);
-          editorRef.current.revealLineInCenter(position.lineNumber);
-          editorRef.current.setPosition(position);
-        }
-      });
+      if (skipFormat) {
+        // The model is shown unformatted, so the original coordinates still line up.
+        const column = Math.max(startColumn, 1);
+        editorRef.current?.revealLineInCenter(startLineNumber);
+        editorRef.current?.setPosition({ lineNumber: startLineNumber, column });
+      } else {
+        // startLineNumber/startColumn were resolved against the unformatted model
+        // text; formatting reflows lines, so remap the position through prettier.
+        const cursorOffset = model.getOffsetAt({ lineNumber: startLineNumber, column: Math.max(startColumn, 1) });
+        formatTypeScriptWithCursor(model.getValue(), cursorOffset).then((result) => {
+          if (!isDisposing && editorRef.current) {
+            editorRef.current.setValue(result.code);
+            const position = model.getPositionAt(result.cursorOffset);
+            editorRef.current.revealLineInCenter(position.lineNumber);
+            editorRef.current.setPosition(position);
+          }
+        });
+      }
+    } else if (skipFormat) {
+      if (viewState) {
+        editorRef.current?.restoreViewState(viewState);
+      }
     } else {
       formatTypeScript(model.getValue()).then((formattedCode) => {
         if (!isDisposing && editorRef.current) {

--- a/ui/src/timestampPicker.ts
+++ b/ui/src/timestampPicker.ts
@@ -8,9 +8,16 @@ export interface TimestampMatch {
   fullRange: monaco.Range;
 }
 
+// Above this size the model is a large generated stub (not editable request
+// code), so scanning it for timestamp literals only burns main-thread time.
+const MAX_SCAN_CHARS = 300_000;
+
 export function findTimestamps(model: monaco.editor.ITextModel): TimestampMatch[] {
   const matches: TimestampMatch[] = [];
   const text = model.getValue();
+  if (text.length > MAX_SCAN_CHARS) {
+    return matches;
+  }
 
   // Use multi-line regex to find timestamp objects regardless of formatting
   // Matches: fieldName: { ... seconds: "digits" ... nanos: digits ... }


### PR DESCRIPTION
Go to Definition on a large OpenAPI spec froze the app because the generated stub is one multi-megabyte TypeScript file that the editor reformatted with prettier on the main thread on every mount. Generated stubs are already formatted, so above a size threshold the model is shown as-is (with the cursor placed using the original coordinates) instead of being reflowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GiaeyZErrZRqvknjFjWhs)_