### PR TITLE
Gave the response room and made calls readable at a glance

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,13 +1,12 @@
 import { useMediaQuery } from "./useMediaQuery";
 import { Alert } from "./components/alert";
-import { Button } from "./components/button";
 import { ConfirmationDialog } from "./components/confirmation-dialog";
 import { Dialog } from "./components/dialog";
 import { FormControl } from "./components/form-control";
 import { IconButton } from "./components/icon-button";
 import { Input } from "./components/input";
 import { SimpleTooltip } from "./components/tooltip";
-import { Columns2, MessagesSquare, Rows2, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { Columns2, Rows2, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import * as monaco from "monaco-editor";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Console, ConsoleItem } from "./Console";
@@ -25,6 +24,7 @@ import { StatusBar, ColorMode } from "./StatusBar";
 import { FeaturePreview } from "./FeaturePreviews";
 import { AppForm } from "./AppForm";
 import { registerKajaModule } from "./Editor";
+import { monacoTheme } from "./monacoTheme";
 import { remapEditorCode, remapSourcesToNewName } from "./sources";
 import { Configuration, ConfigurationApp, LogLevel } from "./server/api";
 import { getApiClient } from "./server/connection";
@@ -57,7 +57,7 @@ import { setVariables, variableReferences } from "./variableExpansion";
 import { flushPersistedWrites, getPersistedValue, setPersistedValue } from "./storage";
 import { FirstAppBlankslate } from "./FirstAppBlankslate";
 import { isWailsEnvironment } from "./wails";
-import { BrowserOpenURL, EventsEmit, EventsOn, WindowSetTitle } from "./wailsjs/runtime";
+import { EventsEmit, EventsOn, WindowSetTitle } from "./wailsjs/runtime";
 import {
   CreateScript,
   DeleteScript,
@@ -75,6 +75,18 @@ import { runTask, runTaskCaptured } from "./taskRunner";
 
 // Maximum number of console items kept in memory; older calls are dropped.
 const MAX_CONSOLE_ITEMS = 500;
+
+// Height of the tab strip sitting above the editor, part of the editor pane.
+const TAB_STRIP_HEIGHT = 35;
+// Vertical padding the editor reserves around the code (see Editor.tsx).
+const EDITOR_PADDING = 32;
+// Bounds for the editor pane in the top-bottom layout. The maximum is a share of
+// the window so a long script can't push the response off screen.
+const MIN_EDITOR_HEIGHT = 120;
+const MAX_EDITOR_HEIGHT_RATIO = 0.55;
+// Above this window width the editor and the response fit side by side, which
+// suits the wide, short shape of a method call better than stacking them.
+const SIDE_BY_SIDE_MIN_WIDTH = 1200;
 
 // Lowercase the first letter (e.g. method name "GetUser" -> "getUser").
 function lowerFirst(s: string): string {
@@ -126,8 +138,18 @@ export function App() {
   const sidebarCollapsedRef = useRef(sidebarCollapsed);
   sidebarCollapsedRef.current = sidebarCollapsed;
   const [editorHeight, setEditorHeight] = usePersistedState("editorHeight", 400);
+  // Until the gutter is dragged, the editor pane is sized to the code it holds
+  // rather than to a fixed split — a three-line call shouldn't reserve half the
+  // window. Dragging switches to the manual editorHeight for good.
+  const [editorHeightAuto, setEditorHeightAuto] = usePersistedState("editorHeightAuto", true);
+  const editorHeightAutoRef = useRef(editorHeightAuto);
+  editorHeightAutoRef.current = editorHeightAuto;
+  const [editorContentHeights, setEditorContentHeights] = useState<{ [tabId: string]: number }>({});
+  const [windowHeight, setWindowHeight] = useState(() => window.innerHeight);
   const [editorWidth, setEditorWidth] = usePersistedState("editorWidth", 600);
-  const [editorLayout, setEditorLayout] = usePersistedState<"vertical" | "horizontal">("editorLayout", "vertical");
+  const [editorLayout, setEditorLayout] = usePersistedState<"vertical" | "horizontal">("editorLayout", () =>
+    window.innerWidth >= SIDE_BY_SIDE_MIN_WIDTH ? "horizontal" : "vertical",
+  );
   const [colorMode, setColorMode] = usePersistedState<ColorMode>("colorMode", "night");
   const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([]);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -233,8 +255,18 @@ export function App() {
     setConsoleItems([]);
   }, []);
 
+  // Kept in sync during render so the first drag can pick up wherever the gutter
+  // currently sits instead of jumping to the stale manual height.
+  const effectiveEditorHeightRef = useRef(editorHeight);
+
   const onEditorResize = useCallback((delta: number) => {
-    setEditorHeight((height) => Math.max(100, height + delta));
+    if (editorHeightAutoRef.current) {
+      editorHeightAutoRef.current = false;
+      setEditorHeightAuto(false);
+      setEditorHeight(Math.max(MIN_EDITOR_HEIGHT, effectiveEditorHeightRef.current + delta));
+      return;
+    }
+    setEditorHeight((height) => Math.max(MIN_EDITOR_HEIGHT, height + delta));
   }, []);
 
   const onEditorWidthResize = useCallback((delta: number) => {
@@ -519,7 +551,7 @@ export function App() {
   useConfigurationChanges(handleConfigurationFileChange);
 
   useEffect(() => {
-    monaco.editor.setTheme(colorMode === "night" ? "vs-dark" : "vs");
+    monaco.editor.setTheme(monacoTheme(colorMode));
     document.body.style.backgroundColor = colorMode === "night" ? "#0d1117" : "#ffffff";
     // Drive the shadcn theme tokens. The class goes on <html> so Radix portals
     // (rendered into <body>) are themed too.
@@ -558,6 +590,12 @@ export function App() {
   useEffect(() => {
     refreshScripts();
   }, [refreshScripts]);
+
+  useEffect(() => {
+    const onResize = () => setWindowHeight(window.innerHeight);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   // Global keyboard shortcuts
   useEffect(() => {
@@ -1124,10 +1162,28 @@ export function App() {
     persistTabs();
   };
 
+  // Track how tall each open editor's code is so the pane can be sized to it.
+  // Derived from the line count rather than Monaco's content height: with
+  // scrollBeyondLastLine on, content height grows with the editor itself, so
+  // feeding it back into the pane height would only ever settle at the maximum.
+  // The listeners belong to the editor and go away when the editor is disposed.
+  const onEditorReady = useCallback((tabId: string, editorInstance: monaco.editor.IStandaloneCodeEditor) => {
+    editorRegistryRef.current.set(tabId, editorInstance);
+    const report = () => {
+      const lineHeight = editorInstance.getOption(monaco.editor.EditorOption.lineHeight);
+      const height = (editorInstance.getModel()?.getLineCount() ?? 1) * lineHeight + EDITOR_PADDING;
+      setEditorContentHeights((heights) => (heights[tabId] === height ? heights : { ...heights, [tabId]: height }));
+    };
+    report();
+    editorInstance.onDidChangeModelContent(report);
+    editorInstance.onDidChangeModel(report);
+  }, []);
+
   const disposeTabEditor = (tab: TabModel) => {
     if (tab.type === "task" || tab.type === "script") {
       flushScriptTab(tab);
       editorRegistryRef.current.delete(tab.id);
+      setEditorContentHeights(({ [tab.id]: _removed, ...rest }) => rest);
       tab.model.dispose();
     }
   };
@@ -1369,6 +1425,17 @@ export function App() {
   const isHorizontalLayout = editorLayout === "horizontal" && isActiveTaskTab;
   const activeScriptPath = activeTab?.type === "script" ? activeTab.script.path : undefined;
 
+  const activeEditorContentHeight = activeTab?.type === "task" || activeTab?.type === "script" ? editorContentHeights[activeTab.id] : undefined;
+  const autoEditorHeight =
+    activeEditorContentHeight === undefined
+      ? undefined
+      : Math.min(
+          Math.max(activeEditorContentHeight + TAB_STRIP_HEIGHT, MIN_EDITOR_HEIGHT),
+          Math.max(MIN_EDITOR_HEIGHT, Math.round(windowHeight * MAX_EDITOR_HEIGHT_RATIO)),
+        );
+  const effectiveEditorHeight = editorHeightAuto && autoEditorHeight !== undefined ? autoEditorHeight : editorHeight;
+  effectiveEditorHeightRef.current = effectiveEditorHeight;
+
   return (
     <>
       <div
@@ -1429,22 +1496,6 @@ export function App() {
                 >
                   {navigator.platform.startsWith("Mac") ? "⌘K" : "Ctrl+K"} to search
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    const url = "https://github.com/wham/kaja/issues/new?template=feedback.yml";
-                    if (isWailsEnvironment()) {
-                      BrowserOpenURL(url);
-                    } else {
-                      window.open(url, "_blank");
-                    }
-                  }}
-                  className="text-xs text-muted-foreground"
-                >
-                  <MessagesSquare size={16} />
-                  Feedback
-                </Button>
               </div>
               <div
                 style={
@@ -1494,7 +1545,7 @@ export function App() {
               <div style={{ flex: 1, display: "flex", flexDirection: isHorizontalLayout ? "row" : "column", minHeight: 0 }}>
                 <div
                   style={{
-                    height: isActiveTaskTab && !isHorizontalLayout ? editorHeight : undefined,
+                    height: isActiveTaskTab && !isHorizontalLayout ? effectiveEditorHeight : undefined,
                     width: isActiveTaskTab && isHorizontalLayout ? editorWidth : undefined,
                     flexGrow: isActiveTaskTab ? 0 : 1,
                     flexShrink: 0,
@@ -1528,7 +1579,7 @@ export function App() {
                             <Task
                               model={tab.model}
                               onGoToDefinition={onGoToDefinition}
-                              onEditorReady={(editor) => editorRegistryRef.current.set(tab.id, editor)}
+                              onEditorReady={(editor) => onEditorReady(tab.id, editor)}
                               viewState={tab.viewState}
                             />
                           </Tab>
@@ -1541,7 +1592,7 @@ export function App() {
                             <Task
                               model={tab.model}
                               onGoToDefinition={onGoToDefinition}
-                              onEditorReady={(editor) => editorRegistryRef.current.set(tab.id, editor)}
+                              onEditorReady={(editor) => onEditorReady(tab.id, editor)}
                               viewState={tab.viewState}
                             />
                           </Tab>
@@ -1608,7 +1659,7 @@ export function App() {
                         flexDirection: "column",
                       }}
                     >
-                      <Console items={consoleItems} onClear={onClearConsole} colorMode={colorMode} />
+                      <Console items={consoleItems} onClear={onClearConsole} />
                     </div>
                   </>
                 )}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -85,8 +85,11 @@ const EDITOR_PADDING = 32;
 const MIN_EDITOR_HEIGHT = 120;
 const MAX_EDITOR_HEIGHT_RATIO = 0.55;
 // Above this window width the editor and the response fit side by side, which
-// suits the wide, short shape of a method call better than stacking them.
-const SIDE_BY_SIDE_MIN_WIDTH = 1200;
+// suits the wide, short shape of a method call better than stacking them. Side
+// by side splits the window four ways — sidebar, editor, call list, response —
+// so the threshold has to leave the response a usable share of it; below this,
+// stacking gives it the full width instead.
+const SIDE_BY_SIDE_MIN_WIDTH = 1600;
 
 // Lowercase the first letter (e.g. method name "GetUser" -> "getUser").
 function lowerFirst(s: string): string {

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -17,10 +17,9 @@ const consoleTabActiveClass = "border-b-primary text-foreground";
 interface ConsoleProps {
   items: ConsoleItem[];
   onClear?: () => void;
-  colorMode?: "day" | "night";
 }
 
-export function Console({ items, onClear, colorMode = "night" }: ConsoleProps) {
+export function Console({ items, onClear }: ConsoleProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<"request" | "response" | "headers">("response");
   const [callListWidth, setCallListWidth] = useState(300);
@@ -139,16 +138,11 @@ export function Console({ items, onClear, colorMode = "night" }: ConsoleProps) {
 
         <Gutter orientation="vertical" onResize={onCallListResize} />
 
-        {/* Right panel - Details */}
-        <div className="flex min-w-0 flex-1 flex-col">
+        {/* Right panel - Details. Elevated to the same surface as the editor:
+            payloads are content, the call list and headers around them are chrome. */}
+        <div className="flex min-w-0 flex-1 flex-col bg-muted">
           {selectedMethodCall ? (
-            <Console.DetailContent
-              methodCall={selectedMethodCall}
-              activeTab={activeTab}
-              onTabChange={setActiveTab}
-              colorMode={colorMode}
-              jsonViewerRef={jsonViewerRef}
-            />
+            <Console.DetailContent methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} jsonViewerRef={jsonViewerRef} />
           ) : (
             <div className="flex flex-1 items-center justify-center gap-1.5 text-xs text-muted-foreground">
               Press <Play size={12} /> to run
@@ -193,17 +187,9 @@ interface MethodCallRowProps {
 // Memoized so the per-second timestamp tick only re-renders rows whose displayed
 // relative time actually changed, instead of every row on every tick.
 Console.MethodCallRow = memo(function MethodCallRow({ methodCall, index, isSelected, onSelect, relativeTime }: MethodCallRowProps) {
-  const isStreaming = methodCall.streamOutputs !== undefined;
-  const isStreamActive = isStreaming && !methodCall.streamComplete && !methodCall.error;
-
-  const status = methodCall.error ? "error" : isStreamActive ? "streaming" : methodCall.output ? "success" : "pending";
-
-  const statusClass = {
-    pending: "text-muted-foreground",
-    streaming: "text-primary",
-    success: "text-emerald-600 dark:text-emerald-400",
-    error: "text-destructive",
-  }[status];
+  const status = callStatus(methodCall);
+  const errorCode = callErrorCode(methodCall);
+  const duration = formatDuration(methodCall.durationMs);
 
   const statusIcon = {
     pending: "○",
@@ -213,9 +199,16 @@ Console.MethodCallRow = memo(function MethodCallRow({ methodCall, index, isSelec
   }[status];
 
   return (
-    <div data-testid="console-row" className={cn(consoleRowClass, isSelected ? "bg-accent" : "hover:bg-accent/50")} onClick={() => onSelect(index)}>
-      <span className={cn("mr-2 text-[10px]", statusClass)}>{statusIcon}</span>
+    <div
+      data-testid="console-row"
+      className={cn(consoleRowClass, isSelected ? "bg-accent" : "hover:bg-accent/50")}
+      onClick={() => onSelect(index)}
+      title={new Date(methodCall.timestamp).toLocaleTimeString()}
+    >
+      <span className={cn("mr-2 text-[10px]", statusClass(status))}>{statusIcon}</span>
       <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-foreground">{methodId(methodCall.service, methodCall.method)}</span>
+      {errorCode && <span className="ml-2 shrink-0 overflow-hidden text-ellipsis text-[10px] font-medium text-destructive">{errorCode}</span>}
+      {duration && <span className="ml-2 shrink-0 text-[11px] tabular-nums text-muted-foreground">{duration}</span>}
       <span className="ml-2 shrink-0 text-[11px] text-muted-foreground">{relativeTime}</span>
     </div>
   );
@@ -255,11 +248,10 @@ interface DetailContentProps {
   methodCall: MethodCall;
   activeTab: ConsoleTab;
   onTabChange: (tab: ConsoleTab) => void;
-  colorMode?: "day" | "night";
   jsonViewerRef: React.MutableRefObject<JsonViewerHandle | null>;
 }
 
-Console.DetailContent = function ({ methodCall, activeTab, onTabChange, colorMode = "night", jsonViewerRef }: DetailContentProps) {
+Console.DetailContent = function ({ methodCall, activeTab, onTabChange, jsonViewerRef }: DetailContentProps) {
   const isStreaming = methodCall.streamOutputs !== undefined;
   const hasResponse = methodCall.output !== undefined || methodCall.error !== undefined || (isStreaming && methodCall.streamOutputs!.length > 0);
   const hasError = methodCall.error !== undefined;
@@ -293,11 +285,41 @@ Console.DetailContent = function ({ methodCall, activeTab, onTabChange, colorMod
         <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Waiting for response...</div>
       ) : (
         <>
+          {activeTab === "response" && <Console.ResponseSummary methodCall={methodCall} content={content} rawText={rawText} />}
           {activeTab === "response" && hasError && methodCall.url && (
             <div className="border-b border-border bg-destructive/10 px-3 py-1.5 font-mono text-xs text-destructive">POST {methodCall.url}</div>
           )}
-          <JsonViewer ref={jsonViewerRef} value={content} rawText={rawText} colorMode={colorMode} />
+          <JsonViewer ref={jsonViewerRef} value={content} rawText={rawText} />
         </>
+      )}
+    </div>
+  );
+};
+
+interface ResponseSummaryProps {
+  methodCall: MethodCall;
+  content: unknown;
+  rawText?: string;
+}
+
+// A one-line readout above the payload: what came back, how long it took and how
+// big it is. Without it a successful call and an empty one look the same.
+Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSummaryProps) {
+  const status = callStatus(methodCall);
+  const label = { pending: "Pending", streaming: "Streaming", success: "OK", error: callErrorCode(methodCall) ?? "Error" }[status];
+  const duration = formatDuration(methodCall.durationMs);
+  const size = formatBytes(payloadBytes(content, rawText));
+  const streamCount = methodCall.streamOutputs?.length;
+
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-border px-3 py-1 font-mono text-[11px]">
+      <span className={cn("font-medium", statusClass(status))}>{label}</span>
+      {duration && <span className="tabular-nums text-muted-foreground">{duration}</span>}
+      {size && <span className="tabular-nums text-muted-foreground">{size}</span>}
+      {streamCount !== undefined && (
+        <span className="text-muted-foreground">
+          {streamCount} {streamCount === 1 ? "message" : "messages"}
+        </span>
       )}
     </div>
   );
@@ -378,6 +400,56 @@ Console.HeadersTable = function ({ headers }: HeadersTableProps) {
   );
 };
 
+type CallStatus = "pending" | "streaming" | "success" | "error";
+
+function callStatus(methodCall: MethodCall): CallStatus {
+  if (methodCall.error) return "error";
+  const isStreaming = methodCall.streamOutputs !== undefined;
+  if (isStreaming && !methodCall.streamComplete) return "streaming";
+  return methodCall.output ? "success" : "pending";
+}
+
+function statusClass(status: CallStatus): string {
+  return {
+    pending: "text-muted-foreground",
+    streaming: "text-primary",
+    success: "text-emerald-600 dark:text-emerald-400",
+    error: "text-destructive",
+  }[status];
+}
+
+// gRPC and Twirp errors carry a status code (e.g. "INVALID_ARGUMENT"); anything
+// else just shows as a plain error.
+function callErrorCode(methodCall: MethodCall): string | undefined {
+  const code = methodCall.error?.code;
+  return typeof code === "string" && code.length > 0 && code.length <= 24 ? code : undefined;
+}
+
+function formatDuration(durationMs?: number): string | undefined {
+  if (durationMs === undefined) return undefined;
+  return durationMs < 1000 ? `${durationMs} ms` : `${(durationMs / 1000).toFixed(durationMs < 10000 ? 2 : 1)} s`;
+}
+
+function payloadBytes(content: unknown, rawText?: string): number | undefined {
+  let text = rawText;
+  if (text === undefined) {
+    if (content === undefined) return undefined;
+    try {
+      text = JSON.stringify(content);
+    } catch {
+      return undefined;
+    }
+  }
+  return text === undefined ? undefined : new TextEncoder().encode(text).length;
+}
+
+function formatBytes(bytes?: number): string | undefined {
+  if (bytes === undefined) return undefined;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 function labelForLogLevel(level: LogLevel): string {
   switch (level) {
     case LogLevel.LEVEL_DEBUG:
@@ -404,17 +476,15 @@ function classForLogLevel(level: LogLevel): string {
   }
 }
 
+// Kept short so the row still has room for the status and duration; the row's
+// tooltip carries the exact time.
 function formatRelativeTime(timestamp: number, now: number): string {
   const seconds = Math.floor((now - timestamp) / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds} seconds ago`;
+  if (seconds < 5) return "now";
+  if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
-  if (minutes === 1) return "1 minute ago";
-  if (minutes < 60) return `${minutes} minutes ago`;
+  if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
-  if (hours === 1) return "1 hour ago";
-  if (hours < 24) return `${hours} hours ago`;
-  const days = Math.floor(hours / 24);
-  if (days === 1) return "1 day ago";
-  return `${days} days ago`;
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
 }

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -312,12 +312,12 @@ Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSu
   const streamCount = methodCall.streamOutputs?.length;
 
   return (
-    <div className="flex shrink-0 items-center gap-3 border-b border-border px-3 py-1 font-mono text-[11px]">
-      <span className={cn("font-medium", statusClass(status))}>{label}</span>
-      {duration && <span className="tabular-nums text-muted-foreground">{duration}</span>}
-      {size && <span className="tabular-nums text-muted-foreground">{size}</span>}
+    <div className="flex shrink-0 items-center gap-3 overflow-hidden whitespace-nowrap border-b border-border px-3 py-1 font-mono text-[11px]">
+      <span className={cn("shrink-0 font-medium", statusClass(status))}>{label}</span>
+      {duration && <span className="shrink-0 tabular-nums text-muted-foreground">{duration}</span>}
+      {size && <span className="shrink-0 tabular-nums text-muted-foreground">{size}</span>}
       {streamCount !== undefined && (
-        <span className="text-muted-foreground">
+        <span className="shrink-0 text-muted-foreground">
           {streamCount} {streamCount === 1 ? "message" : "messages"}
         </span>
       )}

--- a/ui/src/JsonViewer.tsx
+++ b/ui/src/JsonViewer.tsx
@@ -1,11 +1,33 @@
 import * as monaco from "monaco-editor";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { formatJson } from "./formatter";
+import "./monacoTheme";
+
+// A private language rather than the built-in "json" one: that language is wired
+// to the JSON language service, which validates every JSON model against the app
+// configuration schema (see AppForm) and would flag responses as errors. Only
+// tokenization is needed here, and it runs on the main thread — no worker.
+const LANGUAGE_ID = "kaja-json";
+
+monaco.languages.register({ id: LANGUAGE_ID });
+monaco.languages.setMonarchTokensProvider(LANGUAGE_ID, {
+  tokenizer: {
+    root: [
+      [/"(?:[^"\\]|\\.)*"(?=\s*:)/, "string.key.json"],
+      [/"(?:[^"\\]|\\.)*"/, "string.value.json"],
+      [/-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?/, "number.json"],
+      [/\b(?:true|false|null)\b/, "keyword.json"],
+      [/[{}]/, "delimiter.bracket.json"],
+      [/[[\]]/, "delimiter.array.json"],
+      [/:/, "delimiter.colon.json"],
+      [/,/, "delimiter.comma.json"],
+    ],
+  },
+});
 
 interface JsonViewerProps {
   value: any;
   rawText?: string;
-  colorMode?: "day" | "night";
 }
 
 export interface JsonViewerHandle {
@@ -14,7 +36,7 @@ export interface JsonViewerHandle {
   copyToClipboard: () => void;
 }
 
-export const JsonViewer = forwardRef<JsonViewerHandle, JsonViewerProps>(function JsonViewer({ value, rawText, colorMode = "night" }, ref) {
+export const JsonViewer = forwardRef<JsonViewerHandle, JsonViewerProps>(function JsonViewer({ value, rawText }, ref) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [jsonText, setJsonText] = useState("");
@@ -44,8 +66,7 @@ export const JsonViewer = forwardRef<JsonViewerHandle, JsonViewerProps>(function
 
     editorRef.current = monaco.editor.create(containerRef.current, {
       value: jsonText,
-      language: "javascript", // Use JS instead of JSON to avoid worker errors (JSON is valid JS)
-      theme: colorMode === "night" ? "vs-dark" : "vs",
+      language: LANGUAGE_ID,
       automaticLayout: true,
       // Read-only configuration
       readOnly: true,
@@ -117,17 +138,15 @@ export const JsonViewer = forwardRef<JsonViewerHandle, JsonViewerProps>(function
 
   return (
     <div className="relative h-full">
-      {colorMode === "night" && (
-        <style>{`
-          .json-viewer-container .monaco-editor,
-          .json-viewer-container .monaco-editor-background,
-          .json-viewer-container .monaco-editor .margin {
-            background-color: var(--background) !important;
-          }
-        `}</style>
-      )}
+      <style>{`
+        .json-viewer-container .monaco-editor,
+        .json-viewer-container .monaco-editor-background,
+        .json-viewer-container .monaco-editor .margin {
+          background-color: var(--muted) !important;
+        }
+      `}</style>
       {/* Editor */}
-      <div ref={containerRef} className="json-viewer-container h-full" />
+      <div ref={containerRef} className="json-viewer-container h-full bg-muted" />
     </div>
   );
 });

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Moon, Sun, Plug } from "lucide-react";
+import { MessagesSquare, Moon, Sun, Plug } from "lucide-react";
 import { Button } from "./components/button";
 import { IconButton } from "./components/icon-button";
 import { Popover, PopoverContent, PopoverTrigger } from "./components/popover";
@@ -127,6 +127,15 @@ function MCPError({ message }: { message: string }) {
   return <IconButton size="xs" variant="ghost" tooltip={false} icon={Plug} aria-label={message} className="text-destructive" />;
 }
 
+function openFeedback() {
+  const url = "https://github.com/wham/kaja/issues/new?template=feedback.yml";
+  if (isWailsEnvironment()) {
+    BrowserOpenURL(url);
+  } else {
+    window.open(url, "_blank");
+  }
+}
+
 export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, featurePreviews, onToggleFeaturePreview, mcpInfo }: StatusBarProps) {
   const shortRef = gitRef ? (gitRef.length > 7 ? gitRef.slice(0, 7) : gitRef) : undefined;
   const githubUrl = gitRef ? `https://github.com/wham/kaja/tree/${gitRef}` : undefined;
@@ -160,6 +169,7 @@ export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, f
       <div className="flex items-center gap-0.5">
         {mcpInfo?.enabled && mcpInfo.url && <MCPStatus info={mcpInfo} />}
         {mcpInfo?.error && <MCPError message={mcpInfo.error} />}
+        <IconButton size="xs" variant="ghost" icon={MessagesSquare} aria-label="Feedback" onClick={openFeedback} />
         <FeaturePreviews features={featurePreviews} onToggle={onToggleFeaturePreview} />
         <IconButton
           size="xs"

--- a/ui/src/Tabs.tsx
+++ b/ui/src/Tabs.tsx
@@ -137,8 +137,8 @@ export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onClos
                 role="tab"
                 aria-selected={isActive}
                 className={cn(
-                  "group box-border flex h-[35px] shrink-0 cursor-pointer items-center border-r border-t border-r-border border-t-transparent border-b pl-4 pr-2.5 text-sm hover:bg-accent",
-                  isActive ? "border-t-primary border-b-transparent bg-muted" : "border-b-border",
+                  "group box-border flex h-[35px] shrink-0 cursor-pointer items-center border-b border-r border-t-2 border-r-border border-t-transparent pl-4 pr-2.5 text-sm hover:bg-accent",
+                  isActive ? "border-b-transparent border-t-primary bg-muted" : "border-b-border bg-background",
                 )}
                 onClick={() => onSelectTab(index)}
                 onContextMenu={(e) => handleContextMenu(e, index)}

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -120,6 +120,9 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
       };
       client.kaja?._internal.methodCallUpdate(methodCall);
 
+      const startedAt = performance.now();
+      const elapsed = () => Math.round(performance.now() - startedAt);
+
       try {
         const call = clientStub[lcfirst(method.name)](input, options);
 
@@ -137,11 +140,13 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
             client.kaja?._internal.methodCallUpdate(methodCall);
           }
           methodCall.streamComplete = true;
+          methodCall.durationMs = elapsed();
 
           const [headers, trailers] = await Promise.all([streamCall.headers, streamCall.trailers]);
           collectResponseHeaders(methodCall, headers, trailers);
         } else {
           const [response, headers, trailers] = await Promise.all([call.response, call.headers, call.trailers]);
+          methodCall.durationMs = elapsed();
           methodCall.output = response;
           methodCall.inputTypeName = call.method?.I?.typeName;
           methodCall.inputType = call.method?.I;
@@ -152,6 +157,7 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
           collectResponseHeaders(methodCall, headers, trailers);
         }
       } catch (error: any) {
+        methodCall.durationMs = elapsed();
         methodCall.error = serializeError(error);
         applyUpstreamHeadersFromError(methodCall, error);
       }

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -79,6 +79,9 @@ export interface MethodCall {
   upstreamResponseHeaders?: MethodCallHeaders;
   url?: string;
   timestamp: number;
+  // Wall-clock time the call took, set once it succeeds, fails, or its stream
+  // completes. Undefined while still in flight.
+  durationMs?: number;
 }
 
 export interface MethodCallUpdate {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
+import { monacoTheme } from "./monacoTheme";
 import { getPersistedValue, initializeStorage } from "./storage";
 import { installUiLog } from "./uiLog";
 
@@ -14,7 +15,7 @@ installUiLog();
 
 initializeStorage().then(() => {
   const colorMode = getPersistedValue<"day" | "night">("colorMode") ?? "night";
-  monaco.editor.setTheme(colorMode === "night" ? "vs-dark" : "vs");
+  monaco.editor.setTheme(monacoTheme(colorMode));
   document.body.style.backgroundColor = colorMode === "night" ? "#0d1117" : "#ffffff";
   document.documentElement.classList.toggle("dark", colorMode === "night");
 

--- a/ui/src/monacoTheme.ts
+++ b/ui/src/monacoTheme.ts
@@ -1,0 +1,38 @@
+import * as monaco from "monaco-editor";
+
+// Monaco resolves themes globally, so the response palette has to live in the
+// app-wide theme. The rules below only name JSON tokens, which the TypeScript
+// editors never emit, so those keep the stock vs / vs-dark colors.
+//
+// Keys, strings, numbers and literals each get their own hue, and none of them
+// is red: red is reserved for actual error states (failed calls, the response
+// status line, the error banner).
+const jsonRules = {
+  dark: [
+    { token: "string.key.json", foreground: "9CDCFE" },
+    { token: "string.value.json", foreground: "9DDFA6" },
+    { token: "number.json", foreground: "D9B48F" },
+    { token: "keyword.json", foreground: "C4A2E8" },
+    { token: "delimiter.bracket.json", foreground: "8B8B8B" },
+    { token: "delimiter.array.json", foreground: "8B8B8B" },
+    { token: "delimiter.colon.json", foreground: "8B8B8B" },
+    { token: "delimiter.comma.json", foreground: "8B8B8B" },
+  ],
+  light: [
+    { token: "string.key.json", foreground: "0B5FA5" },
+    { token: "string.value.json", foreground: "1F7A3D" },
+    { token: "number.json", foreground: "8A5000" },
+    { token: "keyword.json", foreground: "6F42C1" },
+    { token: "delimiter.bracket.json", foreground: "6E7781" },
+    { token: "delimiter.array.json", foreground: "6E7781" },
+    { token: "delimiter.colon.json", foreground: "6E7781" },
+    { token: "delimiter.comma.json", foreground: "6E7781" },
+  ],
+};
+
+monaco.editor.defineTheme("kaja-dark", { base: "vs-dark", inherit: true, rules: jsonRules.dark, colors: {} });
+monaco.editor.defineTheme("kaja-light", { base: "vs", inherit: true, rules: jsonRules.light, colors: {} });
+
+export function monacoTheme(colorMode: "day" | "night"): string {
+  return colorMode === "night" ? "kaja-dark" : "kaja-light";
+}


### PR DESCRIPTION
Reworks the main window so the response, not an empty editor, gets the space: side-by-side layout by default on wide windows, an editor pane sized to its code, and status/duration/size readouts on call rows and above the payload.

Also retunes the JSON palette (blue keys, green strings, no red), elevates the response onto the editor's surface, thickens the active tab accent, and moves Feedback to the status bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWzrpq8Xjd8PC6KqnPLh8m)_