### PR TITLE
Moved the compiler to a status indicator in the status bar

### DIFF
--- a/.github/scripts/take-demo.js
+++ b/.github/scripts/take-demo.js
@@ -186,24 +186,18 @@ async function takeDemo() {
 
     await page.screenshot({ path: `${DEMO_DIR}/call.png` });
 
-    // 4. Compiler screenshot - click Compiler button and expand first project
+    // 4. Compile log screenshot - open it from the status bar and expand an app
     console.log("Taking compiler screenshot...");
 
-    // Click the Compiler button (CPU icon in sidebar header)
-    const compilerButton = page.locator('button[aria-label="Open Compiler"]');
-    const compilerButtonFallback = page.locator('button[aria-label="Open Compiler"]');
+    // The compile status in the status bar is the way in: it opens a popover
+    // listing every app, and picking one opens its log.
+    await page.locator('button[aria-label*="open app status"]').click();
+    await waitFor(page, '[data-testid="app-status-row"]', "app status popover");
+    await settleDelay(page, 300);
+    await page.locator('[data-testid="app-status-row"]').first().click();
 
-    if ((await compilerButton.count()) > 0) {
-      await compilerButton.click();
-    } else if ((await compilerButtonFallback.count()) > 0) {
-      await compilerButtonFallback.click();
-    } else {
-      // Last fallback
-      await page.locator('button[aria-label*="ompiler"]').click();
-    }
-
-    // Wait for compiler tab to become active
-    await waitFor(page, '[role="tab"][aria-selected="true"]:has-text("Compiler")', "Compiler tab to become active");
+    // Wait for the compile log tab to become active
+    await waitFor(page, '[role="tab"][aria-selected="true"]:has-text("Compile log")', "Compile log tab to become active");
 
     // Wait for compiler content to load - either project items or loading state to finish
     await waitForTextHidden(page, "Loading configuration", "configuration to load");
@@ -212,32 +206,7 @@ async function takeDemo() {
     });
     await settleDelay(page);
 
-    // Expand the first compiled project by clicking its list item
-    const compilerSelectors = ['[data-testid="compiler-item"] li'];
-
-    let clicked = false;
-    for (const selector of compilerSelectors) {
-      const item = page.locator(selector).first();
-      if ((await item.count()) > 0) {
-        await item.click();
-        clicked = true;
-        console.log(`  ✓ Clicked compiler item using: ${selector}`);
-        break;
-      }
-    }
-
-    if (!clicked) {
-      // Last resort: click by visible text
-      const textItem = page.getByText('seating').first();
-      if ((await textItem.count()) > 0) {
-        await textItem.click();
-        console.log("  ✓ Clicked compiler item using text: seating");
-      } else {
-        console.log("  ⚠ Could not find compiler item to expand");
-      }
-    }
-
-    // Wait for logs to expand - look for expanded state or logs container
+    // Opening the log from the popover expands that app's logs already
     await waitFor(page, '[data-testid="compiler-logs"]', "logs to expand", 5000).catch(() => {
       console.log("  ✓ Logs expansion state unknown, proceeding");
     });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -204,6 +204,8 @@ export function App() {
   const [appFormJsonValid, setAppFormJsonValid] = useState(true);
   // One-shot signal to auto-expand a just-added app in the sidebar.
   const [autoExpandApp, setAutoExpandApp] = useState<{ name: string }>();
+  // One-shot signal to expand an app's logs when the compile log is opened for it.
+  const [compileLogExpandApp, setCompileLogExpandApp] = useState<{ name: string }>();
   // Rename dialog and delete confirmation for scripts (right-click menu).
   const [renameScript, setRenameScript] = useState<{ script: Script; name: string } | null>(null);
   const [renameError, setRenameError] = useState<string>();
@@ -1310,7 +1312,11 @@ export function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onRunActiveTab]);
 
-  const onCompilerClick = () => {
+  // Opens the compile log, expanded on an app when one is named. Nothing else
+  // opens it: compiling is reported in the status bar, and the log is where you
+  // go when it has something to say.
+  const onShowCompileLog = (appName?: string) => {
+    setCompileLogExpandApp(appName ? { name: appName } : undefined);
     setTabs((tabs) => {
       const compilerIndex = tabs.findIndex((tab) => tab.type === "compiler");
       if (compilerIndex === -1) {
@@ -1323,6 +1329,19 @@ export function App() {
       }
     });
     persistTabs();
+  };
+
+  // Recompiles one app, or every app when no name is given, by putting it back
+  // to pending — the compilation hook picks it up from there. An app already
+  // compiling is left to finish.
+  const onRecompile = (appName?: string) => {
+    setApps((prevApps) =>
+      prevApps.map((app) => {
+        if (appName !== undefined && app.configuration.name !== appName) return app;
+        if (app.compilation.status === "running" || app.compilation.status === "pending") return app;
+        return { ...app, compilation: { status: "pending" as const, logs: [] } };
+      }),
+    );
   };
 
   const onNewAppClick = () => {
@@ -1376,13 +1395,6 @@ export function App() {
     }
 
     const isEdit = originalName !== undefined;
-    const needsRecompilation =
-      isEdit &&
-      (() => {
-        const originalApp = apps.find((p) => p.configuration.name === originalName);
-        if (!originalApp) return false;
-        return appNeedsRecompile(originalApp.configuration, app);
-      })();
     const isNewApp = !isEdit;
 
     // Update configuration
@@ -1396,11 +1408,6 @@ export function App() {
     const { response } = await client.updateConfiguration({ configuration: updatedConfiguration });
     if (response.configuration) {
       applyConfiguration(response.configuration);
-    }
-
-    // Show compiler tab for new apps or when recompilation is needed
-    if (isNewApp || needsRecompilation) {
-      onCompilerClick();
     }
 
     if (isNewApp) {
@@ -1527,7 +1534,8 @@ export function App() {
                 currentMethod={selectedMethod}
                 currentScriptPath={activeScriptPath}
                 scrollToMethod={scrollToMethod}
-                onCompilerClick={onCompilerClick}
+                onShowCompileLog={onShowCompileLog}
+                onRecompileApp={onRecompile}
                 onNewAppClick={onNewAppClick}
                 onVariablesClick={previewScripts ? onVariablesClick : undefined}
                 autoExpandApp={autoExpandApp}
@@ -1634,8 +1642,8 @@ export function App() {
                     {tabs.map((tab, index) => {
                       if (tab.type === "compiler") {
                         return (
-                          <Tab tabId="compiler" tabLabel="Compiler" key="compiler">
-                            <Compiler apps={apps} configurationLoaded={configurationLoaded} onNewAppClick={onNewAppClick} />
+                          <Tab tabId="compiler" tabLabel="Compile log" key="compiler">
+                            <Compiler apps={apps} configurationLoaded={configurationLoaded} onNewAppClick={onNewAppClick} expandApp={compileLogExpandApp} />
                           </Tab>
                         );
                       }
@@ -1751,6 +1759,10 @@ export function App() {
           featurePreviews={featurePreviews}
           onToggleFeaturePreview={onToggleFeaturePreview}
           mcpInfo={previewMcp ? mcpInfo : undefined}
+          apps={apps}
+          configurationLoaded={configurationLoaded}
+          onShowCompileLog={onShowCompileLog}
+          onRecompile={onRecompile}
         />
       </div>
       <SearchPopup isOpen={isSearchOpen} apps={apps} onClose={() => setIsSearchOpen(false)} onSelect={onSearchMethodSelect} />

--- a/ui/src/CompileStatus.tsx
+++ b/ui/src/CompileStatus.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, CircleX, RotateCw, TriangleAlert } from "lucide-react";
+import { cn } from "./cn";
+import { App } from "./apps";
+import { appType } from "./appTypes";
+import { AppPill } from "./Sidebar";
+import { IconButton } from "./components/icon-button";
+import { Popover, PopoverContent, PopoverTrigger } from "./components/popover";
+import { Spinner } from "./components/spinner";
+import { appWarnings, countMethods, firstErrorMessage, isCompiling, settledLabel, summarizeCompilation, visibleTarget, CompileState } from "./compileSummary";
+
+// How long the green receipt stays up after a batch settles, before the
+// indicator falls back to its resting label.
+const RECEIPT_MS = 3000;
+
+const ICON_SIZE = 14;
+
+interface CompileStatusProps {
+  apps: App[];
+  configurationLoaded: boolean;
+  // Opens the compile log, expanded on the given app.
+  onShowLog: (appName?: string) => void;
+  // Recompiles one app, or every app when no name is given.
+  onRecompile: (appName?: string) => void;
+}
+
+// A state that carries a colour keeps it on hover; the quiet ones lift to the
+// foreground the way the rest of the footer does.
+const stateClass: Record<CompileState, string> = {
+  empty: "",
+  loading: "text-muted-foreground hover:text-foreground",
+  compiling: "text-muted-foreground hover:text-foreground",
+  ready: "text-muted-foreground hover:text-foreground",
+  warning: "text-amber-600 dark:text-amber-400",
+  failed: "text-destructive",
+};
+
+function StateIcon({ state }: { state: CompileState }) {
+  if (state === "loading" || state === "compiling") return <Spinner size="sm" className="size-[14px] text-current" />;
+  if (state === "failed") return <CircleX size={ICON_SIZE} />;
+  if (state === "warning") return <TriangleAlert size={ICON_SIZE} />;
+  return <Check size={ICON_SIZE} />;
+}
+
+// AppRow is the app as the popover states it: what it is, where it points, and
+// what came of compiling it. Selecting it opens the log.
+function AppRow({ app, onShowLog, onRecompile }: { app: App; onShowLog: () => void; onRecompile: () => void }) {
+  const [hovered, setHovered] = useState(false);
+  const status = app.compilation.status;
+  const warnings = appWarnings(app);
+
+  const detail = () => {
+    if (status === "error") {
+      return <span className="text-destructive">{firstErrorMessage(app) ?? "Compilation failed"}</span>;
+    }
+    if (isCompiling(app)) {
+      return <span>{status === "pending" ? "Waiting…" : "Compiling…"}</span>;
+    }
+    const counts = `${app.services.length} service${app.services.length === 1 ? "" : "s"}, ${countMethods(app)} method${countMethods(app) === 1 ? "" : "s"}`;
+    const target = visibleTarget(app);
+    return <span>{target ? `${target} · ${counts}` : counts}</span>;
+  };
+
+  return (
+    <div className="relative" onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+      <button
+        type="button"
+        data-testid="app-status-row"
+        onClick={onShowLog}
+        className="flex w-full items-start gap-2 rounded-md py-1.5 pl-2 pr-9 text-left hover:bg-accent"
+      >
+        <span className="mt-px flex size-[14px] shrink-0 items-center justify-center">
+          {isCompiling(app) ? (
+            <Spinner size="sm" className="size-[14px]" />
+          ) : status === "error" ? (
+            <CircleX size={ICON_SIZE} className="text-destructive" />
+          ) : warnings.length > 0 ? (
+            <TriangleAlert size={ICON_SIZE} className="text-amber-600 dark:text-amber-400" />
+          ) : (
+            <Check size={ICON_SIZE} className="text-emerald-600 dark:text-emerald-400" />
+          )}
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="flex items-center">
+            <span className="truncate text-xs font-medium text-foreground">{app.configuration.name}</span>
+            <AppPill type={appType(app.configuration)} />
+          </span>
+          <span className="truncate text-[11px] text-muted-foreground">{detail()}</span>
+        </span>
+        {!hovered && app.compilation.duration && <span className="shrink-0 pt-px text-[11px] text-muted-foreground">{app.compilation.duration}</span>}
+      </button>
+      {/* Outside the row button: a button can't nest another one. */}
+      {hovered && (
+        <IconButton
+          size="xs"
+          variant="ghost"
+          tooltip={false}
+          icon={RotateCw}
+          aria-label={`Recompile ${app.configuration.name}`}
+          className="absolute right-2 top-1.5"
+          onClick={onRecompile}
+        />
+      )}
+    </div>
+  );
+}
+
+// CompileStatus rolls the compile state of every app into one footer item, and
+// keeps the detail — per app, and the logs behind it — one click away.
+export function CompileStatus({ apps, configurationLoaded, onShowLog, onRecompile }: CompileStatusProps) {
+  const [open, setOpen] = useState(false);
+  const [receipt, setReceipt] = useState<string>();
+  const summary = summarizeCompilation(apps, configurationLoaded);
+
+  const batchStart = useRef<number | undefined>(undefined);
+  const wasCompiling = useRef(false);
+  useEffect(() => {
+    if (summary.compiling > 0) {
+      if (!wasCompiling.current) {
+        batchStart.current = Date.now();
+        wasCompiling.current = true;
+      }
+      setReceipt(undefined);
+      return;
+    }
+    if (!wasCompiling.current) return;
+    wasCompiling.current = false;
+    if (summary.state !== "ready" || batchStart.current === undefined) return;
+    setReceipt(settledLabel(apps, Date.now() - batchStart.current));
+    const timer = setTimeout(() => setReceipt(undefined), RECEIPT_MS);
+    return () => clearTimeout(timer);
+  }, [summary.compiling, summary.state]);
+
+  // A failure asks for attention exactly once: the popover opens itself when an
+  // app that wasn't failing starts to, and only after the batch has settled, so
+  // it doesn't appear mid-compile. A recompile of an unrelated app leaves it
+  // alone.
+  const failedNames = apps.filter((app) => app.compilation.status === "error").map((app) => app.configuration.name);
+  const failedKey = failedNames.join(",");
+  const seenFailures = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (summary.compiling > 0) return;
+    const isNew = failedNames.some((name) => !seenFailures.current.has(name));
+    seenFailures.current = new Set(failedNames);
+    if (isNew) setOpen(true);
+  }, [failedKey, summary.compiling]);
+
+  if (summary.state === "empty") return null;
+
+  const settled = receipt !== undefined;
+  const label = receipt ?? summary.label;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${label}, open app status`}
+          className={cn(
+            "flex h-6 items-center gap-1.5 rounded px-1.5 text-xs transition-colors hover:bg-accent",
+            settled ? "text-emerald-600 dark:text-emerald-400" : stateClass[summary.state],
+          )}
+        >
+          <StateIcon state={settled ? "ready" : summary.state} />
+          <span aria-live="polite">{label}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" side="top" className="w-[360px] p-1">
+        <div className="flex items-center justify-between px-2 py-1">
+          <span className="text-xs font-semibold text-foreground">Apps</span>
+          <IconButton size="xs" variant="ghost" tooltip={false} icon={RotateCw} aria-label="Recompile all" onClick={() => onRecompile()} />
+        </div>
+        <div className="max-h-[320px] overflow-y-auto">
+          {apps.map((app) => (
+            <AppRow
+              key={app.configuration.name}
+              app={app}
+              onShowLog={() => {
+                setOpen(false);
+                onShowLog(app.configuration.name);
+              }}
+              onRecompile={() => onRecompile(app.configuration.name)}
+            />
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/src/Compiler.tsx
+++ b/ui/src/Compiler.tsx
@@ -3,7 +3,7 @@ import { cn } from "./cn";
 import { ActionList } from "./components/action-list";
 import { Spinner } from "./components/spinner";
 import { FirstAppBlankslate } from "./FirstAppBlankslate";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CompilationStatus, App } from "./apps";
 import { appType, appTypeLabel } from "./appTypes";
 
@@ -11,13 +11,22 @@ interface CompilerProps {
   apps: App[];
   configurationLoaded: boolean;
   onNewAppClick?: () => void;
+  // The app the log was opened for; its logs are expanded and scrolled to.
+  expandApp?: { name: string };
 }
 
 const CHEVRON_SIZE = 16;
 const CHECK_ICON_SIZE = 12;
 
-export function Compiler({ apps, configurationLoaded, onNewAppClick }: CompilerProps) {
+export function Compiler({ apps, configurationLoaded, onNewAppClick, expandApp }: CompilerProps) {
   const [expandedApps, setExpandedApps] = useState<Set<string>>(new Set());
+  const itemRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  useEffect(() => {
+    if (!expandApp) return;
+    setExpandedApps((prev) => new Set(prev).add(expandApp.name));
+    itemRefs.current.get(expandApp.name)?.scrollIntoView({ block: "nearest" });
+  }, [expandApp]);
 
   const toggleExpand = (appName: string) => {
     setExpandedApps((prev) => {
@@ -81,7 +90,15 @@ export function Compiler({ apps, configurationLoaded, onNewAppClick }: CompilerP
         {apps.map((app, index) => {
           const isExpanded = expandedApps.has(app.configuration.name);
           return (
-            <div key={`app-${index}-${app.configuration.name}`} data-testid="compiler-item" className="relative">
+            <div
+              key={`app-${index}-${app.configuration.name}`}
+              data-testid="compiler-item"
+              className="relative"
+              ref={(el) => {
+                if (el) itemRefs.current.set(app.configuration.name, el);
+                else itemRefs.current.delete(app.configuration.name);
+              }}
+            >
               <div className={cn(isExpanded && "sticky top-0 z-10 bg-background")}>
                 <ActionList>
                   <ActionList.Item

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -4,15 +4,17 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { IconButton } from "./components/icon-button";
 import { TreeView } from "./components/tree-view";
 import {
-  Cpu,
+  CircleX,
   FileCode,
   FoldVertical,
   Pencil,
   Pin,
   Plus,
+  RotateCw,
   Settings,
   SlidersHorizontal,
   Trash2,
+  TriangleAlert,
   UnfoldVertical,
   ChevronRight,
   Package,
@@ -20,6 +22,7 @@ import {
 } from "lucide-react";
 import { appType, appTypeLabel } from "./appTypes";
 import { Method, App, Script, Service, methodId } from "./apps";
+import { appWarnings, firstErrorMessage } from "./compileSummary";
 import { getPersistedValue, setPersistedValue } from "./storage";
 
 // Width the macOS traffic lights occupy at the window's left edge. The desktop
@@ -46,7 +49,7 @@ function groupServicesByPackage(services: Service[]): [string, Service[]][] {
 
 const pillClass = "ml-1.5 rounded bg-accent px-[5px] py-px text-[9px] font-bold text-accent-foreground";
 
-function AppPill({ type }: { type: string }) {
+export function AppPill({ type }: { type: string }) {
   return <span className={pillClass}>{appTypeLabel(type)}</span>;
 }
 
@@ -74,7 +77,9 @@ interface SidebarProps {
   onRenameScript?: (script: Script) => void;
   onDeleteScript?: (script: Script) => void;
   onPinScript?: (script: Script) => void;
-  onCompilerClick: () => void;
+  // Opens the compile log for an app, from the marker on a failed or warned app.
+  onShowCompileLog: (appName: string) => void;
+  onRecompileApp: (appName: string) => void;
   // Opens the create form to add an app (gRPC, Twirp, or a built-in integration).
   onNewAppClick: () => void;
   // Opens the variables manager tab. Undefined when the feature preview is off.
@@ -101,7 +106,8 @@ export function Sidebar({
   onRenameScript,
   onDeleteScript,
   onPinScript,
-  onCompilerClick,
+  onShowCompileLog,
+  onRecompileApp,
   onNewAppClick,
   onVariablesClick,
   autoExpandApp,
@@ -409,7 +415,6 @@ export function Sidebar({
           }
         >
           <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New app" onClick={onNewAppClick} />
-          <IconButton icon={Cpu} size="sm" variant="ghost" aria-label="Open Compiler" onClick={onCompilerClick} />
           {onVariablesClick && <IconButton icon={SlidersHorizontal} size="sm" variant="ghost" aria-label="Variables" onClick={onVariablesClick} />}
         </div>
         <div style={{ flex: 1 }} />
@@ -524,6 +529,7 @@ export function Sidebar({
                     </span>
                     {appName}
                     <AppPill type={appType(app.configuration)} />
+                    <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
                   </span>
                   {(hoveredApp === appName || appMenu?.appName === appName) && (
                     <IconButton
@@ -697,6 +703,15 @@ export function Sidebar({
             <Settings size={16} />
             Settings
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              const appName = appMenu?.appName;
+              if (appName) onRecompileApp(appName);
+            }}
+          >
+            <RotateCw size={16} />
+            Recompile
+          </DropdownMenuItem>
           {canDeleteApps && (
             <DropdownMenuItem
               variant="danger"
@@ -712,6 +727,32 @@ export function Sidebar({
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
+  );
+}
+
+// A failed app otherwise looks like an app with no services. The marker says
+// which app is broken and opens its log; warnings get the same treatment a shade
+// quieter.
+function AppCompileMarker({ app, onShowCompileLog }: { app: App; onShowCompileLog: (appName: string) => void }) {
+  const failed = app.compilation.status === "error";
+  const warned = appWarnings(app).length;
+  if (!failed && warned === 0) return null;
+
+  const label = failed ? (firstErrorMessage(app) ?? "Compilation failed") : `${warned} warning${warned === 1 ? "" : "s"}`;
+
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={`${app.configuration.name}: ${label}. Show compile log`}
+      className={cn("ml-1.5 inline-flex items-center", failed ? "text-destructive" : "text-amber-600 dark:text-amber-400")}
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        onShowCompileLog(app.configuration.name);
+      }}
+    >
+      {failed ? <CircleX size={13} /> : <TriangleAlert size={13} />}
+    </button>
   );
 }
 

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { GitBranch, MessagesSquare, Moon, Sun, Plug } from "lucide-react";
 import { cn } from "./cn";
 import { Button } from "./components/button";
@@ -8,6 +8,9 @@ import { SegmentedControl } from "./components/segmented-control";
 import { isWailsEnvironment } from "./wails";
 import { BrowserOpenURL } from "./wailsjs/runtime/runtime";
 import { FeaturePreview, FeaturePreviews } from "./FeaturePreviews";
+import { CompileStatus } from "./CompileStatus";
+import { summarizeCompilation } from "./compileSummary";
+import { App } from "./apps";
 import { main } from "./wailsjs/go/models";
 
 export type ColorMode = "day" | "night";
@@ -24,6 +27,10 @@ interface StatusBarProps {
   featurePreviews: FeaturePreview[];
   onToggleFeaturePreview: (key: string) => void;
   mcpInfo?: main.MCPInfo;
+  apps: App[];
+  configurationLoaded: boolean;
+  onShowCompileLog: (appName?: string) => void;
+  onRecompile: (appName?: string) => void;
 }
 
 // McpClient is one way to connect an agent to the local MCP server. Each client
@@ -132,7 +139,19 @@ function openFeedback() {
   }
 }
 
-export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, featurePreviews, onToggleFeaturePreview, mcpInfo }: StatusBarProps) {
+export function StatusBar({
+  colorMode,
+  onToggleColorMode,
+  gitRef,
+  buildNumber,
+  featurePreviews,
+  onToggleFeaturePreview,
+  mcpInfo,
+  apps,
+  configurationLoaded,
+  onShowCompileLog,
+  onRecompile,
+}: StatusBarProps) {
   const shortRef = gitRef ? (gitRef.length > 7 ? gitRef.slice(0, 7) : gitRef) : undefined;
   const githubUrl = gitRef ? `https://github.com/wham/kaja/tree/${gitRef}` : undefined;
 
@@ -143,25 +162,49 @@ export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, f
     }
   };
 
+  // The left cluster is whatever this build has to say about itself, separated by
+  // rules. The compile status sits at the end so its label can grow and shrink
+  // without moving the ref and the build around.
+  const leftItems: React.ReactNode[] = [];
+  if (githubUrl && shortRef) {
+    leftItems.push(
+      <a
+        key="ref"
+        href={githubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleLinkClick}
+        className="inline-flex items-center gap-2 text-xs text-muted-foreground no-underline hover:text-foreground"
+      >
+        <GitBranch size={14} />
+        <span>{shortRef}</span>
+      </a>,
+    );
+  }
+  if (buildNumber) {
+    leftItems.push(
+      <span key="build" className="font-mono text-xs text-muted-foreground">
+        build {buildNumber}
+      </span>,
+    );
+  }
+  if (summarizeCompilation(apps, configurationLoaded).state !== "empty") {
+    leftItems.push(
+      <CompileStatus key="compile" apps={apps} configurationLoaded={configurationLoaded} onShowLog={onShowCompileLog} onRecompile={onRecompile} />,
+    );
+  }
+
   // The right padding is 11, not 12: these glyphs are smaller than the rest of the
   // chrome's, so they need one pixel less to land on the same 16px right line.
   return (
     <div className="flex h-[30px] shrink-0 items-center border-t border-border bg-background pl-3 pr-[11px]">
       <div className="flex items-center gap-2">
-        {githubUrl && shortRef && (
-          <a
-            href={githubUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={handleLinkClick}
-            className="inline-flex items-center gap-2 text-xs text-muted-foreground no-underline hover:text-foreground"
-          >
-            <GitBranch size={14} />
-            <span>{shortRef}</span>
-          </a>
-        )}
-        {githubUrl && shortRef && buildNumber && <div className="h-3 w-px bg-border" />}
-        {buildNumber && <span className="font-mono text-xs text-muted-foreground">build {buildNumber}</span>}
+        {leftItems.map((item, index) => (
+          <Fragment key={index}>
+            {index > 0 && <div className="h-3 w-px bg-border" />}
+            {item}
+          </Fragment>
+        ))}
       </div>
       <div className="ml-auto flex items-center gap-3">
         {mcpInfo?.enabled && mcpInfo.url && <MCPStatus info={mcpInfo} />}

--- a/ui/src/compileSummary.test.ts
+++ b/ui/src/compileSummary.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { App, CompilationStatus, createPendingApp } from "./apps";
+import { LogLevel } from "./server/api";
+import { appWarnings, countMethods, firstErrorMessage, settledLabel, summarizeCompilation } from "./compileSummary";
+
+function app(name: string, status: CompilationStatus, logs: { level: LogLevel; message: string }[] = []): App {
+  const app = createPendingApp({ name, grpc: { url: "", protoDir: "", headers: {} }, app: { oneofKind: "grpc" } } as any);
+  app.compilation = { status, logs: logs.map((log) => ({ level: log.level, message: log.message })) as any };
+  return app;
+}
+
+const WARN = { level: LogLevel.LEVEL_WARN, message: "deprecated option" };
+const ERROR = { level: LogLevel.LEVEL_ERROR, message: "unknown type Foo" };
+
+describe("summarizeCompilation", () => {
+  test("no apps yet and no configuration is still loading", () => {
+    expect(summarizeCompilation([], false)).toMatchObject({ state: "loading", label: "Loading…" });
+  });
+
+  test("a workspace with no apps says nothing", () => {
+    expect(summarizeCompilation([], true)).toMatchObject({ state: "empty", label: "" });
+  });
+
+  test("all ready counts the apps", () => {
+    expect(summarizeCompilation([app("a", "success"), app("b", "success")], true)).toMatchObject({ state: "ready", label: "2 apps", ready: 2 });
+  });
+
+  test("a single app is not pluralized", () => {
+    expect(summarizeCompilation([app("a", "success")], true)).toMatchObject({ state: "ready", label: "1 app" });
+  });
+
+  test("one app compiling is named", () => {
+    expect(summarizeCompilation([app("seating", "running"), app("b", "success")], true)).toMatchObject({
+      state: "compiling",
+      label: "Compiling seating…",
+    });
+  });
+
+  test("several apps compiling are counted", () => {
+    expect(summarizeCompilation([app("a", "running"), app("b", "pending")], true)).toMatchObject({ state: "compiling", label: "Compiling 2 apps…" });
+  });
+
+  test("some failed reports the share of the workspace", () => {
+    const apps = [app("a", "error", [ERROR]), app("b", "success"), app("c", "success")];
+    expect(summarizeCompilation(apps, true)).toMatchObject({ state: "failed", label: "1 of 3 apps failed", failed: 1 });
+  });
+
+  test("all failed says so", () => {
+    const apps = [app("a", "error", [ERROR]), app("b", "error", [ERROR])];
+    expect(summarizeCompilation(apps, true)).toMatchObject({ state: "failed", label: "All 2 apps failed" });
+  });
+
+  test("the only app is named when it fails", () => {
+    expect(summarizeCompilation([app("quirks", "error", [ERROR])], true)).toMatchObject({ state: "failed", label: "quirks failed" });
+  });
+
+  test("failure outranks a compile still in flight", () => {
+    const apps = [app("a", "error", [ERROR]), app("b", "running")];
+    expect(summarizeCompilation(apps, true)).toMatchObject({ state: "failed", label: "1 of 2 apps failed" });
+  });
+
+  test("warnings surface once everything settles", () => {
+    const apps = [app("a", "success", [WARN]), app("b", "success")];
+    expect(summarizeCompilation(apps, true)).toMatchObject({ state: "warning", label: "2 apps · 1 warning" });
+  });
+
+  test("progress outranks a warning", () => {
+    const apps = [app("a", "success", [WARN]), app("b", "running")];
+    expect(summarizeCompilation(apps, true)).toMatchObject({ state: "compiling" });
+  });
+
+  test("warnings on an app that failed are not counted twice", () => {
+    const apps = [app("a", "error", [WARN, ERROR]), app("b", "success")];
+    expect(summarizeCompilation(apps, true)).toMatchObject({ state: "failed", warnings: 0 });
+  });
+});
+
+describe("app details", () => {
+  test("warnings are only read off a successful compile", () => {
+    expect(appWarnings(app("a", "success", [WARN]))).toHaveLength(1);
+    expect(appWarnings(app("a", "error", [WARN]))).toHaveLength(0);
+  });
+
+  test("the first error is the line worth showing", () => {
+    expect(firstErrorMessage(app("a", "error", [{ level: LogLevel.LEVEL_INFO, message: "Starting" }, ERROR]))).toBe("unknown type Foo");
+  });
+
+  test("without an error line the last log stands in", () => {
+    expect(firstErrorMessage(app("a", "error", [{ level: LogLevel.LEVEL_INFO, message: "Starting" }]))).toBe("Starting");
+  });
+
+  test("an app that logged nothing has no line", () => {
+    expect(firstErrorMessage(app("a", "error"))).toBeUndefined();
+  });
+
+  test("methods are counted across services", () => {
+    const withServices = app("a", "success");
+    withServices.services = [
+      { name: "S", packageName: "p", sourcePath: "", clientStubModuleId: "", methods: [{ name: "m" }, { name: "n" }] },
+      { name: "T", packageName: "p", sourcePath: "", clientStubModuleId: "", methods: [{ name: "o" }] },
+    ];
+    expect(countMethods(withServices)).toBe(3);
+  });
+});
+
+describe("settledLabel", () => {
+  test("sub-second compiles keep a decimal", () => {
+    expect(settledLabel([app("a", "success")], 1400)).toBe("1 app ready · 1.4s");
+  });
+
+  test("a very fast compile still reads as time passing", () => {
+    expect(settledLabel([app("a", "success")], 12)).toBe("1 app ready · 0.1s");
+  });
+
+  test("long compiles round to whole seconds", () => {
+    expect(settledLabel([app("a", "success"), app("b", "success")], 12400)).toBe("2 apps ready · 12s");
+  });
+});

--- a/ui/src/compileSummary.ts
+++ b/ui/src/compileSummary.ts
@@ -1,0 +1,96 @@
+import { App } from "./apps";
+import { Log, LogLevel } from "./server/api";
+
+// The compile state of the whole workspace, rolled up for the status bar. A
+// failure outranks a warning outranks progress, so the indicator never has to
+// combine two states in one label.
+export type CompileState = "empty" | "loading" | "compiling" | "failed" | "warning" | "ready";
+
+export interface CompileSummary {
+  state: CompileState;
+  total: number;
+  ready: number;
+  failed: number;
+  compiling: number;
+  // Apps that compiled but logged a warning.
+  warnings: number;
+  label: string;
+}
+
+export function isCompiling(app: App): boolean {
+  return app.compilation.status === "pending" || app.compilation.status === "running";
+}
+
+export function appWarnings(app: App): Log[] {
+  if (app.compilation.status !== "success") return [];
+  return app.compilation.logs.filter((log) => log.level === LogLevel.LEVEL_WARN);
+}
+
+// The line to show for a failed app: its first error, falling back to the last
+// thing it logged before giving up.
+export function firstErrorMessage(app: App): string | undefined {
+  const logs = app.compilation.logs;
+  const error = logs.find((log) => log.level === LogLevel.LEVEL_ERROR);
+  return (error ?? logs[logs.length - 1])?.message;
+}
+
+// Where the app's calls go, when that is worth stating. An in-process app is
+// reached through a generated kaja-app:// id, which says nothing to the reader.
+export function visibleTarget(app: App): string {
+  return app.target.startsWith("kaja-app://") ? "" : app.target;
+}
+
+export function countMethods(app: App): number {
+  return app.services.reduce((total, service) => total + service.methods.length, 0);
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+export function summarizeCompilation(apps: App[], configurationLoaded: boolean): CompileSummary {
+  const compiling = apps.filter(isCompiling);
+  const failed = apps.filter((app) => app.compilation.status === "error");
+  const warned = apps.filter((app) => appWarnings(app).length > 0);
+  const ready = apps.filter((app) => app.compilation.status === "success");
+
+  const summary: Omit<CompileSummary, "state" | "label"> = {
+    total: apps.length,
+    ready: ready.length,
+    failed: failed.length,
+    compiling: compiling.length,
+    warnings: warned.length,
+  };
+
+  if (apps.length === 0) {
+    return configurationLoaded ? { ...summary, state: "empty", label: "" } : { ...summary, state: "loading", label: "Loading…" };
+  }
+
+  if (failed.length > 0) {
+    if (apps.length === 1) {
+      return { ...summary, state: "failed", label: `${failed[0].configuration.name} failed` };
+    }
+    if (failed.length === apps.length) {
+      return { ...summary, state: "failed", label: `All ${plural(apps.length, "app")} failed` };
+    }
+    return { ...summary, state: "failed", label: `${failed.length} of ${apps.length} apps failed` };
+  }
+
+  if (compiling.length > 0) {
+    const label = compiling.length === 1 ? `Compiling ${compiling[0].configuration.name}…` : `Compiling ${plural(compiling.length, "app")}…`;
+    return { ...summary, state: "compiling", label };
+  }
+
+  if (warned.length > 0) {
+    return { ...summary, state: "warning", label: `${plural(apps.length, "app")} · ${plural(warned.length, "warning")}` };
+  }
+
+  return { ...summary, state: "ready", label: plural(apps.length, "app") };
+}
+
+// The receipt shown for a few seconds after a batch settles green.
+export function settledLabel(apps: App[], milliseconds: number): string {
+  const seconds = Math.max(milliseconds, 100) / 1000;
+  const duration = seconds >= 10 ? `${Math.round(seconds)}s` : `${seconds.toFixed(1)}s`;
+  return `${plural(apps.length, "app")} ready · ${duration}`;
+}


### PR DESCRIPTION
The Compiler is no longer a tab that opens itself — it's a compile status roll-up in the status bar (ready / compiling / warnings / failed) with a popover listing every app, and the log one click behind it. Failed and warned apps are now marked in the sidebar, and apps can be recompiled without re-saving them.