### PR TITLE
Dropped clsx and class-variance-authority from the UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ off `data-starting-style` / `data-ending-style`.
 ### Conventions
 
 - Icons: import from `lucide-react` directly, under lucide's own names (e.g. `Trash2`, `Ellipsis`, `PanelLeftClose`). Standalone icons take a numeric `size` prop; inside `IconButton` the size comes from the button. lucide ships no brand icons, so the GitHub mark is drawn inline in `StatusBar.tsx`.
-- Class names: compose with `cn()` from `ui/src/cn.ts` (clsx + tailwind-merge).
+- Class names: compose with `cn()` from `ui/src/cn.ts` (tailwind-merge over a plain join). The same file holds `cva()` for variant maps and `cnState()` for the Base UI parts whose `className` may be a function of the part's state.
 - Theme tokens: the shadcn CSS variables live in `ui/src/tailwind.css`. Style with Tailwind utilities (`bg-muted`, `text-muted-foreground`, `border-border`); reference the raw `var(--muted)` only where the markup isn't ours, i.e. the CSS overrides for Monaco's internal DOM. Day/night is a `dark` class toggled on `<html>` (so Base UI portals are themed too); Monaco is themed separately via `vs`/`vs-dark`.
 - Status colors beyond the tokens: warnings are `text-amber-600 dark:text-amber-400` over `bg-amber-500/10`, successes `text-emerald-600 dark:text-emerald-400` over `bg-emerald-500/10`, errors `text-destructive` over `bg-destructive/10`.
 - Tailwind build: `ui/src/tailwind.css` is compiled by the Tailwind CLI (run through `bun`) inside an esbuild `OnStart` plugin in `server/internal/ui/builder.go`; the generated `server/build/tailwind.css` is imported by `main.tsx` and folded into `main.css`.

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -10,8 +10,6 @@
         "@protobuf-ts/runtime-rpc": "^2.11.1",
         "@protobuf-ts/twirp-transport": "^2.11.1",
         "@tailwindcss/cli": "^4",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
         "lucide-react": "^1.25.0",
         "monaco-editor": "^0.55.1",
         "prettier": "^3.7.4",
@@ -132,10 +130,6 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
-
-    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,8 +11,6 @@
     "@protobuf-ts/runtime-rpc": "^2.11.1",
     "@protobuf-ts/twirp-transport": "^2.11.1",
     "@tailwindcss/cli": "^4",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "lucide-react": "^1.25.0",
     "monaco-editor": "^0.55.1",
     "prettier": "^3.7.4",

--- a/ui/src/cn.ts
+++ b/ui/src/cn.ts
@@ -1,6 +1,42 @@
-import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+export type ClassValue = string | false | null | undefined;
+
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(inputs.filter(Boolean).join(" "));
+}
+
+// Base UI lets `className` be a function of the part's state; keep that form
+// intact while merging our own classes in.
+export type StatefulClassName<S> = string | ((state: S) => string | undefined) | undefined;
+
+export function cnState<S>(base: string, className: StatefulClassName<S>) {
+  if (typeof className === "function") {
+    return (state: S) => cn(base, className(state));
+  }
+  return cn(base, className);
+}
+
+type Variants = Record<string, Record<string, string>>;
+
+type Selection<V extends Variants> = { [K in keyof V]?: keyof V[K] | null };
+
+interface VariantSelector<V extends Variants> {
+  (selection?: Selection<V> & { className?: ClassValue }): string;
+}
+
+export type VariantProps<T> = T extends VariantSelector<infer V> ? Selection<V> : never;
+
+export function cva<V extends Variants>(base: string, configuration: { variants: V; defaultVariants?: Selection<V> }): VariantSelector<V> {
+  return (selection) => {
+    const classes: ClassValue[] = [base];
+    for (const name of Object.keys(configuration.variants)) {
+      const value = selection?.[name] ?? configuration.defaultVariants?.[name];
+      if (value != null) {
+        classes.push(configuration.variants[name][value as string]);
+      }
+    }
+    classes.push(selection?.className);
+    return classes.filter(Boolean).join(" ");
+  };
 }

--- a/ui/src/components/alert.tsx
+++ b/ui/src/components/alert.tsx
@@ -1,7 +1,6 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cn, cva, type VariantProps } from "../cn";
 
 const alertVariants = cva("rounded-md border px-4 py-3 text-sm shadow-sm", {
   variants: {

--- a/ui/src/components/button.tsx
+++ b/ui/src/components/button.tsx
@@ -1,7 +1,6 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cn, cva, type VariantProps } from "../cn";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",

--- a/ui/src/components/checkbox.tsx
+++ b/ui/src/components/checkbox.tsx
@@ -2,13 +2,13 @@ import { Checkbox as BaseCheckbox } from "@base-ui-components/react/checkbox";
 import { Check } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cnState } from "../cn";
 
 const Checkbox = React.forwardRef<React.ElementRef<typeof BaseCheckbox.Root>, React.ComponentPropsWithoutRef<typeof BaseCheckbox.Root>>(
   ({ className, ...props }, ref) => (
     <BaseCheckbox.Root
       ref={ref}
-      className={cn(
+      className={cnState(
         "flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground",
         className,
       )}

--- a/ui/src/components/dropdown-menu.tsx
+++ b/ui/src/components/dropdown-menu.tsx
@@ -1,7 +1,7 @@
 import { Menu } from "@base-ui-components/react/menu";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cn, cnState } from "../cn";
 
 const DropdownMenu = Menu.Root;
 const DropdownMenuGroup = Menu.Group;
@@ -27,7 +27,7 @@ function DropdownMenuContent({ className, align = "center", side = "bottom", sid
     <Menu.Portal>
       <Menu.Positioner className="z-50 outline-none" align={align} side={side} sideOffset={sideOffset} anchor={anchor}>
         <Menu.Popup
-          className={cn(
+          className={cnState(
             "min-w-[10rem] origin-[var(--transform-origin)] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md transition-[transform,opacity] data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
             className,
           )}
@@ -49,9 +49,11 @@ function DropdownMenuItem({ className, variant = "default", onSelect, ...props }
   return (
     <Menu.Item
       onClick={() => onSelect?.()}
-      className={cn(
-        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:shrink-0",
-        variant === "danger" && "text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive",
+      className={cnState(
+        cn(
+          "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:shrink-0",
+          variant === "danger" && "text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive",
+        ),
         className,
       )}
       {...props}
@@ -60,11 +62,11 @@ function DropdownMenuItem({ className, variant = "default", onSelect, ...props }
 }
 
 function DropdownMenuSeparator({ className }: { className?: string }) {
-  return <Menu.Separator className={cn("-mx-1 my-1 h-px bg-border", className)} />;
+  return <Menu.Separator className={cnState("-mx-1 my-1 h-px bg-border", className)} />;
 }
 
 function DropdownMenuLabel({ className, ...props }: React.ComponentPropsWithoutRef<typeof Menu.GroupLabel>) {
-  return <Menu.GroupLabel className={cn("px-2 py-1.5 text-xs font-semibold text-muted-foreground", className)} {...props} />;
+  return <Menu.GroupLabel className={cnState("px-2 py-1.5 text-xs font-semibold text-muted-foreground", className)} {...props} />;
 }
 
 export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuLabel, DropdownMenuGroup };

--- a/ui/src/components/icon-button.tsx
+++ b/ui/src/components/icon-button.tsx
@@ -1,8 +1,7 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import type { LucideIcon } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cn, cva, type VariantProps } from "../cn";
 import { buttonVariants } from "./button";
 import { SimpleTooltip } from "./tooltip";
 

--- a/ui/src/components/popover.tsx
+++ b/ui/src/components/popover.tsx
@@ -1,7 +1,7 @@
 import { Popover as BasePopover } from "@base-ui-components/react/popover";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cnState } from "../cn";
 
 const Popover = BasePopover.Root;
 
@@ -23,7 +23,7 @@ function PopoverContent({ className, align = "center", side = "bottom", sideOffs
     <BasePopover.Portal>
       <BasePopover.Positioner className="z-50 outline-none" align={align} side={side} sideOffset={sideOffset}>
         <BasePopover.Popup
-          className={cn(
+          className={cnState(
             "origin-[var(--transform-origin)] rounded-md border border-border bg-popover text-popover-foreground shadow-md outline-none transition-[transform,opacity] data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
             className,
           )}

--- a/ui/src/components/select.tsx
+++ b/ui/src/components/select.tsx
@@ -2,7 +2,7 @@ import { Select as BaseSelect } from "@base-ui-components/react/select";
 import { Check, ChevronDown } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cnState } from "../cn";
 
 const Select = BaseSelect.Root;
 const SelectGroup = BaseSelect.Group;
@@ -15,7 +15,7 @@ const SelectTrigger = React.forwardRef<React.ElementRef<typeof BaseSelect.Trigge
   ({ className, children, ...props }, ref) => (
     <BaseSelect.Trigger
       ref={ref}
-      className={cn(
+      className={cnState(
         "flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
@@ -35,7 +35,7 @@ function SelectContent({ className, children, ...props }: React.ComponentPropsWi
     <BaseSelect.Portal>
       <BaseSelect.Positioner className="z-50 outline-none" sideOffset={4}>
         <BaseSelect.Popup
-          className={cn(
+          className={cnState(
             "max-h-96 min-w-[8rem] origin-[var(--transform-origin)] overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md transition-[transform,opacity] data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
             className,
           )}
@@ -49,7 +49,7 @@ function SelectContent({ className, children, ...props }: React.ComponentPropsWi
 }
 
 function SelectLabel({ className, ...props }: React.ComponentPropsWithoutRef<typeof BaseSelect.GroupLabel>) {
-  return <BaseSelect.GroupLabel className={cn("px-2 py-1.5 text-xs font-semibold text-muted-foreground", className)} {...props} />;
+  return <BaseSelect.GroupLabel className={cnState("px-2 py-1.5 text-xs font-semibold text-muted-foreground", className)} {...props} />;
 }
 
 interface SelectItemProps extends React.ComponentPropsWithoutRef<typeof BaseSelect.Item> {
@@ -59,7 +59,7 @@ interface SelectItemProps extends React.ComponentPropsWithoutRef<typeof BaseSele
 function SelectItem({ className, children, ...props }: SelectItemProps) {
   return (
     <BaseSelect.Item
-      className={cn(
+      className={cnState(
         "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}

--- a/ui/src/components/spinner.tsx
+++ b/ui/src/components/spinner.tsx
@@ -1,7 +1,6 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cn, cva, type VariantProps } from "../cn";
 
 const spinnerVariants = cva("animate-spin text-muted-foreground", {
   variants: {

--- a/ui/src/components/switch.tsx
+++ b/ui/src/components/switch.tsx
@@ -1,13 +1,13 @@
 import { Switch as BaseSwitch } from "@base-ui-components/react/switch";
 import * as React from "react";
 
-import { cn } from "../cn";
+import { cnState } from "../cn";
 
 const Switch = React.forwardRef<React.ElementRef<typeof BaseSwitch.Root>, React.ComponentPropsWithoutRef<typeof BaseSwitch.Root>>(
   ({ className, ...props }, ref) => (
     <BaseSwitch.Root
       ref={ref}
-      className={cn(
+      className={cnState(
         "inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary data-[unchecked]:bg-input",
         className,
       )}


### PR DESCRIPTION
Both packages were small enough to inline into `ui/src/cn.ts`, so the UI now depends on two fewer npm packages. Narrowing `cn()`'s `ClassValue` also surfaced ten Base UI wrappers whose `className` may be a state function — clsx accepted those types and silently dropped them at runtime, so they now go through a small `cnState()` helper that keeps the function form.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVomasf7RgMyby6A1osmcd)_