### PR TITLE
Drafted value_as_json rendering for the OpenAPI app

### DIFF
--- a/protoc-gen-kaja/kaja/kaja.go
+++ b/protoc-gen-kaja/kaja/kaja.go
@@ -79,10 +79,26 @@ func escapeMethodName(name string) string {
 	return name
 }
 
-type params struct{}
+type params struct {
+	// valueAsJson renders google.protobuf.Value fields as the runtime's plain
+	// JsonValue type (any JSON) instead of the wire-oneof Value message. Enabled
+	// via the "value_as_json" plugin parameter; used by the OpenAPI app so its
+	// free-form fields read as ordinary JSON in the script editor.
+	valueAsJson bool
+}
 
 func parseParameters(paramStr *string) params {
-	return params{}
+	p := params{}
+	if paramStr == nil {
+		return p
+	}
+	for _, part := range strings.Split(*paramStr, ",") {
+		switch strings.TrimSpace(part) {
+		case "value_as_json":
+			p.valueAsJson = true
+		}
+	}
+	return p
 }
 
 func findFile(files []*descriptorpb.FileDescriptorProto, name string) *descriptorpb.FileDescriptorProto {
@@ -580,6 +596,7 @@ type generator struct {
 	file                *descriptorpb.FileDescriptorProto
 	allFiles            []*descriptorpb.FileDescriptorProto
 	indent              string
+	usesJsonValueType   bool     // A field was rendered as JsonValue (value_as_json), so import it
 	isImportedByService bool     // True if imported ONLY by service files (not by non-service files)
 	importedTypeNames   map[string]bool   // Set of simple type names that have been imported
 	typeNameSuffixes    map[string]int    // Map from full proto type name to numeric suffix (0 = no suffix, 1 = $1, etc.)
@@ -2945,6 +2962,11 @@ func (g *generator) writeImports(imports map[string]bool) {
 		}
 		g.pNoIndent("import type { %s } from \"@protobuf-ts/runtime\";", g.partialMessageImport())
 		g.pNoIndent("import { %s } from \"@protobuf-ts/runtime\";", g.reflectionMergePartialImport())
+		// JsonValue for value_as_json fields (imports emit before bodies, so pre-scan).
+		// WKT files (Struct/Timestamp/...) import JsonValue on their own below.
+		if g.fileUsesValueAsJson() && !isStruct && !isTimestamp && !isDuration && !isFieldMask {
+			g.pNoIndent("import type { %s } from \"@protobuf-ts/runtime\";", g.jsonValueImport())
+		}
 		}
 		// ScalarType for wrappers (after reflectionMergePartial, only when aliased)
 		if wrapperNeedsScalarType && (g.scalarTypeRef == "ScalarType$" || g.longTypeRef == "LongType$") {
@@ -4500,12 +4522,62 @@ func (g *generator) getBaseTypescriptType(field *descriptorpb.FieldDescriptorPro
 	case descriptorpb.FieldDescriptorProto_TYPE_BYTES:
 		return "Uint8Array"
 	case descriptorpb.FieldDescriptorProto_TYPE_MESSAGE:
+		if g.isValueAsJsonField(field) {
+			g.usesJsonValueType = true
+			return g.jsonValueRef
+		}
 		return g.stripPackage(field.GetTypeName())
 	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
 		return g.stripPackage(field.GetTypeName())
 	default:
 		return "any"
 	}
+}
+
+// isValueAsJsonField reports whether a field should be typed as the plain
+// JsonValue (any JSON) rather than the wire-oneof google.protobuf.Value message.
+// Only the field's TypeScript *type* changes: the message keeps serializing and
+// reflecting as a real Value, and the client converts JsonValue <-> Value at the
+// request boundary. Gated by the value_as_json plugin parameter (OpenAPI app).
+func (g *generator) isValueAsJsonField(field *descriptorpb.FieldDescriptorProto) bool {
+	return g.params.valueAsJson &&
+		field.GetType() == descriptorpb.FieldDescriptorProto_TYPE_MESSAGE &&
+		field.GetTypeName() == ".google.protobuf.Value"
+}
+
+// fileUsesValueAsJson reports whether any field in the file (including nested
+// messages and map values) renders as JsonValue, so the import is emitted.
+func (g *generator) fileUsesValueAsJson() bool {
+	if !g.params.valueAsJson {
+		return false
+	}
+	var scan func(msg *descriptorpb.DescriptorProto) bool
+	scan = func(msg *descriptorpb.DescriptorProto) bool {
+		for _, field := range msg.Field {
+			f := field
+			// A map value lives on the synthetic map-entry message's second field.
+			if field.GetType() == descriptorpb.FieldDescriptorProto_TYPE_MESSAGE {
+				if entry := g.findMessageType(field.GetTypeName()); entry != nil && entry.GetOptions().GetMapEntry() {
+					f = entry.Field[1]
+				}
+			}
+			if g.isValueAsJsonField(f) {
+				return true
+			}
+		}
+		for _, nested := range msg.NestedType {
+			if scan(nested) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, msg := range g.file.MessageType {
+		if scan(msg) {
+			return true
+		}
+	}
+	return false
 }
 
 func is64BitIntType(field *descriptorpb.FieldDescriptorProto) bool {

--- a/protoc-gen-kaja/kaja/value_as_json_test.go
+++ b/protoc-gen-kaja/kaja/value_as_json_test.go
@@ -1,0 +1,73 @@
+package kaja_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wham/kaja/v2/protoc-gen-kaja/kaja"
+	"github.com/wham/protoc-go/protoc"
+)
+
+const valueAsJsonProto = `syntax = "proto3";
+package demo;
+import "google/protobuf/struct.proto";
+
+message Event {
+  string type = 1;
+  map<string, google.protobuf.Value> data = 2;
+  google.protobuf.Value payload = 3;
+}
+`
+
+func generateEventsTS(t *testing.T, parameter string) string {
+	t.Helper()
+	c := protoc.New(protoc.WithOverlay(map[string]string{"events.proto": valueAsJsonProto}))
+	result, err := c.Compile("events.proto")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	files, err := result.RunLibraryPlugin(kaja.NewPlugin(), parameter)
+	if err != nil {
+		t.Fatalf("run plugin: %v", err)
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f.Name, "events.ts") {
+			return f.Content
+		}
+	}
+	t.Fatal("events.ts not generated")
+	return ""
+}
+
+// Without the parameter, Value fields keep the wire-oneof Value type.
+func TestValueAsJson_DefaultKeepsValueType(t *testing.T) {
+	ts := generateEventsTS(t, "")
+	if !strings.Contains(ts, "[key: string]: Value;") {
+		t.Errorf("expected map value to render as Value, got:\n%s", ts)
+	}
+	if !strings.Contains(ts, "payload?: Value;") {
+		t.Errorf("expected singular field to render as Value, got:\n%s", ts)
+	}
+	if strings.Contains(ts, "JsonValue") {
+		t.Errorf("did not expect JsonValue without the parameter, got:\n%s", ts)
+	}
+}
+
+// With value_as_json, Value fields render as plain JsonValue (any JSON), the
+// import is added, but the message class still serializes through the real Value.
+func TestValueAsJson_RendersJsonValue(t *testing.T) {
+	ts := generateEventsTS(t, "value_as_json")
+	if !strings.Contains(ts, "[key: string]: JsonValue;") {
+		t.Errorf("expected map value to render as JsonValue, got:\n%s", ts)
+	}
+	if !strings.Contains(ts, "payload?: JsonValue;") {
+		t.Errorf("expected singular field to render as JsonValue, got:\n%s", ts)
+	}
+	if !strings.Contains(ts, `import type { JsonValue } from "@protobuf-ts/runtime";`) {
+		t.Errorf("expected JsonValue import, got:\n%s", ts)
+	}
+	// The message machinery is untouched: it still reads/writes real Value.
+	if !strings.Contains(ts, "Value.internalBinaryWrite(") {
+		t.Errorf("expected class to still serialize via Value, got:\n%s", ts)
+	}
+}

--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -16,6 +16,7 @@ import (
 
 type ApiService struct {
 	compilers              sync.Map // map[string]*Compiler - keyed by ID
+	valueAsJsonProtoDirs   sync.Map // map[string]bool - proto dirs that opt into value_as_json codegen (OpenAPI apps)
 	configurationPath      string
 	canUpdateConfiguration bool
 	gitRef                 string
@@ -69,6 +70,12 @@ func (s *ApiService) Compile(ctx context.Context, req *CompileRequest) (*Compile
 		compiler.status = CompileStatus_STATUS_RUNNING
 		compiler.logger = NewLogger()
 		compiler.sources = []*Source{}
+		// OpenAPI apps render google.protobuf.Value fields as plain JSON. OpenApp
+		// recorded the proto dir when it opened such an app.
+		compiler.pluginParameter = ""
+		if _, ok := s.valueAsJsonProtoDirs.Load(req.ProtoDir); ok {
+			compiler.pluginParameter = "value_as_json"
+		}
 		compiler.logger.info("Starting compilation")
 		go compiler.start(req.Id, req.ProtoDir)
 	}
@@ -119,6 +126,12 @@ func (s *ApiService) OpenApp(ctx context.Context, req *OpenAppRequest) (*OpenApp
 	if err != nil {
 		logger.error("Failed to open app", err)
 		return &OpenAppResponse{Status: OpenStatus_OPEN_STATUS_ERROR, Logs: logger.logs}, nil
+	}
+
+	// The OpenAPI app maps free-form/mixed schemas to google.protobuf.Value. Remember
+	// its proto dir so the follow-up Compile renders those fields as plain JsonValue.
+	if appType == "openapi" {
+		s.valueAsJsonProtoDirs.Store(result.ProtoDir, true)
 	}
 
 	return &OpenAppResponse{

--- a/server/pkg/api/compiler.go
+++ b/server/pkg/api/compiler.go
@@ -14,11 +14,12 @@ import (
 )
 
 type Compiler struct {
-	mu      sync.Mutex
-	status  CompileStatus
-	logger  *Logger
-	sources []*Source
-	stub    string
+	mu              sync.Mutex
+	status          CompileStatus
+	logger          *Logger
+	sources         []*Source
+	stub            string
+	pluginParameter string // passed to protoc-gen-kaja, e.g. "value_as_json" for OpenAPI apps
 }
 
 func NewCompiler() *Compiler {
@@ -126,7 +127,7 @@ func (c *Compiler) compile(cwd string, sourcesDir string, protoDir string) error
 	}
 
 	c.logger.debug("Running protoc-gen-kaja")
-	generated, err := result.RunLibraryPlugin(kaja.NewPlugin(), "")
+	generated, err := result.RunLibraryPlugin(kaja.NewPlugin(), c.pluginParameter)
 	if err != nil {
 		return fmt.Errorf("protoc-gen-kaja: %v", err)
 	}


### PR DESCRIPTION
Draft: renders the OpenAPI app's `google.protobuf.Value` fields as the runtime's plain `JsonValue` type (any JSON) instead of the verbose wire-oneof `Value`, so free-form data reads as ordinary JSON in the script editor. Only the exported TS type changes — the message still serializes/reflects through the real `Value` — and it's gated to the OpenAPI app via a new `value_as_json` protoc-gen-kaja parameter. The client-side `JsonValue`↔`Value` conversion is the remaining piece.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HV6PstX9Y2hRURnBjBS8KR)_