### PR TITLE
Fixed kaja import failing when written as "./kaja"

### DIFF
--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -20,6 +20,16 @@ describe("kaja.variables injection", () => {
     expect(run.result).toBe("https://api.example.com / 42");
   });
 
+  it("resolves the kaja import from the relative ./kaja path", async () => {
+    const kaja = makeKaja();
+    kaja.variables = { HELLO: "world" };
+
+    const run = await runTaskCaptured(`import { kaja } from "./kaja";\nreturn kaja.variables.HELLO;`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe("world");
+  });
+
   it("reflects updates to variables on the shared kaja object", async () => {
     const kaja = makeKaja();
     kaja.variables = { TOKEN: "old" };

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -48,7 +48,9 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
     if (ts.isImportDeclaration(statement)) {
       // slice(1, -1) - remove quotes
       const path = statement.moduleSpecifier.getText(file).slice(1, -1);
-      if (path === "kaja") {
+      // Monaco backs the kaja module with a model at ts:/kaja.ts, so its
+      // auto-import and go-to-definition can emit the relative "./kaja" form.
+      if (path === "kaja" || path === "./kaja") {
         const importClause = statement.importClause;
         if (importClause && importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
           importClause.namedBindings.elements.forEach((importSpecifier) => {


### PR DESCRIPTION
The task runner only recognized `import { kaja } from "kaja"`, but Monaco's auto-import/go-to-definition emits the relative `"./kaja"` form (the backing model lives at `ts:/kaja.ts`), which was silently ignored and left `kaja` undefined at run time. Now both paths resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2jMJ3R7wt614N6Wd9GRny)_