### PR TITLE
Fixed legacy OpenAPI projects migrating into an empty gRPC app

### DIFF
--- a/server/pkg/api/configuration.go
+++ b/server/pkg/api/configuration.go
@@ -121,11 +121,28 @@ func migrateConfiguration(content []byte, logger *Logger) []byte {
 	return migrated
 }
 
-// legacyProjectToApp converts a pre-unification gRPC/Twirp project into the typed
-// app shape { name, headers, <type>: { url, proto_dir, reflection } }.
+// legacyProjectToApp converts a pre-unification gRPC/Twirp/OpenAPI project into the
+// typed app shape, e.g. { name, headers, <type>: { url, proto_dir, reflection } }.
 func legacyProjectToApp(project map[string]any) map[string]any {
+	protocol := strings.ToUpper(stringField(project, "protocol"))
+
+	// An OpenAPI project carries its spec document URL in "url", which maps to the
+	// openapi app's spec_url (not a gRPC/Twirp upstream url). Without this the
+	// project would fall through to the gRPC branch below, producing an app with no
+	// proto surface and therefore no methods.
+	if strings.Contains(protocol, "OPENAPI") {
+		variant := map[string]any{}
+		if url := stringField(project, "url"); url != "" {
+			variant["spec_url"] = url
+		}
+		if headers, ok := project["headers"]; ok {
+			variant["headers"] = headers
+		}
+		return map[string]any{"name": project["name"], "openapi": variant}
+	}
+
 	appType := "grpc"
-	if protocol, _ := project["protocol"].(string); strings.Contains(strings.ToUpper(protocol), "TWIRP") {
+	if strings.Contains(protocol, "TWIRP") {
 		appType = "twirp"
 	}
 

--- a/server/pkg/api/configuration_test.go
+++ b/server/pkg/api/configuration_test.go
@@ -156,6 +156,43 @@ func TestLoadGetConfigurationResponse_MigratesLegacyProjects(t *testing.T) {
 	}
 }
 
+func TestLoadGetConfigurationResponse_MigratesLegacyOpenApiProject(t *testing.T) {
+	// A legacy OpenAPI project keeps its spec document URL in "url"; it must migrate
+	// to an openapi app whose spec_url is set, not a gRPC app with no proto surface.
+	configContent := `{
+		"projects": [
+			{
+				"name": "theatre",
+				"protocol": "RPC_PROTOCOL_OPENAPI",
+				"url": "https://kaja.tools/theatre/openapi.yaml"
+			}
+		]
+	}`
+
+	tmpfile, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	configuration := LoadGetConfigurationResponse(tmpfile.Name(), false).Configuration
+	if len(configuration.Apps) != 1 {
+		t.Fatalf("expected 1 migrated app, got %d", len(configuration.Apps))
+	}
+
+	app := configuration.Apps[0]
+	appType, params := flattenApp(app)
+	if app.Name != "theatre" || appType != "openapi" {
+		t.Errorf("expected openapi app 'theatre', got %q/%q", app.Name, appType)
+	}
+	if params["spec_url"] != "https://kaja.tools/theatre/openapi.yaml" {
+		t.Errorf("expected spec_url to carry the document URL, got %v", params)
+	}
+}
+
 func TestUpdateConfiguration_DeniedWhenNotAllowed(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "config-*.json")
 	if err != nil {


### PR DESCRIPTION
A legacy `projects` entry with `RPC_PROTOCOL_OPENAPI` fell through to the gRPC branch in `legacyProjectToApp`, becoming a gRPC app with no proto surface — so the theatre service loaded no methods in the sidebar (visible on kaja.tools/demo).

- Migrate OpenAPI projects to an `openapi` app, mapping the project `url` to `spec_url`.
- Add a migration test covering the OpenAPI case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsM6xusVt7gggRwLYvgnef)_