### PR TITLE
Reworked the main window around the design spec

### DIFF
--- a/.github/scripts/take-demo.js
+++ b/.github/scripts/take-demo.js
@@ -174,24 +174,14 @@ async function takeDemo() {
     }
 
     // Wait for console to show results
-    // First wait for the call to appear in console
-    await waitFor(page, '[data-testid="console-row"]', "call to appear in console");
+    // The console header's call select appears as soon as the call is issued
+    await waitFor(page, '[data-testid="console-call-select"]', "call to appear in console");
 
-    // Wait for response to complete - the pending state shows hollow circle, completed shows filled
+    // The response status line only renders once the response (or error) lands
     console.log("  Waiting for: response to complete...");
-    try {
-      // Wait for filled status indicator (● means complete, ○ means pending)
-      await page.waitForFunction(() => {
-        const rows = document.querySelectorAll('[data-testid="console-row"]');
-        if (rows.length === 0) return false;
-        // Check if any row has the filled circle (success or error)
-        const text = rows[0].textContent || '';
-        return text.includes('●');
-      }, { timeout: 15000 });
-      console.log("  ✓ Response completed");
-    } catch {
+    await waitFor(page, '[data-testid="console-status"]', "response to complete").catch(() => {
       console.log("  ⚠ Response completion check timed out, proceeding anyway");
-    }
+    });
     await settleDelay(page, 500);
 
     await page.screenshot({ path: `${DEMO_DIR}/call.png` });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ off `data-starting-style` / `data-ending-style`.
 
 ### Conventions
 
-- Icons: import from `lucide-react` directly, under lucide's own names (e.g. `Trash2`, `Ellipsis`, `PanelLeftClose`). Standalone icons take a numeric `size` prop; inside `IconButton` the size comes from the button. lucide ships no brand icons, so the GitHub mark is drawn inline in `StatusBar.tsx`.
+- Icons: import from `lucide-react` directly, under lucide's own names (e.g. `Trash2`, `Ellipsis`, `PanelLeftClose`). Standalone icons take a numeric `size` prop; inside `IconButton` the size comes from the button.
 - Class names: compose with `cn()` from `ui/src/cn.ts` (tailwind-merge over a plain join). The same file holds `cva()` for variant maps and `cnState()` for the Base UI parts whose `className` may be a function of the part's state.
 - Theme tokens: the shadcn CSS variables live in `ui/src/tailwind.css`. Style with Tailwind utilities (`bg-muted`, `text-muted-foreground`, `border-border`); reference the raw `var(--muted)` only where the markup isn't ours, i.e. the CSS overrides for Monaco's internal DOM. Day/night is a `dark` class toggled on `<html>` (so Base UI portals are themed too); Monaco is themed separately via `vs`/`vs-dark`.
 - Status colors beyond the tokens: warnings are `text-amber-600 dark:text-amber-400` over `bg-amber-500/10`, successes `text-emerald-600 dark:text-emerald-400` over `bg-emerald-500/10`, errors `text-destructive` over `bg-destructive/10`.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,7 +14,7 @@ import { GetStartedBlankslate } from "./GetStartedBlankslate";
 import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Gutter } from "./Gutter";
-import { AskCancelledError, Kaja, MethodCall } from "./kaja";
+import { AskCancelledError, isCallInFlight, Kaja, MethodCall } from "./kaja";
 import { appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, createAppRef, getDefaultMethod, Method, App as AppModel, Script, Service, Transport, updateAppRef } from "./apps";
 import { Sidebar } from "./Sidebar";
@@ -86,9 +86,9 @@ const MIN_EDITOR_HEIGHT = 120;
 const MAX_EDITOR_HEIGHT_RATIO = 0.55;
 // Above this window width the editor and the response fit side by side, which
 // suits the wide, short shape of a method call better than stacking them. Side
-// by side splits the window four ways — sidebar, editor, call list, response —
-// so the threshold has to leave the response a usable share of it; below this,
-// stacking gives it the full width instead.
+// by side splits the window three ways — sidebar, editor, response — so the
+// threshold has to leave the response a usable share of it; below this, stacking
+// gives it the full width instead.
 const SIDE_BY_SIDE_MIN_WIDTH = 1600;
 
 // Lowercase the first letter (e.g. method name "GetUser" -> "getUser").
@@ -206,6 +206,10 @@ export function App() {
   const [deleteScript, setDeleteScript] = useState<Script | null>(null);
   // Path of the script pinned to the macOS "Run Kaja Script" text service.
   const [pinnedScriptPath, setPinnedScriptPath] = useState<string | undefined>(() => getPersistedValue<string>("contextMenuScriptPath"));
+  // The run in flight, if any: which tab issued it, when it started, and the
+  // controller its Stop button aborts. `settled` marks the script itself as
+  // finished — the run is only over once its calls have landed too.
+  const [activeRun, setActiveRun] = useState<{ tabId: string; startedAt: number; controller: AbortController; settled: boolean } | null>(null);
   // Pending debounced disk writes for open script tabs, keyed by tab id.
   const scriptSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   // Tab ids whose next content change is a programmatic revalidation poke (see
@@ -1223,8 +1227,8 @@ export function App() {
     persistTabs();
   };
 
-  // Run the active task/script tab's editor contents. Triggered by the docked
-  // Run button in the tab strip and by F5.
+  // Run the active task/script tab's editor contents. Triggered by the Run
+  // button floating over the editor, by ⌘⏎ and by F5.
   const onRunActiveTab = useCallback(() => {
     const index = activeTabIndexRef.current;
     const tab = tabsRef.current[index];
@@ -1235,16 +1239,40 @@ export function App() {
     if (!editor) {
       return;
     }
-    runTask(editor.getValue(), kajaRef.current!, apps, onScriptError);
+    const controller = new AbortController();
+    setActiveRun({ tabId: tab.id, startedAt: Date.now(), controller, settled: false });
+    runTask(editor.getValue(), kajaRef.current!, apps, onScriptError, controller.signal).finally(() =>
+      setActiveRun((run) => (run?.controller === controller ? { ...run, settled: true } : run)),
+    );
     if (tab.type === "task") {
       setTabs((tabs) => markInteraction(tabs, index));
       persistTabs();
     }
   }, [apps, persistTabs, onScriptError]);
 
+  // A generated method-call script issues its call without awaiting it, so the
+  // script's own promise settles well before the response lands. The run is over
+  // once the script has settled and nothing it started is still in flight.
+  useEffect(() => {
+    if (!activeRun?.settled) return;
+    const inFlight = consoleItems.some((item) => "method" in item && item.timestamp >= activeRun.startedAt && isCallInFlight(item));
+    if (!inFlight) {
+      setActiveRun(null);
+    }
+  }, [consoleItems, activeRun]);
+
+  // Stop aborts the calls the run has in flight; the script itself stops at the
+  // call it was awaiting.
+  const onStopActiveRun = useCallback(() => {
+    setActiveRun((run) => {
+      run?.controller.abort();
+      return null;
+    });
+  }, []);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "F5") {
+      if (event.key === "F5" || ((event.metaKey || event.ctrlKey) && event.key === "Enter")) {
         event.preventDefault();
         onRunActiveTab();
       }
@@ -1491,7 +1519,31 @@ export function App() {
               className="flex h-[30px] shrink-0 items-center border-b border-border bg-background"
               style={{ "--wails-draggable": "drag" } as React.CSSProperties}
             >
-              <div style={{ flex: 1, minWidth: 0, paddingLeft: 8 }} />
+              {/* A panel toggle reads as "this edge", so it sits against the sidebar seam.
+                  It belongs to this pane, not to the sidebar, so it stays put when the
+                  sidebar collapses and the reopen target never moves. */}
+              <div
+                style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", paddingLeft: 12, "--wails-draggable": "no-drag" } as React.CSSProperties}
+              >
+                <SimpleTooltip
+                  text={
+                    sidebarCollapsed
+                      ? `Show sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
+                      : `Hide sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
+                  }
+                  side="bottom"
+                >
+                  <IconButton
+                    icon={sidebarCollapsed ? PanelLeftOpen : PanelLeftClose}
+                    aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                    onClick={() => setSidebarCollapsed((collapsed) => !collapsed)}
+                    size="sm"
+                    variant="ghost"
+                    tooltip={false}
+                    className="[&_svg]:size-[17px]"
+                  />
+                </SimpleTooltip>
+              </div>
               <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0, "--wails-draggable": "no-drag" } as React.CSSProperties}>
                 <div
                   onClick={() => setIsSearchOpen(true)}
@@ -1507,29 +1559,12 @@ export function App() {
                     minWidth: 0,
                     display: "flex",
                     justifyContent: "flex-end",
-                    paddingRight: 8,
+                    paddingRight: 12,
                     gap: 2,
                     "--wails-draggable": "no-drag",
                   } as React.CSSProperties
                 }
               >
-                <SimpleTooltip
-                  text={
-                    sidebarCollapsed
-                      ? `Show sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
-                      : `Hide sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
-                  }
-                  side="bottom"
-                >
-                  <IconButton
-                    icon={sidebarCollapsed ? PanelLeftClose : PanelLeftOpen}
-                    aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-                    onClick={() => setSidebarCollapsed((collapsed) => !collapsed)}
-                    size="sm"
-                    variant="ghost"
-                    tooltip={false}
-                  />
-                </SimpleTooltip>
                 <SimpleTooltip text={editorLayout === "vertical" ? "Side-by-side layout" : "Top-bottom layout"} side="bottom">
                   <IconButton
                     icon={editorLayout === "vertical" ? Columns2 : Rows2}
@@ -1538,6 +1573,7 @@ export function App() {
                     size="sm"
                     variant="ghost"
                     tooltip={false}
+                    className="[&_svg]:size-[17px]"
                   />
                 </SimpleTooltip>
               </div>
@@ -1559,14 +1595,7 @@ export function App() {
                     minWidth: 0,
                   }}
                 >
-                  <Tabs
-                    activeTabIndex={activeTabIndex}
-                    onSelectTab={onSelectTab}
-                    onCloseTab={onCloseTab}
-                    onCloseAll={onCloseAll}
-                    onCloseOthers={onCloseOthers}
-                    onRun={isActiveTaskTab ? onRunActiveTab : undefined}
-                  >
+                  <Tabs activeTabIndex={activeTabIndex} onSelectTab={onSelectTab} onCloseTab={onCloseTab} onCloseAll={onCloseAll} onCloseOthers={onCloseOthers}>
                     {tabs.map((tab, index) => {
                       if (tab.type === "compiler") {
                         return (
@@ -1584,6 +1613,10 @@ export function App() {
                               onGoToDefinition={onGoToDefinition}
                               onEditorReady={(editor) => onEditorReady(tab.id, editor)}
                               viewState={tab.viewState}
+                              onRun={onRunActiveTab}
+                              onStop={onStopActiveRun}
+                              running={activeRun?.tabId === tab.id}
+                              startedAt={activeRun?.tabId === tab.id ? activeRun.startedAt : undefined}
                             />
                           </Tab>
                         );
@@ -1597,6 +1630,10 @@ export function App() {
                               onGoToDefinition={onGoToDefinition}
                               onEditorReady={(editor) => onEditorReady(tab.id, editor)}
                               viewState={tab.viewState}
+                              onRun={onRunActiveTab}
+                              onStop={onStopActiveRun}
+                              running={activeRun?.tabId === tab.id}
+                              startedAt={activeRun?.tabId === tab.id ? activeRun.startedAt : undefined}
                             />
                           </Tab>
                         );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,7 +17,7 @@ import { Gutter } from "./Gutter";
 import { AskCancelledError, isCallInFlight, Kaja, MethodCall } from "./kaja";
 import { appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, createAppRef, getDefaultMethod, Method, App as AppModel, Script, Service, Transport, updateAppRef } from "./apps";
-import { Sidebar } from "./Sidebar";
+import { Sidebar, TRAFFIC_LIGHTS_INSET } from "./Sidebar";
 import { NewAppDialog } from "./NewAppDialog";
 import { SearchPopup } from "./SearchPopup";
 import { StatusBar, ColorMode } from "./StatusBar";
@@ -1451,6 +1451,10 @@ export function App() {
     }
   };
 
+  // With the sidebar open its own header holds the macOS traffic lights; collapsed,
+  // this bar is what the window's left corner lands on, so it takes over the inset.
+  const topBarInset = isDesktopMac && sidebarCollapsed ? TRAFFIC_LIGHTS_INSET : 12;
+
   const activeTab = tabs[activeTabIndex];
   const isActiveTaskTab = activeTab?.type === "task" || activeTab?.type === "script";
   const isHorizontalLayout = editorLayout === "horizontal" && isActiveTaskTab;
@@ -1520,29 +1524,31 @@ export function App() {
               style={{ "--wails-draggable": "drag" } as React.CSSProperties}
             >
               {/* A panel toggle reads as "this edge", so it sits against the sidebar seam.
-                  It belongs to this pane, not to the sidebar, so it stays put when the
-                  sidebar collapses and the reopen target never moves. */}
-              <div
-                style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", paddingLeft: 12, "--wails-draggable": "no-drag" } as React.CSSProperties}
-              >
-                <SimpleTooltip
-                  text={
-                    sidebarCollapsed
-                      ? `Show sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
-                      : `Hide sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
-                  }
-                  side="bottom"
-                >
-                  <IconButton
-                    icon={sidebarCollapsed ? PanelLeftOpen : PanelLeftClose}
-                    aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-                    onClick={() => setSidebarCollapsed((collapsed) => !collapsed)}
-                    size="sm"
-                    variant="ghost"
-                    tooltip={false}
-                    className="[&_svg]:size-[17px]"
-                  />
-                </SimpleTooltip>
+                  It belongs to this pane, not to the sidebar, so it keeps its place when
+                  the sidebar collapses — except on the macOS desktop, where collapsing
+                  leaves this bar under the window's traffic lights and the toggle has to
+                  clear them the way the sidebar header does. */}
+              <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", paddingLeft: topBarInset }}>
+                <div style={{ display: "flex", "--wails-draggable": "no-drag" } as React.CSSProperties}>
+                  <SimpleTooltip
+                    text={
+                      sidebarCollapsed
+                        ? `Show sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
+                        : `Hide sidebar (${navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+"}B)`
+                    }
+                    side="bottom"
+                  >
+                    <IconButton
+                      icon={sidebarCollapsed ? PanelLeftOpen : PanelLeftClose}
+                      aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                      onClick={() => setSidebarCollapsed((collapsed) => !collapsed)}
+                      size="sm"
+                      variant="ghost"
+                      tooltip={false}
+                      className="[&_svg]:size-[17px]"
+                    />
+                  </SimpleTooltip>
+                </div>
               </div>
               <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0, "--wails-draggable": "no-drag" } as React.CSSProperties}>
                 <div

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -1,18 +1,30 @@
-import { Check, Copy, FoldVertical, Play, Trash2, UnfoldVertical } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, ChevronsUpDown, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "./cn";
-import { Gutter } from "./Gutter";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { IconButton } from "./components/icon-button";
+import { Spinner } from "./components/spinner";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
-import { MethodCall } from "./kaja";
+import { isCallInFlight, MethodCall } from "./kaja";
 import { methodId } from "./apps";
+import { runShortcutLabel } from "./RunButton";
 import { Log, LogLevel } from "./server/api";
 
 export type ConsoleItem = Log[] | MethodCall;
 
-const consoleRowClass = "flex cursor-pointer items-center border-b border-border px-3 py-1.5 font-mono text-xs";
-const consoleTabClass = "cursor-pointer border-b-2 border-transparent px-4 py-2 font-mono text-xs text-muted-foreground hover:text-foreground";
-const consoleTabActiveClass = "border-b-primary text-foreground";
+// The dropdown is a fixed 420px and scrolls after eight rows, so a long session
+// never turns the console header into a full-height surface.
+const CALL_ROW_HEIGHT = 32;
+const MAX_VISIBLE_CALL_ROWS = 8;
+// Beyond this the qualified call name is truncated from the left, so the method
+// — the part that identifies the call — survives.
+const MAX_TRIGGER_NAME_LENGTH = 28;
+
+const consoleTabClass = "cursor-pointer select-none text-sm text-muted-foreground hover:text-foreground";
+const consoleTabActiveClass = "font-medium text-foreground";
+// Utilities carry no resting chrome: they are worth no more weight than the tabs
+// beside them.
+const utilityButtonClass = "h-6 w-6 rounded-md hover:bg-accent hover:text-foreground";
 
 interface ConsoleProps {
   items: ConsoleItem[];
@@ -21,18 +33,20 @@ interface ConsoleProps {
 
 export function Console({ items, onClear }: ConsoleProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [activeTab, setActiveTab] = useState<"request" | "response" | "headers">("response");
-  const [callListWidth, setCallListWidth] = useState(300);
+  const [activeTab, setActiveTab] = useState<ConsoleTab>("response");
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState(false);
-  const listRef = useRef<HTMLDivElement>(null);
 
   const jsonViewerRef = useRef<JsonViewerHandle | null>(null);
 
+  // A call in flight counts up in tenths, so the tick has to be finer than the
+  // one that ages the settled calls.
+  const hasInFlight = items.some((item) => !Array.isArray(item) && isCallInFlight(item));
+
   useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 1000);
+    const interval = setInterval(() => setNow(Date.now()), hasInFlight ? 100 : 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [hasInFlight]);
 
   // Reset selectedIndex when items are cleared or become invalid
   useEffect(() => {
@@ -43,203 +57,251 @@ export function Console({ items, onClear }: ConsoleProps) {
     }
   }, [items.length, selectedIndex]);
 
-  const onCallListResize = (delta: number) => {
-    setCallListWidth((prev) => Math.max(150, Math.min(600, prev + delta)));
-  };
+  const selectedItem = selectedIndex !== null ? items[selectedIndex] : undefined;
+  const selectedMethodCall = selectedItem && "method" in selectedItem ? selectedItem : null;
+  const selectedLogs = Array.isArray(selectedItem) ? selectedItem : null;
 
-  // Filter items into method calls for easier access
-  const methodCalls = items.map((item, index) => ({ item, index })).filter((entry): entry is { item: MethodCall; index: number } => "method" in entry.item);
-
-  // Get selected method call
-  const selectedMethodCall = selectedIndex !== null && items[selectedIndex] && "method" in items[selectedIndex] ? (items[selectedIndex] as MethodCall) : null;
-
-  // Auto-scroll and auto-select when the last item is selected (or nothing is)
+  // Follow the newest item, so an in-flight call is selected the moment it is
+  // issued instead of after its response lands.
   useEffect(() => {
     if (items.length === 0) return;
     const lastIndex = items.length - 1;
-    const prevLastIndex = items.length - 2;
-    if (selectedIndex === null || selectedIndex === prevLastIndex || selectedIndex === lastIndex) {
+    if (selectedIndex === null || selectedIndex >= lastIndex - 1) {
       setSelectedIndex(lastIndex);
-      requestAnimationFrame(() => {
-        if (listRef.current) {
-          listRef.current.scrollTop = listRef.current.scrollHeight;
-        }
-      });
     }
   }, [items.length]);
 
-  const handleRowClick = useCallback((index: number) => {
-    setSelectedIndex(index);
+  // ⌃↑ / ⌃↓ step through the history without opening the dropdown.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.ctrlKey || event.metaKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
+      if (items.length === 0) return;
+      event.preventDefault();
+      setSelectedIndex((index) => {
+        const current = index ?? items.length - 1;
+        const next = event.key === "ArrowUp" ? current - 1 : current + 1;
+        return Math.max(0, Math.min(items.length - 1, next));
+      });
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [items.length]);
+
+  const handleCopy = useCallback(() => {
+    jsonViewerRef.current?.copyToClipboard();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
   }, []);
 
-  const handleCopy = async () => {
-    if (jsonViewerRef.current) {
-      jsonViewerRef.current.copyToClipboard();
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
-
-  const handleFoldAll = () => {
-    if (jsonViewerRef.current) {
-      jsonViewerRef.current.foldAll();
-    }
-  };
-
-  const handleUnfoldAll = () => {
-    if (jsonViewerRef.current) {
-      jsonViewerRef.current.unfoldAll();
-    }
-  };
+  const showUtilities = selectedMethodCall !== null && (activeTab === "request" || activeTab === "response");
+  const position = selectedIndex === null ? items.length : selectedIndex + 1;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
-      {/* Header row */}
-      <div className="flex h-[35px] shrink-0 border-b border-border">
-        <div className="flex shrink-0 items-center justify-between px-3" style={{ width: callListWidth }}>
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Calls</span>
-          {onClear && items.length > 0 && <IconButton icon={Trash2} aria-label="Clear console" onClick={onClear} size="sm" variant="ghost" />}
-        </div>
-        <div className="w-px shrink-0 bg-border" />
-        <div className="flex min-w-0 flex-1 items-center">
-          {selectedMethodCall && <Console.DetailTabs methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} />}
-          {selectedMethodCall && (activeTab === "request" || activeTab === "response") && (
-            <div className="ml-auto mr-3 flex gap-0.5 rounded-md bg-muted p-0.5">
-              <IconButton icon={FoldVertical} aria-label="Fold all" onClick={handleFoldAll} size="sm" variant="ghost" />
-              <IconButton icon={UnfoldVertical} aria-label="Unfold all" onClick={handleUnfoldAll} size="sm" variant="ghost" />
-              <IconButton icon={copied ? Check : Copy} aria-label="Copy JSON" onClick={handleCopy} size="sm" variant="ghost" />
+      {/* One row spanning the full console width: which call, how to step through
+          them, what to look at, and what to do with it. */}
+      <div className="flex h-10 shrink-0 items-center gap-3 border-b border-border px-3">
+        {items.length === 0 ? (
+          <span className="text-xs text-muted-foreground">No calls yet</span>
+        ) : (
+          <>
+            <Console.CallSelect items={items} selectedIndex={selectedIndex} onSelect={setSelectedIndex} onClear={onClear} now={now} />
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={ChevronUp}
+                aria-label="Previous call"
+                variant="ghost"
+                size="sm"
+                tooltip={false}
+                className="h-6 w-6"
+                disabled={position <= 1}
+                onClick={() => setSelectedIndex((index) => Math.max(0, (index ?? items.length - 1) - 1))}
+              />
+              <IconButton
+                icon={ChevronDown}
+                aria-label="Next call"
+                variant="ghost"
+                size="sm"
+                tooltip={false}
+                className="h-6 w-6"
+                disabled={position >= items.length}
+                onClick={() => setSelectedIndex((index) => Math.min(items.length - 1, (index ?? items.length - 1) + 1))}
+              />
+              <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                {position} of {items.length}
+              </span>
             </div>
-          )}
-        </div>
+          </>
+        )}
+        <div className="h-4 w-px bg-border" />
+        <Console.DetailTabs methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} />
+        {showUtilities && (
+          <div className="ml-auto flex items-center gap-2">
+            <IconButton
+              icon={FoldVertical}
+              aria-label="Fold all"
+              variant="ghost"
+              size="sm"
+              className={utilityButtonClass}
+              onClick={() => jsonViewerRef.current?.foldAll()}
+            />
+            <IconButton
+              icon={UnfoldVertical}
+              aria-label="Unfold all"
+              variant="ghost"
+              size="sm"
+              className={utilityButtonClass}
+              onClick={() => jsonViewerRef.current?.unfoldAll()}
+            />
+            <div className="h-4 w-px bg-border" />
+            <IconButton icon={copied ? Check : Copy} aria-label="Copy JSON" variant="ghost" size="sm" className={utilityButtonClass} onClick={handleCopy} />
+          </div>
+        )}
       </div>
 
-      {/* Content row */}
-      <div className="flex min-h-0 flex-1">
-        {/* Left panel - Call list */}
-        <div ref={listRef} className="shrink-0 overflow-y-auto" style={{ width: callListWidth }}>
-          {items.map((item, index) => {
-            if (Array.isArray(item)) {
-              return <Console.LogRow key={`log:${index}`} logs={item} />;
-            } else if ("method" in item) {
-              return (
-                <Console.MethodCallRow
-                  key={`mc:${item.id}`}
-                  methodCall={item}
-                  index={index}
-                  isSelected={selectedIndex === index}
-                  onSelect={handleRowClick}
-                  relativeTime={formatRelativeTime(item.timestamp, now)}
-                />
-              );
-            }
-            return null;
-          })}
-        </div>
-
-        <Gutter orientation="vertical" onResize={onCallListResize} />
-
-        {/* Right panel - Details. Elevated to the same surface as the editor:
-            payloads are content, the call list and headers around them are chrome. */}
-        <div className="flex min-w-0 flex-1 flex-col bg-muted">
-          {selectedMethodCall ? (
-            <Console.DetailContent methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} jsonViewerRef={jsonViewerRef} />
-          ) : (
-            <div className="flex flex-1 items-center justify-center gap-1.5 text-xs text-muted-foreground">
-              Press <Play size={12} /> to run
-            </div>
-          )}
-        </div>
+      {/* The response owns the full width of the console below the header.
+          Elevated to the same surface as the editor: payloads are content, the
+          header around them is chrome. */}
+      <div className="flex min-h-0 flex-1 flex-col bg-muted">
+        {selectedMethodCall ? (
+          <Console.DetailContent methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} jsonViewerRef={jsonViewerRef} />
+        ) : selectedLogs ? (
+          <Console.LogContent logs={selectedLogs} />
+        ) : (
+          <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+            Run a script to see its calls here — <span className="ml-1 font-mono">{runShortcutLabel}</span>
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
-interface LogRowProps {
-  logs: Log[];
+interface CallSelectProps {
+  items: ConsoleItem[];
+  selectedIndex: number | null;
+  onSelect: (index: number) => void;
+  onClear?: () => void;
+  now: number;
 }
 
-Console.LogRow = function ({ logs }: LogRowProps) {
-  if (logs.length === 0) return null;
-
-  // Show summary of logs with highest severity
-  const highestSeverity = Math.max(...logs.map((l) => l.level));
+// The whole history behind one 26px trigger: the trigger answers "which run am I
+// looking at", the list answers "which other ones are there".
+Console.CallSelect = function ({ items, selectedIndex, onSelect, onClear, now }: CallSelectProps) {
+  const [open, setOpen] = useState(false);
+  const selected = selectedIndex !== null ? items[selectedIndex] : undefined;
+  const summary = selected ? itemSummary(selected, now) : undefined;
 
   return (
-    <div
-      data-testid="console-row"
-      className={cn(consoleRowClass, "opacity-80 hover:bg-accent/50", classForLogLevel(highestSeverity))}
-      title={logs.map((l) => l.message).join("\n")}
-    >
-      <span className="mr-2 text-[10px]">{labelForLogLevel(highestSeverity)}</span>
-      <span className="overflow-hidden text-ellipsis whitespace-nowrap">{logs.length === 1 ? logs[0].message.trim() : `${logs.length} log messages`}</span>
-    </div>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex h-[26px] min-w-0 shrink-0 items-center gap-2 rounded-md border border-border bg-card px-2.5 hover:bg-accent"
+          title={summary?.name}
+        >
+          {summary?.pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", summary?.dotClass)} />}
+          <span className="max-w-[190px] truncate font-mono text-xs text-foreground">{truncateStart(summary?.name ?? "", MAX_TRIGGER_NAME_LENGTH)}</span>
+          {summary?.meta && <span className="shrink-0 font-mono text-xs text-muted-foreground">{summary.meta}</span>}
+          <ChevronsUpDown size={13} className="shrink-0 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="bottom" className="w-[420px] p-0">
+        <div className="flex items-center justify-between border-b border-border px-3 py-2">
+          <span className="text-xs tracking-[0.06em] text-muted-foreground">RECENT CALLS</span>
+          <span className="font-mono text-xs text-muted-foreground">{items.length}</span>
+        </div>
+        <div className="overflow-y-auto" style={{ maxHeight: MAX_VISIBLE_CALL_ROWS * CALL_ROW_HEIGHT }}>
+          {items
+            .map((item, index) => ({ item, index }))
+            .reverse()
+            .map(({ item, index }) => (
+              <Console.CallRow
+                key={"method" in item ? `mc:${item.id}` : `log:${index}`}
+                {...itemSummary(item, now)}
+                index={index}
+                isSelected={index === selectedIndex}
+                onSelect={onSelect}
+              />
+            ))}
+        </div>
+        {onClear && (
+          <DropdownMenuItem
+            className="h-8 gap-2 rounded-none border-t border-border px-3 text-xs text-muted-foreground"
+            onSelect={() => {
+              onClear();
+              setOpen(false);
+            }}
+          >
+            <Trash2 size={13} />
+            Clear history
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 
-interface MethodCallRowProps {
-  methodCall: MethodCall;
+interface CallRowProps extends ItemSummary {
   index: number;
   isSelected: boolean;
   onSelect: (index: number) => void;
-  relativeTime: string;
 }
 
-// Memoized so the per-second timestamp tick only re-renders rows whose displayed
-// relative time actually changed, instead of every row on every tick.
-Console.MethodCallRow = memo(function MethodCallRow({ methodCall, index, isSelected, onSelect, relativeTime }: MethodCallRowProps) {
-  const status = callStatus(methodCall);
-  const errorCode = callErrorCode(methodCall);
-  const duration = formatDuration(methodCall.durationMs);
-
-  const statusIcon = {
-    pending: "○",
-    streaming: "◉",
-    success: "●",
-    error: "●",
-  }[status];
-
+// Memoized so the per-second age tick only re-renders rows whose displayed time
+// actually changed, instead of every row on every tick.
+Console.CallRow = memo(function CallRow({ name, meta, dotClass, pending, index, isSelected, onSelect }: CallRowProps) {
   return (
-    <div
-      data-testid="console-row"
-      className={cn(consoleRowClass, isSelected ? "bg-accent" : "hover:bg-accent/50")}
-      onClick={() => onSelect(index)}
-      title={new Date(methodCall.timestamp).toLocaleTimeString()}
-    >
-      <span className={cn("mr-2 text-[10px]", statusClass(status))}>{statusIcon}</span>
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-foreground">{methodId(methodCall.service, methodCall.method)}</span>
-      {errorCode && <span className="ml-2 shrink-0 overflow-hidden text-ellipsis text-[10px] font-medium text-destructive">{errorCode}</span>}
-      {duration && <span className="ml-2 shrink-0 text-[11px] tabular-nums text-muted-foreground">{duration}</span>}
-      <span className="ml-2 shrink-0 text-[11px] text-muted-foreground">{relativeTime}</span>
-    </div>
+    <DropdownMenuItem data-testid="console-row" className={cn("h-8 gap-3 rounded-none px-3", isSelected && "bg-accent")} onSelect={() => onSelect(index)}>
+      {pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass)} />}
+      <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">{name}</span>
+      {meta && <span className="shrink-0 font-mono text-xs text-muted-foreground">{meta}</span>}
+    </DropdownMenuItem>
   );
 });
 
 type ConsoleTab = "request" | "response" | "headers";
 
 interface DetailTabsProps {
-  methodCall: MethodCall;
+  methodCall: MethodCall | null;
   activeTab: ConsoleTab;
   onTabChange: (tab: ConsoleTab) => void;
 }
 
 Console.DetailTabs = function ({ methodCall, activeTab, onTabChange }: DetailTabsProps) {
-  const isStreaming = methodCall.streamOutputs !== undefined;
-  const streamCount = isStreaming ? methodCall.streamOutputs!.length : 0;
+  const isStreaming = methodCall?.streamOutputs !== undefined;
+  const streamCount = isStreaming ? methodCall!.streamOutputs!.length : 0;
 
+  const tab = (id: ConsoleTab, label: string) => (
+    <span className={cn(consoleTabClass, activeTab === id && consoleTabActiveClass)} onClick={() => methodCall && onTabChange(id)}>
+      {label}
+    </span>
+  );
+
+  // A failed call colours its dot and its status line, and nothing else — the
+  // header stays neutral.
   return (
-    <div className="flex">
-      <div className={cn(consoleTabClass, activeTab === "request" && consoleTabActiveClass)} onClick={() => onTabChange("request")}>
-        Request
-      </div>
-      <div
-        className={cn(consoleTabClass, activeTab === "response" && consoleTabActiveClass, methodCall.error && "text-destructive hover:text-destructive")}
-        onClick={() => onTabChange("response")}
-      >
-        Response{isStreaming && streamCount > 0 ? ` (${streamCount})` : ""}
-      </div>
-      <div className={cn(consoleTabClass, activeTab === "headers" && consoleTabActiveClass)} onClick={() => onTabChange("headers")}>
-        Headers
-      </div>
+    <div className={cn("flex items-center gap-4", !methodCall && "pointer-events-none opacity-40")}>
+      {tab("request", "Request")}
+      {tab("response", `Response${isStreaming && streamCount > 0 ? ` (${streamCount})` : ""}`)}
+      {tab("headers", "Headers")}
+    </div>
+  );
+};
+
+interface LogContentProps {
+  logs: Log[];
+}
+
+Console.LogContent = function ({ logs }: LogContentProps) {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto px-4 py-3 font-mono text-xs">
+      {logs.map((log, index) => (
+        <div key={index} className={cn("whitespace-pre-wrap break-words", classForLogLevel(log.level))}>
+          <span className="mr-2 text-[10px] uppercase opacity-70">{labelForLogLevel(log.level)}</span>
+          {log.message.trim()}
+        </div>
+      ))}
     </div>
   );
 };
@@ -282,12 +344,12 @@ Console.DetailContent = function ({ methodCall, activeTab, onTabChange, jsonView
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {activeTab === "response" && !hasResponse ? (
-        <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Waiting for response...</div>
+        <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Waiting for a response…</div>
       ) : (
         <>
           {activeTab === "response" && <Console.ResponseSummary methodCall={methodCall} content={content} rawText={rawText} />}
           {activeTab === "response" && hasError && methodCall.url && (
-            <div className="border-b border-border bg-destructive/10 px-3 py-1.5 font-mono text-xs text-destructive">POST {methodCall.url}</div>
+            <div className="border-b border-border bg-destructive/10 px-4 py-1.5 font-mono text-xs text-destructive">POST {methodCall.url}</div>
           )}
           <JsonViewer ref={jsonViewerRef} value={content} rawText={rawText} />
         </>
@@ -303,7 +365,8 @@ interface ResponseSummaryProps {
 }
 
 // A one-line readout above the payload: what came back, how long it took and how
-// big it is. Without it a successful call and an empty one look the same.
+// big it is. Without it a successful call and an empty one look the same. Status
+// colour appears here and in the call's dot, and nowhere else.
 Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSummaryProps) {
   const status = callStatus(methodCall);
   const label = { pending: "Pending", streaming: "Streaming", success: "OK", error: callErrorCode(methodCall) ?? "Error" }[status];
@@ -312,7 +375,7 @@ Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSu
   const streamCount = methodCall.streamOutputs?.length;
 
   return (
-    <div className="flex shrink-0 items-center gap-3 overflow-hidden whitespace-nowrap border-b border-border px-3 py-1 font-mono text-[11px]">
+    <div className="flex shrink-0 items-center gap-3 overflow-hidden whitespace-nowrap px-4 pb-2 pt-3 font-mono text-xs">
       <span className={cn("shrink-0 font-medium", statusClass(status))}>{label}</span>
       {duration && <span className="shrink-0 tabular-nums text-muted-foreground">{duration}</span>}
       {size && <span className="shrink-0 tabular-nums text-muted-foreground">{size}</span>}
@@ -400,6 +463,47 @@ Console.HeadersTable = function ({ headers }: HeadersTableProps) {
   );
 };
 
+interface ItemSummary {
+  name: string;
+  // Duration (or status code for a failed call) and the call's age.
+  meta?: string;
+  dotClass: string;
+  pending: boolean;
+}
+
+// The three columns every row in the history shares — the trigger shows them for
+// the selected item, the list for all of them.
+function itemSummary(item: ConsoleItem, now: number): ItemSummary {
+  if (Array.isArray(item)) {
+    const level = item.length === 0 ? LogLevel.LEVEL_INFO : Math.max(...item.map((log) => log.level));
+    return {
+      name: item.length === 1 ? item[0].message.trim() : `${item.length} log messages`,
+      meta: labelForLogLevel(level),
+      dotClass: dotClassForLogLevel(level),
+      pending: false,
+    };
+  }
+
+  const status = callStatus(item);
+  const pending = status === "pending" || status === "streaming";
+  const detail = callErrorCode(item) ?? formatDuration(item.durationMs);
+  const age = formatRelativeTime(item.timestamp, now);
+  return {
+    name: methodId(item.service, item.method),
+    // While the call is in flight its own elapsed time is the interesting
+    // number; once it lands, how long it took and how long ago that was.
+    meta: pending ? `${Math.max(0, (now - item.timestamp) / 1000).toFixed(1)}s` : detail ? `${detail} · ${age}` : age,
+    dotClass: dotClass(status),
+    pending,
+  };
+}
+
+// Keep the tail — for a qualified call name that is the method, the part that
+// says which call this is.
+function truncateStart(text: string, maxLength: number): string {
+  return text.length > maxLength ? `…${text.slice(text.length - maxLength + 1)}` : text;
+}
+
 type CallStatus = "pending" | "streaming" | "success" | "error";
 
 function callStatus(methodCall: MethodCall): CallStatus {
@@ -415,6 +519,15 @@ function statusClass(status: CallStatus): string {
     streaming: "text-primary",
     success: "text-emerald-600 dark:text-emerald-400",
     error: "text-destructive",
+  }[status];
+}
+
+function dotClass(status: CallStatus): string {
+  return {
+    pending: "bg-muted-foreground",
+    streaming: "bg-primary",
+    success: "bg-emerald-500",
+    error: "bg-red-500",
   }[status];
 }
 
@@ -473,6 +586,17 @@ function classForLogLevel(level: LogLevel): string {
       return "text-amber-600 dark:text-amber-400";
     case LogLevel.LEVEL_ERROR:
       return "text-destructive";
+  }
+}
+
+function dotClassForLogLevel(level: LogLevel): string {
+  switch (level) {
+    case LogLevel.LEVEL_WARN:
+      return "bg-amber-500";
+    case LogLevel.LEVEL_ERROR:
+      return "bg-red-500";
+    default:
+      return "bg-muted-foreground";
   }
 }
 

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -197,6 +197,7 @@ Console.CallSelect = function ({ items, selectedIndex, onSelect, onClear, now }:
       <DropdownMenuTrigger asChild>
         <button
           type="button"
+          data-testid="console-call-select"
           className="flex h-[26px] min-w-0 shrink-0 items-center gap-2 rounded-md border border-border bg-card px-2.5 hover:bg-accent"
           title={summary?.name}
         >
@@ -376,7 +377,9 @@ Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSu
 
   return (
     <div className="flex shrink-0 items-center gap-3 overflow-hidden whitespace-nowrap px-4 pb-2 pt-3 font-mono text-xs">
-      <span className={cn("shrink-0 font-medium", statusClass(status))}>{label}</span>
+      <span data-testid="console-status" className={cn("shrink-0 font-medium", statusClass(status))}>
+        {label}
+      </span>
       {duration && <span className="shrink-0 tabular-nums text-muted-foreground">{duration}</span>}
       {size && <span className="shrink-0 tabular-nums text-muted-foreground">{size}</span>}
       {streamCount !== undefined && (

--- a/ui/src/FeaturePreviews.tsx
+++ b/ui/src/FeaturePreviews.tsx
@@ -13,9 +13,10 @@ export interface FeaturePreview {
 interface FeaturePreviewsProps {
   features: FeaturePreview[];
   onToggle: (key: string) => void;
+  className?: string;
 }
 
-export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
+export function FeaturePreviews({ features, onToggle, className }: FeaturePreviewsProps) {
   const [open, setOpen] = useState(false);
 
   if (features.length === 0) {
@@ -25,7 +26,7 @@ export function FeaturePreviews({ features, onToggle }: FeaturePreviewsProps) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <IconButton size="xs" variant="ghost" tooltip={false} icon={FlaskConical} aria-label="Feature previews" />
+        <IconButton size="xs" variant="ghost" tooltip={false} icon={FlaskConical} aria-label="Feature previews" className={className} />
       </PopoverTrigger>
       <PopoverContent align="end" side="top" className="p-2">
         <div className="flex min-w-[180px] flex-col gap-2">

--- a/ui/src/RunButton.tsx
+++ b/ui/src/RunButton.tsx
@@ -1,0 +1,142 @@
+import * as monaco from "monaco-editor";
+import { Play } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "./cn";
+import { Spinner } from "./components/spinner";
+
+// Distance from the editor's top-right corner. The right offset grows by the
+// scrollbar width when the editor scrolls, so the button never sits on the track.
+const TOP_OFFSET = 10;
+const RIGHT_OFFSET = 16;
+// The button dims while typing so it doesn't sit in the way of the code, and
+// comes back once the cursor rests.
+const DIM_OPACITY = 0.55;
+const IDLE_DELAY = 800;
+
+export const runShortcutLabel = navigator.platform.startsWith("Mac") ? "⌘⏎" : "Ctrl+⏎";
+
+interface RunButtonProps {
+  editor: monaco.editor.IStandaloneCodeEditor | null;
+  model: monaco.editor.ITextModel;
+  onRun: () => void;
+  onStop: () => void;
+  running: boolean;
+  // Wall-clock start of the run in flight, used for the elapsed counter.
+  startedAt?: number;
+}
+
+// RunButton floats over the editor's top-right corner: it costs no layout, stays
+// with the document it runs, and carries the run's state in place — Run becomes
+// Stop with a spinner and an elapsed counter while a script is in flight.
+export function RunButton({ editor, model, onRun, onStop, running, startedAt }: RunButtonProps) {
+  const [rightOffset, setRightOffset] = useState(RIGHT_OFFSET);
+  const [dimmed, setDimmed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const syntaxError = useSyntaxError(model);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (!editor) return;
+    const update = () => {
+      const layout = editor.getLayoutInfo();
+      const scrolls = editor.getContentHeight() > layout.height;
+      setRightOffset(RIGHT_OFFSET + (scrolls ? layout.verticalScrollbarWidth : 0));
+    };
+    update();
+    const disposables = [editor.onDidContentSizeChange(update), editor.onDidLayoutChange(update)];
+    return () => disposables.forEach((d) => d.dispose());
+  }, [editor]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const wake = () => {
+      clearTimeout(idleTimer.current);
+      setDimmed(false);
+    };
+    const disposables = [
+      editor.onDidChangeModelContent(() => {
+        // Only a real keystroke dims it; programmatic edits (formatting on open,
+        // a reload from disk) leave it alone.
+        if (!editor.hasTextFocus()) return;
+        setDimmed(true);
+        clearTimeout(idleTimer.current);
+        idleTimer.current = setTimeout(() => setDimmed(false), IDLE_DELAY);
+      }),
+      editor.onDidBlurEditorText(wake),
+    ];
+    return () => {
+      clearTimeout(idleTimer.current);
+      disposables.forEach((d) => d.dispose());
+    };
+  }, [editor]);
+
+  useEffect(() => {
+    if (!running || startedAt === undefined) {
+      setElapsedMs(0);
+      return;
+    }
+    setElapsedMs(Date.now() - startedAt);
+    const interval = setInterval(() => setElapsedMs(Date.now() - startedAt), 100);
+    return () => clearInterval(interval);
+  }, [running, startedAt]);
+
+  const disabled = !running && syntaxError !== undefined;
+  const opacity = running || hovered ? 1 : disabled ? 0.45 : dimmed ? DIM_OPACITY : 1;
+
+  return (
+    <div
+      className="absolute z-10 transition-opacity duration-[120ms]"
+      style={{ top: TOP_OFFSET, right: rightOffset, opacity }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        title={disabled ? syntaxError : undefined}
+        onClick={running ? onStop : onRun}
+        className={cn(
+          "flex h-7 cursor-pointer items-center gap-1.5 rounded-md px-3 shadow-md",
+          running ? "border border-border bg-secondary text-secondary-foreground" : "border-none bg-emerald-600 text-white hover:bg-emerald-700",
+          disabled && "cursor-default",
+        )}
+      >
+        {running ? <Spinner className="size-[13px] text-muted-foreground" /> : <Play size={13} />}
+        <span className="text-xs font-medium">{running ? "Stop" : "Run"}</span>
+        {running ? (
+          <span className="font-mono text-xs tabular-nums text-muted-foreground">{(elapsedMs / 1000).toFixed(1)}s</span>
+        ) : (
+          !disabled && <span className="font-mono text-xs opacity-70">{runShortcutLabel}</span>
+        )}
+      </button>
+    </div>
+  );
+}
+
+// The task runner transpiles without type checking, so only a syntax error can
+// stop a script from running. TypeScript numbers those below 2000; anything
+// above is a semantic complaint the run doesn't care about.
+function useSyntaxError(model: monaco.editor.ITextModel): string | undefined {
+  const [message, setMessage] = useState<string>();
+
+  useEffect(() => {
+    const update = () => {
+      const marker = monaco.editor.getModelMarkers({ resource: model.uri }).find((m) => m.severity === monaco.MarkerSeverity.Error && isSyntaxCode(m.code));
+      setMessage(marker?.message);
+    };
+    update();
+    const disposable = monaco.editor.onDidChangeMarkers((uris) => {
+      if (uris.some((uri) => uri.toString() === model.uri.toString())) update();
+    });
+    return () => disposable.dispose();
+  }, [model]);
+
+  return message;
+}
+
+function isSyntaxCode(code: monaco.editor.IMarker["code"]): boolean {
+  const value = typeof code === "object" && code !== null ? code.value : code;
+  const number = Number(value);
+  return Number.isFinite(number) && number < 2000;
+}

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -8,6 +8,10 @@ import { appType, appTypeLabel } from "./appTypes";
 import { Method, App, Script, Service, methodId } from "./apps";
 import { getPersistedValue, setPersistedValue } from "./storage";
 
+// Width the macOS traffic lights occupy at the window's left edge. The desktop
+// window hides its title bar, so whatever sits in that corner has to clear them.
+export const TRAFFIC_LIGHTS_INSET = 78;
+
 function hasMultiplePackages(services: Service[]): boolean {
   if (services.length === 0) return false;
   const first = services[0].packageName;
@@ -376,7 +380,7 @@ export function Sidebar({
                 alignItems: "center",
                 flexShrink: 0,
                 height: 28,
-                paddingLeft: 78,
+                paddingLeft: TRAFFIC_LIGHTS_INSET,
                 paddingRight: 8,
                 "--wails-draggable": "drag",
               } as React.CSSProperties)

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { MessagesSquare, Moon, Sun, Plug } from "lucide-react";
+import { GitBranch, MessagesSquare, Moon, Sun, Plug } from "lucide-react";
+import { cn } from "./cn";
 import { Button } from "./components/button";
 import { IconButton } from "./components/icon-button";
 import { Popover, PopoverContent, PopoverTrigger } from "./components/popover";
@@ -11,14 +12,9 @@ import { main } from "./wailsjs/go/models";
 
 export type ColorMode = "day" | "night";
 
-// lucide ships no brand icons, so the GitHub mark is drawn here.
-function GithubIcon({ size = 16 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-    </svg>
-  );
-}
+// Every icon in the status bar is the same 14px glyph on the same hit area; the
+// row has no per-icon size overrides and no vertical offsets.
+export const statusBarIconClass = "h-6 w-6 [&_svg]:size-[14px]";
 
 interface StatusBarProps {
   colorMode: ColorMode;
@@ -97,7 +93,7 @@ function MCPStatus({ info }: { info: main.MCPInfo }) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <IconButton size="xs" variant="ghost" tooltip={false} icon={Plug} aria-label="MCP server" />
+        <IconButton size="xs" variant="ghost" tooltip={false} icon={Plug} aria-label="MCP server" className={statusBarIconClass} />
       </PopoverTrigger>
       <PopoverContent align="end" side="top" className="p-3">
         <div className="flex max-w-[420px] flex-col gap-2">
@@ -124,7 +120,7 @@ function MCPStatus({ info }: { info: main.MCPInfo }) {
 // in use). It reuses the plug icon so the footer keeps the same shape, tinted red
 // to signal the failure, instead of silently dropping the connection command.
 function MCPError({ message }: { message: string }) {
-  return <IconButton size="xs" variant="ghost" tooltip={false} icon={Plug} aria-label={message} className="text-destructive" />;
+  return <IconButton size="xs" variant="ghost" tooltip={false} icon={Plug} aria-label={message} className={cn(statusBarIconClass, "text-destructive")} />;
 }
 
 function openFeedback() {
@@ -148,29 +144,28 @@ export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, f
   };
 
   return (
-    <div className="flex h-[22px] shrink-0 items-center justify-between border-t border-border bg-background px-4">
-      <div className="flex items-center gap-1.5">
-        {githubUrl && shortRef ? (
+    <div className="flex h-[30px] shrink-0 items-center border-t border-border bg-background px-3">
+      <div className="flex items-center gap-2">
+        {githubUrl && shortRef && (
           <a
             href={githubUrl}
             target="_blank"
             rel="noopener noreferrer"
             onClick={handleLinkClick}
-            className="inline-flex items-center gap-1 text-[11px] text-muted-foreground no-underline"
+            className="inline-flex items-center gap-2 text-xs text-muted-foreground no-underline hover:text-foreground"
           >
-            <GithubIcon size={12} />
-            <span className="relative top-px">{shortRef}</span>
+            <GitBranch size={14} />
+            <span>{shortRef}</span>
           </a>
-        ) : (
-          <div />
         )}
-        {buildNumber && <span className="text-[11px] text-muted-foreground">build {buildNumber}</span>}
+        {githubUrl && shortRef && buildNumber && <div className="h-3 w-px bg-border" />}
+        {buildNumber && <span className="font-mono text-xs text-muted-foreground">build {buildNumber}</span>}
       </div>
-      <div className="flex items-center gap-0.5">
+      <div className="ml-auto flex items-center gap-3">
         {mcpInfo?.enabled && mcpInfo.url && <MCPStatus info={mcpInfo} />}
         {mcpInfo?.error && <MCPError message={mcpInfo.error} />}
-        <IconButton size="xs" variant="ghost" icon={MessagesSquare} aria-label="Feedback" onClick={openFeedback} />
-        <FeaturePreviews features={featurePreviews} onToggle={onToggleFeaturePreview} />
+        <IconButton size="xs" variant="ghost" icon={MessagesSquare} aria-label="Feedback" onClick={openFeedback} className={statusBarIconClass} />
+        <FeaturePreviews features={featurePreviews} onToggle={onToggleFeaturePreview} className={statusBarIconClass} />
         <IconButton
           size="xs"
           variant="ghost"
@@ -178,6 +173,7 @@ export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, f
           icon={colorMode === "night" ? Sun : Moon}
           aria-label={colorMode === "night" ? "Switch to light theme" : "Switch to dark theme"}
           onClick={onToggleColorMode}
+          className={statusBarIconClass}
         />
       </div>
     </div>

--- a/ui/src/Tabs.tsx
+++ b/ui/src/Tabs.tsx
@@ -1,9 +1,7 @@
-import { Ellipsis, Play, X } from "lucide-react";
+import { Ellipsis, X } from "lucide-react";
 import { cn } from "./cn";
-import { Button } from "./components/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { IconButton } from "./components/icon-button";
-import { SimpleTooltip } from "./components/tooltip";
 import { useMediaQuery } from "./useMediaQuery";
 
 import React, { ReactElement, useCallback, useEffect, useRef, useState } from "react";
@@ -22,21 +20,19 @@ interface TabsProps {
   onCloseTab?: (index: number) => void;
   onCloseAll?: () => void;
   onCloseOthers?: (index: number) => void;
-  // When set, a compact Run button is docked into the tab-strip control cluster.
-  onRun?: () => void;
 }
 
 export function Tab({ children }: TabProps) {
   return <>{children}</>;
 }
 
-export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onCloseAll, onCloseOthers, onRun }: TabsProps) {
+export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onCloseAll, onCloseOthers }: TabsProps) {
   const isNarrow = useMediaQuery("(max-width: 767px)");
   const overflow = isNarrow ? "auto" : "hidden";
   const tabsHeaderRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<Map<number, HTMLDivElement>>(new Map());
-  // Width of the right-hand control cluster (Run + Tab options), measured so tabs
-  // reserve room for it and scrolling keeps them clear of it.
+  // Width of the overflow menu, the only control pinned to the strip, measured so
+  // tabs reserve room for it and scrolling keeps them clear of it.
   const controlsRef = useRef<HTMLDivElement>(null);
   const controlsWidthRef = useRef(0);
   const [controlsWidth, setControlsWidth] = useState(0);
@@ -105,7 +101,7 @@ export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onClos
     const observer = new ResizeObserver(update);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [onRun, onCloseAll, children]);
+  }, [onCloseAll, children]);
 
   const handleContextMenu = useCallback((event: React.MouseEvent, index: number) => {
     event.preventDefault();
@@ -171,21 +167,14 @@ export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onClos
           })}
           <div className="grow border-b border-border" />
         </div>
-        {tabCount > 0 && (onRun || onCloseAll) && (
-          <div ref={controlsRef} className="absolute bottom-0 right-0 top-0 flex items-center gap-1.5 border-b border-border bg-background pl-1 pr-2">
-            {onRun && (
-              <SimpleTooltip text="Run (F5)" side="bottom">
-                <Button
-                  onClick={onRun}
-                  size="sm"
-                  className="h-[22px] rounded-md bg-emerald-600 pl-[7px] pr-[9px] text-xs font-medium text-white hover:bg-emerald-700"
-                >
-                  <Play size={14} />
-                  Run
-                </Button>
-              </SimpleTooltip>
-            )}
-            {onCloseAll && (
+        {tabCount > 0 && onCloseAll && (
+          <>
+            {/* Tabs scroll under the menu, so they fade out instead of being clipped mid-label. */}
+            <div
+              className="pointer-events-none absolute bottom-px top-0 w-6 bg-gradient-to-r from-transparent to-background"
+              style={{ right: controlsWidth }}
+            />
+            <div ref={controlsRef} className="absolute bottom-0 right-0 top-0 flex items-center border-b border-border bg-background pl-1 pr-2">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <IconButton icon={Ellipsis} aria-label="Tab options" variant="ghost" size="sm" tooltip={false} />
@@ -194,8 +183,8 @@ export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onClos
                   <DropdownMenuItem onSelect={onCloseAll}>Close All</DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-            )}
-          </div>
+            </div>
+          </>
         )}
         {showScrollbar && scrollMetrics.width > scrollMetrics.clientWidth && (
           <div

--- a/ui/src/Task.tsx
+++ b/ui/src/Task.tsx
@@ -1,21 +1,31 @@
 import { editor } from "monaco-editor";
+import { useState } from "react";
 import { Editor, onGoToDefinition } from "./Editor";
+import { RunButton } from "./RunButton";
 
 interface TaskProps {
   model: editor.ITextModel;
   onGoToDefinition: onGoToDefinition;
   onEditorReady?: (editorInstance: editor.IStandaloneCodeEditor) => void;
   viewState?: editor.ICodeEditorViewState;
+  onRun: () => void;
+  onStop: () => void;
+  running: boolean;
+  startedAt?: number;
 }
 
-export function Task({ model, onGoToDefinition, onEditorReady, viewState }: TaskProps) {
-  function onEditorMount(editorInstance: editor.IStandaloneCodeEditor) {
-    onEditorReady?.(editorInstance);
+export function Task({ model, onGoToDefinition, onEditorReady, viewState, onRun, onStop, running, startedAt }: TaskProps) {
+  const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null);
+
+  function onEditorMount(instance: editor.IStandaloneCodeEditor) {
+    setEditorInstance(instance);
+    onEditorReady?.(instance);
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+    <div className="relative flex min-h-0 flex-1 flex-col">
       <Editor model={model} onMount={onEditorMount} onGoToDefinition={onGoToDefinition} viewState={viewState} />
+      <RunButton editor={editorInstance} model={model} onRun={onRun} onStop={onStop} running={running} startedAt={startedAt} />
     </div>
   );
 }

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -124,7 +124,10 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
       const elapsed = () => Math.round(performance.now() - startedAt);
 
       try {
-        const call = clientStub[lcfirst(method.name)](input, options);
+        // The run's abort signal is read here rather than captured with the
+        // client, so every call a script makes joins the run that issued it.
+        const abort = client.kaja?._internal.abortSignal;
+        const call = clientStub[lcfirst(method.name)](input, abort ? { ...options, abort } : options);
 
         if (isServerStreaming) {
           const streamCall = call as ServerStreamingCall<any, any>;

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -88,7 +88,18 @@ export interface MethodCallUpdate {
   (methodCall: MethodCall): void;
 }
 
+// A call is in flight until it fails, produces a response, or its stream ends. A
+// stream sets `output` on every message, so it can't be judged by that alone.
+export function isCallInFlight(methodCall: MethodCall): boolean {
+  if (methodCall.error !== undefined) return false;
+  if (methodCall.streamOutputs !== undefined) return !methodCall.streamComplete;
+  return methodCall.output === undefined;
+}
+
 class KajaInternal {
+  // Signal of the run currently in flight, so the calls a script makes can be
+  // aborted from the editor's Stop button. Undefined when nothing is running.
+  abortSignal?: AbortSignal;
   #onMethodCallUpdate: MethodCallUpdate;
 
   constructor(onMethodCallUpdate: MethodCallUpdate) {

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -100,7 +100,16 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
   return { args, runCode: printStatements(runStatements) };
 }
 
-export function runTask(code: string, kaja: Kaja, apps: App[], onError: (error: unknown) => void) {
+// runTask runs a script and resolves once it settles, so the caller can show it
+// as running. Passing a signal lets the caller abort the calls it makes.
+export function runTask(code: string, kaja: Kaja, apps: App[], onError: (error: unknown) => void, signal?: AbortSignal): Promise<void> {
+  const clearSignal = () => {
+    if (kaja._internal.abortSignal === signal) {
+      kaja._internal.abortSignal = undefined;
+    }
+  };
+  kaja._internal.abortSignal = signal;
+
   let result: any;
   try {
     const { args, runCode } = prepareTask(code, kaja, apps);
@@ -117,16 +126,21 @@ export function runTask(code: string, kaja: Kaja, apps: App[], onError: (error: 
 
     result = func(...Object.values(args));
   } catch (err) {
+    clearSignal();
     onError(err);
-    return;
+    return Promise.resolve();
   }
-  if (result && typeof result.then === "function") {
-    result.catch((err: unknown) => {
-      // A cancelled prompt simply stops the script; surface everything else.
-      if (err instanceof AskCancelledError) return;
-      onError(err);
-    });
-  }
+  return Promise.resolve(result)
+    .then(
+      () => {},
+      (err: unknown) => {
+        // A cancelled prompt or an aborted run simply stops the script; surface
+        // everything else.
+        if (err instanceof AskCancelledError || signal?.aborted) return;
+        onError(err);
+      },
+    )
+    .finally(clearSignal);
 }
 
 export interface CapturedRun {


### PR DESCRIPTION
Applied the five main-window changes from the design spec: the sidebar toggle moved to the seam it controls, Run floats over the editor and carries its own Run/Stop state, the tab strip keeps only its overflow menu, the call list collapsed into a select in a full-width console header, and the status bar became a single aligned row.

Stop is a real abort — the run's `AbortSignal` reaches every call the script makes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbBHEKmV9UZXP4t1A9mDhR)_