### PR TITLE
Authenticated OpenAPI spec fetches and clarified login errors

### DIFF
--- a/server/pkg/apps/openapi/openapi.go
+++ b/server/pkg/apps/openapi/openapi.go
@@ -43,6 +43,7 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 			strings.TrimSpace(parameters["token"]),
 			strings.TrimSpace(parameters["username"]),
 			strings.TrimSpace(parameters["password"]),
+			log,
 		)
 	default:
 		return nil, fmt.Errorf("missing required parameter: provide %q or %q", "spec_url", "spec_content")
@@ -64,6 +65,7 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 
 	// Compile the generated proto to descriptors so invocations can decode the
 	// protobuf request and encode the protobuf response (the app is a gRPC app).
+	log("Compiling generated proto to descriptors")
 	methods, err := compileMethods(protoDir, gen)
 	if err != nil {
 		return nil, err

--- a/server/pkg/apps/openapi/openapi.go
+++ b/server/pkg/apps/openapi/openapi.go
@@ -39,7 +39,11 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 			return nil, err
 		}
 		log("Fetching OpenAPI spec from " + specURL)
-		s, err = loadSpec(specURL)
+		s, err = loadSpec(specURL,
+			strings.TrimSpace(parameters["token"]),
+			strings.TrimSpace(parameters["username"]),
+			strings.TrimSpace(parameters["password"]),
+		)
 	default:
 		return nil, fmt.Errorf("missing required parameter: provide %q or %q", "spec_url", "spec_content")
 	}

--- a/server/pkg/apps/openapi/openapi_test.go
+++ b/server/pkg/apps/openapi/openapi_test.go
@@ -1005,7 +1005,7 @@ paths:
 			}))
 			defer srv.Close()
 
-			s, err := loadSpec(srv.URL+"/openapi.yaml", tc.token, tc.user, tc.password)
+			s, err := loadSpec(srv.URL+"/openapi.yaml", tc.token, tc.user, tc.password, func(string) {})
 			if err != nil {
 				t.Fatalf("loadSpec: %v", err)
 			}
@@ -1030,12 +1030,18 @@ func TestLoadSpecReportsLoginRedirect(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "")
+	var logs []string
+	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "", func(m string) { logs = append(logs, m) })
 	if err == nil {
 		t.Fatal("expected an error for an unauthenticated fetch")
 	}
 	if !strings.Contains(err.Error(), "authentication") {
 		t.Errorf("error = %q, want it to mention authentication", err)
+	}
+	// The compile log should make the redirect diagnosable.
+	joined := strings.Join(logs, "\n")
+	if !strings.Contains(joined, "redirected to") || !strings.Contains(joined, "text/html") {
+		t.Errorf("logs did not surface the redirect/content-type: %q", joined)
 	}
 }
 
@@ -1047,9 +1053,28 @@ func TestLoadSpecReportsUnauthorizedStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "")
+	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "", func(string) {})
 	if err == nil || !strings.Contains(err.Error(), "authentication") {
 		t.Fatalf("error = %v, want it to mention authentication", err)
+	}
+}
+
+// TestLoadSpecNonYAMLErrorIncludesSnippet checks that a fetched-but-unparseable
+// non-HTML body surfaces its content type and a preview, so the log explains the
+// failure instead of a bare YAML error.
+func TestLoadSpecNonYAMLErrorIncludesSnippet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"error": "not found", "code": 404}`)
+	}))
+	defer srv.Close()
+
+	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "", func(string) {})
+	if err == nil {
+		t.Fatal("expected an error for a non-spec body")
+	}
+	if !strings.Contains(err.Error(), "application/json") || !strings.Contains(err.Error(), "starts with") {
+		t.Errorf("error = %q, want content type and preview", err)
 	}
 }
 

--- a/server/pkg/apps/openapi/openapi_test.go
+++ b/server/pkg/apps/openapi/openapi_test.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -970,6 +971,85 @@ paths:
 			}
 			assertJSONEq(t, decodeResponse(t, inst, svc+"/GetPetById", out), `{"id":1,"name":"Rex","tag":"dog"}`)
 		})
+	}
+}
+
+// TestLoadSpecSendsCredentials verifies the spec fetch authenticates: a URL that
+// serves the document only to an authenticated request must load when credentials
+// are supplied. Both a bearer token and HTTP Basic are exercised.
+func TestLoadSpecSendsCredentials(t *testing.T) {
+	spec := `openapi: 3.0.1
+info: {title: Guarded, version: "1"}
+servers: [{url: "https://api.example.com"}]
+paths:
+  /ping:
+    get:
+      responses:
+        "200": {description: OK}
+`
+	for _, tc := range []struct {
+		name, wantAuth        string
+		token, user, password string
+	}{
+		{name: "bearer", wantAuth: "Bearer secret-token", token: "secret-token"},
+		{name: "basic", wantAuth: "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass")), user: "user", password: "pass"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") != tc.wantAuth {
+					http.Redirect(w, r, "/signin", http.StatusFound)
+					return
+				}
+				w.Header().Set("Content-Type", "application/yaml")
+				io.WriteString(w, spec)
+			}))
+			defer srv.Close()
+
+			s, err := loadSpec(srv.URL+"/openapi.yaml", tc.token, tc.user, tc.password)
+			if err != nil {
+				t.Fatalf("loadSpec: %v", err)
+			}
+			if s.Info.Title != "Guarded" {
+				t.Errorf("title = %q", s.Info.Title)
+			}
+		})
+	}
+}
+
+// TestLoadSpecReportsLoginRedirect covers the real failure behind a misleading
+// YAML error: an unauthenticated fetch is redirected to an HTML sign-in page,
+// which must surface as an authentication error, not a parse error.
+func TestLoadSpecReportsLoginRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/signin" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			io.WriteString(w, "<!doctype html>\n<html><title>Sign in</title></html>")
+			return
+		}
+		http.Redirect(w, r, "/signin", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "")
+	if err == nil {
+		t.Fatal("expected an error for an unauthenticated fetch")
+	}
+	if !strings.Contains(err.Error(), "authentication") {
+		t.Errorf("error = %q, want it to mention authentication", err)
+	}
+}
+
+// TestLoadSpecReportsUnauthorizedStatus checks that a 401 spec response is
+// reported as an authentication problem.
+func TestLoadSpecReportsUnauthorizedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := loadSpec(srv.URL+"/openapi.yaml", "", "", "")
+	if err == nil || !strings.Contains(err.Error(), "authentication") {
+		t.Fatalf("error = %v, want it to mention authentication", err)
 	}
 }
 

--- a/server/pkg/apps/openapi/spec.go
+++ b/server/pkg/apps/openapi/spec.go
@@ -207,17 +207,28 @@ func textContent(content map[string]mediaType) bool {
 	return false
 }
 
-// loadSpec fetches and parses an OpenAPI document from a URL.
-func loadSpec(specURL string) (*spec, error) {
+// loadSpec fetches and parses an OpenAPI document from a URL, authenticating the
+// request with the user's credentials so specs served behind a login (e.g. a
+// tenant's /api/v2/openapi.yaml) can be read. The spec's own security schemes are
+// not known yet, so it falls back the same way invocations do: username/password
+// as HTTP Basic, otherwise a bearer token.
+func loadSpec(specURL, token, username, password string) (*spec, error) {
+	req, err := http.NewRequest(http.MethodGet, specURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching spec: %w", err)
+	}
+	req.Header.Set("Accept", "application/yaml, application/json, text/yaml, text/plain, */*")
+	applyFetchAuth(req, token, username, password)
+
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(specURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching spec: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetching spec: unexpected status %s", resp.Status)
+		return nil, specFetchError(specURL, resp)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
@@ -225,7 +236,49 @@ func loadSpec(specURL string) (*spec, error) {
 		return nil, fmt.Errorf("reading spec: %w", err)
 	}
 
-	return parseSpec(body)
+	s, err := parseSpec(body)
+	if err != nil {
+		// A server that gates the spec behind a login typically redirects to an
+		// HTML sign-in page, which the client follows to a 200; parsing that as
+		// YAML yields a misleading error, so name the real cause instead.
+		if isHTML(resp.Header.Get("Content-Type"), body) {
+			return nil, fmt.Errorf("spec URL %q returned an HTML page, not an OpenAPI document; it likely requires authentication (provide a token or username/password)", specURL)
+		}
+		return nil, err
+	}
+	return s, nil
+}
+
+// applyFetchAuth adds the user's credentials to a spec-fetch request. It mirrors
+// resolveAuth's no-scheme fallback since the spec is not parsed yet.
+func applyFetchAuth(req *http.Request, token, username, password string) {
+	switch {
+	case username != "" || password != "":
+		req.SetBasicAuth(username, password)
+	case token != "":
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+// specFetchError builds a helpful error for a non-200 spec response, calling out
+// authentication for the statuses that indicate it.
+func specFetchError(specURL string, resp *http.Response) error {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("fetching spec: %q returned %s; it requires authentication (provide a token or username/password)", specURL, resp.Status)
+	default:
+		return fmt.Errorf("fetching spec: unexpected status %s", resp.Status)
+	}
+}
+
+// isHTML reports whether a fetched spec response is actually an HTML document,
+// judged by content type and, failing that, the body's opening tag.
+func isHTML(contentType string, body []byte) bool {
+	if strings.Contains(strings.ToLower(contentType), "text/html") {
+		return true
+	}
+	head := strings.ToLower(strings.TrimSpace(string(body)))
+	return strings.HasPrefix(head, "<!doctype html") || strings.HasPrefix(head, "<html")
 }
 
 func parseSpec(body []byte) (*spec, error) {

--- a/server/pkg/apps/openapi/spec.go
+++ b/server/pkg/apps/openapi/spec.go
@@ -212,7 +212,7 @@ func textContent(content map[string]mediaType) bool {
 // tenant's /api/v2/openapi.yaml) can be read. The spec's own security schemes are
 // not known yet, so it falls back the same way invocations do: username/password
 // as HTTP Basic, otherwise a bearer token.
-func loadSpec(specURL, token, username, password string) (*spec, error) {
+func loadSpec(specURL, token, username, password string, log func(string)) (*spec, error) {
 	req, err := http.NewRequest(http.MethodGet, specURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("fetching spec: %w", err)
@@ -227,6 +227,14 @@ func loadSpec(specURL, token, username, password string) (*spec, error) {
 	}
 	defer resp.Body.Close()
 
+	contentType := resp.Header.Get("Content-Type")
+	log(fmt.Sprintf("Spec response: HTTP %d, Content-Type %q", resp.StatusCode, contentType))
+	if final := resp.Request.URL.String(); final != specURL {
+		// A redirect to a different location (typically a sign-in page) is the
+		// usual reason an authenticated spec ends up as unparseable HTML.
+		log("Request was redirected to " + final)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, specFetchError(specURL, resp)
 	}
@@ -235,18 +243,30 @@ func loadSpec(specURL, token, username, password string) (*spec, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading spec: %w", err)
 	}
+	log(fmt.Sprintf("Read %d bytes of spec", len(body)))
 
 	s, err := parseSpec(body)
 	if err != nil {
-		// A server that gates the spec behind a login typically redirects to an
-		// HTML sign-in page, which the client follows to a 200; parsing that as
-		// YAML yields a misleading error, so name the real cause instead.
-		if isHTML(resp.Header.Get("Content-Type"), body) {
+		// The response was fetched but is not a parseable OpenAPI document. Name
+		// what actually came back so the failure is diagnosable from the log
+		// instead of a cryptic YAML error against, e.g., an HTML sign-in page.
+		if isHTML(contentType, body) {
 			return nil, fmt.Errorf("spec URL %q returned an HTML page, not an OpenAPI document; it likely requires authentication (provide a token or username/password)", specURL)
 		}
-		return nil, err
+		return nil, fmt.Errorf("%w (Content-Type %q, starts with %q)", err, contentType, snippet(body))
 	}
 	return s, nil
+}
+
+// snippet returns a short, single-line preview of a fetched body for diagnostics.
+func snippet(body []byte) string {
+	const max = 120
+	s := strings.TrimSpace(string(body))
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", "")
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
 }
 
 // applyFetchAuth adds the user's credentials to a spec-fetch request. It mirrors

--- a/ui/src/appTypes.ts
+++ b/ui/src/appTypes.ts
@@ -108,7 +108,7 @@ export const appTypes: AppTypeDefinition[] = [
         type: "url",
         optional: true,
         placeholder: "https://petstore3.swagger.io/api/v3/openapi.json",
-        caption: "The OpenAPI 3.x document is converted into a service you can call like a gRPC or Twirp app.",
+        caption: "The OpenAPI 3.x document is converted into a service you can call like a gRPC or Twirp app. Credentials below are used to fetch it, so a spec behind a login can be read.",
       },
       {
         key: "specContent",
@@ -123,7 +123,7 @@ export const appTypes: AppTypeDefinition[] = [
         type: "text",
         optional: true,
         placeholder: "Token or API key",
-        caption: "Sent per the spec's security scheme: as a Bearer token, or as the named API key header/query/cookie.",
+        caption: "Sent per the spec's security scheme: as a Bearer token, or as the named API key header/query/cookie. Also used to fetch the spec URL.",
       },
       {
         key: "username",


### PR DESCRIPTION
Fetching an OpenAPI spec from a URL sent no credentials, so a spec behind a login (e.g. a tenant's `/api/v2/openapi.yaml`) redirected to an HTML sign-in page that got parsed as YAML — the misleading `mapping values are not allowed in this context` error. The fetch now sends the configured token/username/password, and a login redirect or 401/403 is reported as an authentication problem. The compile log also records the response status, content type, redirect, and size, and non-YAML responses report their content type with a preview, so this is diagnosable at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FY8itJxC8NUeaFQAmW8Yns