### PR TITLE
Aligned the right-edge icon buttons on one line

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1560,7 +1560,6 @@ export function App() {
                       size="sm"
                       variant="ghost"
                       tooltip={false}
-                      className="[&_svg]:size-[17px]"
                     />
                   </SimpleTooltip>
                 </div>
@@ -1573,6 +1572,9 @@ export function App() {
                   {navigator.platform.startsWith("Mac") ? "⌘K" : "Ctrl+K"} to search
                 </div>
               </div>
+              {/* Every control on this pane's right edge — here, in the tab strip, in the
+                  console header — puts its icon on the same vertical line, 16px in. The
+                  padding is that line minus the button's own centering room. */}
               <div
                 style={
                   {
@@ -1580,7 +1582,7 @@ export function App() {
                     minWidth: 0,
                     display: "flex",
                     justifyContent: "flex-end",
-                    paddingRight: 12,
+                    paddingRight: 10,
                     gap: 2,
                     "--wails-draggable": "no-drag",
                   } as React.CSSProperties
@@ -1594,7 +1596,6 @@ export function App() {
                     size="sm"
                     variant="ghost"
                     tooltip={false}
-                    className="[&_svg]:size-[17px]"
                   />
                 </SimpleTooltip>
               </div>

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -143,8 +143,10 @@ export function StatusBar({ colorMode, onToggleColorMode, gitRef, buildNumber, f
     }
   };
 
+  // The right padding is 11, not 12: these glyphs are smaller than the rest of the
+  // chrome's, so they need one pixel less to land on the same 16px right line.
   return (
-    <div className="flex h-[30px] shrink-0 items-center border-t border-border bg-background px-3">
+    <div className="flex h-[30px] shrink-0 items-center border-t border-border bg-background pl-3 pr-[11px]">
       <div className="flex items-center gap-2">
         {githubUrl && shortRef && (
           <a

--- a/ui/src/Tabs.tsx
+++ b/ui/src/Tabs.tsx
@@ -179,7 +179,7 @@ export function Tabs({ children, activeTabIndex, onSelectTab, onCloseTab, onClos
               className="pointer-events-none absolute bottom-px top-0 w-6 bg-gradient-to-r from-transparent to-background"
               style={{ right: controlsWidth }}
             />
-            <div ref={controlsRef} className="absolute bottom-0 right-0 top-0 flex items-center gap-1 border-b border-border bg-background pl-1 pr-2">
+            <div ref={controlsRef} className="absolute bottom-0 right-0 top-0 flex items-center gap-1 border-b border-border bg-background pl-1 pr-2.5">
               {controls}
               {onCloseAll && (
                 <DropdownMenu>


### PR DESCRIPTION
The layout toggle, the tab strip's controls, the console utilities and the status bar icons each sat on their own line, 14–17.5px from the pane's right edge; they now all put their glyph 16px in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMrSeVhvWK4AkxEFkCkKKN)_