### PR TITLE
Fixed the provisioning profile permissions in the app bundle

### DIFF
--- a/scripts/testflight
+++ b/scripts/testflight
@@ -178,6 +178,9 @@ fi
 echo ""
 echo "--- Signing and packaging"
 cp "$PROVISION_PROFILE_PATH" "$APP_BUNDLE/Contents/embedded.provisionprofile"
+# cp carries over mktemp's 0600, and the App Store rejects a package whose
+# files are not readable by non-root users.
+chmod 644 "$APP_BUNDLE/Contents/embedded.provisionprofile"
 
 # The App Store rejects packages whose files carry quarantine attributes.
 # Must run before signing so the clean state is sealed in.


### PR DESCRIPTION
The profile is copied from a `mktemp` file, so it landed in the bundle as 0600 and the App Store rejected the upload with error 90255. Chmod it to 644 after the copy.

---
_Generated by [Claude Code](https://claude.com/claude-code)_