### PR TITLE
Closed stale task tabs when their app was deleted

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -661,12 +661,17 @@ export function App() {
       if (tabsRestoredRef.current) {
         tabsRestoredRef.current = false;
         setTabs((prevTabs) => {
-          linkTabsToApps(prevTabs, updatedApps);
-          const activeTab = prevTabs[activeTabIndexRef.current];
+          const { tabs: linkedTabs, removedTabIds } = linkTabsToApps(prevTabs, updatedApps);
+          removedTabIds.forEach((id) => editorRegistryRef.current.delete(id));
+          if (removedTabIds.length > 0) {
+            setActiveTabIndex((idx) => Math.min(idx, Math.max(0, linkedTabs.length - 1)));
+          }
+          const clampedIndex = Math.min(activeTabIndexRef.current, Math.max(0, linkedTabs.length - 1));
+          const activeTab = linkedTabs[clampedIndex];
           if (activeTab?.type === "task") {
             setSelectedMethod(activeTab.originMethod);
           }
-          return [...prevTabs];
+          return linkedTabs;
         });
         // Force TypeScript to revalidate restored models now that source models exist
         refreshOpenTaskEditors();

--- a/ui/src/tabModel.test.ts
+++ b/ui/src/tabModel.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { getTabLabel, serializeTabs, TabModel } from "./tabModel";
+import { getTabLabel, linkTabsToApps, serializeTabs, TabModel } from "./tabModel";
+import { App } from "./apps";
 
 describe("getTabLabel", () => {
   it("should return just the filename from a path", () => {
@@ -57,10 +58,7 @@ describe("serializeTabs", () => {
   });
 
   it("should adjust active index when non-serialized tabs are before the active tab", () => {
-    const tabs: TabModel[] = [
-      { type: "definition", id: "def-1", model: {} as any, startLineNumber: 1, startColumn: 1 },
-      { type: "compiler" },
-    ];
+    const tabs: TabModel[] = [{ type: "definition", id: "def-1", model: {} as any, startLineNumber: 1, startColumn: 1 }, { type: "compiler" }];
 
     const result = serializeTabs(tabs, 1, () => undefined);
     expect(result.activeIndex).toBe(0);
@@ -85,5 +83,67 @@ describe("serializeTabs", () => {
 
     const result = serializeTabs(tabs, 0, () => liveViewState);
     expect((result.tabs[0] as any).viewState).toBe(liveViewState);
+  });
+});
+
+describe("linkTabsToApps", () => {
+  function taskTab(id: string, appName: string, serviceName: string, methodName: string): TabModel {
+    let disposed = false;
+    return {
+      type: "task",
+      id,
+      originMethod: { name: methodName },
+      originService: { name: serviceName, packageName: "", sourcePath: "", clientStubModuleId: "", methods: [{ name: methodName }] },
+      originApp: { configuration: { name: appName } } as any,
+      hasInteraction: false,
+      model: { dispose: () => (disposed = true), isDisposed: () => disposed } as any,
+      originalCode: "",
+    };
+  }
+
+  function app(name: string, serviceName: string, methodName: string): App {
+    const service = { name: serviceName, packageName: "", sourcePath: "", clientStubModuleId: "", methods: [{ name: methodName }] };
+    return { configuration: { name }, services: [service] } as any;
+  }
+
+  it("re-binds a task tab to the matching compiled app by identity", () => {
+    const tab = taskTab("task-1", "users", "UserService", "GetUser");
+    const compiled = app("users", "UserService", "GetUser");
+
+    const result = linkTabsToApps([tab], [compiled]);
+
+    expect(result.tabs).toHaveLength(1);
+    expect(result.removedTabIds).toHaveLength(0);
+    expect((result.tabs[0] as any).originApp).toBe(compiled);
+    expect((result.tabs[0] as any).originService).toBe(compiled.services[0]);
+  });
+
+  it("drops and disposes a task tab whose app was deleted", () => {
+    const tab = taskTab("task-1", "teams", "Teams", "GetAllTeams");
+
+    const result = linkTabsToApps([tab], [app("users", "UserService", "GetUser")]);
+
+    expect(result.tabs).toHaveLength(0);
+    expect(result.removedTabIds).toEqual(["task-1"]);
+    expect((tab as any).model.isDisposed()).toBe(true);
+  });
+
+  it("drops a task tab whose service or method no longer exists", () => {
+    const goneMethod = taskTab("task-1", "users", "UserService", "RemovedMethod");
+    const goneService = taskTab("task-2", "users", "RemovedService", "GetUser");
+    const kept = taskTab("task-3", "users", "UserService", "GetUser");
+
+    const result = linkTabsToApps([goneMethod, goneService, kept], [app("users", "UserService", "GetUser")]);
+
+    expect(result.tabs.map((t) => (t as any).id)).toEqual(["task-3"]);
+    expect(result.removedTabIds).toEqual(["task-1", "task-2"]);
+  });
+
+  it("keeps non-task tabs untouched", () => {
+    const compilerTab: TabModel = { type: "compiler" };
+    const result = linkTabsToApps([compilerTab], []);
+
+    expect(result.tabs).toEqual([compilerTab]);
+    expect(result.removedTabIds).toHaveLength(0);
   });
 });

--- a/ui/src/tabModel.ts
+++ b/ui/src/tabModel.ts
@@ -383,19 +383,33 @@ export function restoreTabs(state: PersistedTabState | undefined): { tabs: TabMo
   return { tabs, activeIndex };
 }
 
-export function linkTabsToApps(tabs: TabModel[], apps: App[]): void {
+// Re-bind restored task tabs to the compiled apps by name. A task tab whose
+// app/service/method no longer exists (e.g. the app was deleted while the tab
+// was closed) can no longer resolve its import, so it is dropped instead of
+// lingering as a stale stub. Runs only once compilation has succeeded, so a
+// missing app means removed, not still-compiling. Returns the surviving tabs
+// and the ids of the dropped tabs so the caller can clean up editor state.
+export function linkTabsToApps(tabs: TabModel[], apps: App[]): { tabs: TabModel[]; removedTabIds: string[] } {
+  const kept: TabModel[] = [];
+  const removedTabIds: string[] = [];
+
   for (const tab of tabs) {
     if (tab.type === "task") {
       const app = apps.find((p) => p.configuration.name === tab.originApp.configuration.name);
-      if (!app) continue;
-      const service = app.services.find((s) => s.name === tab.originService.name);
-      if (!service) continue;
-      const method = service.methods.find((m) => m.name === tab.originMethod.name);
-      if (!method) continue;
+      const service = app?.services.find((s) => s.name === tab.originService.name);
+      const method = service?.methods.find((m) => m.name === tab.originMethod.name);
+      if (!app || !service || !method) {
+        tab.model.dispose();
+        removedTabIds.push(tab.id);
+        continue;
+      }
 
       tab.originApp = app;
       tab.originService = service;
       tab.originMethod = method;
     }
+    kept.push(tab);
   }
+
+  return { tabs: kept, removedTabIds };
 }

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -83,6 +83,15 @@ return pick<number>([base]) + 1;`,
   });
 });
 
+describe("orphaned imports", () => {
+  it("reports a clear error when the imported app no longer exists", async () => {
+    const run = await runTaskCaptured(`import { Teams } from "teams/teams";\nTeams.GetAllTeams({});`, makeKaja(), []);
+
+    expect(run.result).toBeUndefined();
+    expect(run.error).toContain(`app "teams" was not found`);
+  });
+});
+
 describe("kaja.uuid", () => {
   it("generates a version 4 UUID from scripts", async () => {
     const kaja = makeKaja();

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -65,11 +65,13 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
       }
       const app = apps.find((app) => path.startsWith(app.configuration.name + "/"));
       if (!app) {
-        return;
+        // A silent drop here surfaces later as an opaque "X is not defined" when
+        // the body uses the binding; name the unresolved app instead.
+        throw new Error(`Cannot resolve import "${path}": app "${path.split("/")[0]}" was not found (it may have been deleted).`);
       }
       const source = app.sources.find((source) => source.importPath === path);
       if (!source) {
-        return;
+        throw new Error(`Cannot resolve import "${path}" in app "${app.configuration.name}".`);
       }
 
       const importClause = statement.importClause;


### PR DESCRIPTION
Restored task tabs whose app/service/method no longer exists are now dropped instead of lingering as stale stubs, and an orphaned service import in a script throws a clear "app not found" error rather than failing later with a confusing `ReferenceError`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012PhH8D8ZZKYccNWWFhoCTW)_