### PR TITLE
Replaced request prefill with value completions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Ask me before adding a new shared UI primitive; one-off compositions of existing primitives are fine.
 - Keep pull-request descriptions super short - one or two sentences summarizing the change.
 - Don't reference specific example services (e.g. names of APIs used to reproduce a bug) in code, comments, or tests. Keep them generic — they are just random examples.
+- Values seen in earlier calls are never written into a generated request: `defaultInput.ts` only ever emits zero values, and `typeMemory.ts` + `valueCompletions.ts` offer what was seen as editor completions, each labelled with the field and call it came from.
 
 ## Experimental (Preview)
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,7 +23,7 @@ import { SearchPopup } from "./SearchPopup";
 import { StatusBar, ColorMode } from "./StatusBar";
 import { FeaturePreview } from "./FeaturePreviews";
 import { AppForm } from "./AppForm";
-import { registerKajaModule } from "./Editor";
+import { registerKajaModule, setValueCompletionApps } from "./Editor";
 import { monacoTheme } from "./monacoTheme";
 import { remapEditorCode, remapSourcesToNewName } from "./sources";
 import { Configuration, ConfigurationApp, LogLevel } from "./server/api";
@@ -560,6 +560,11 @@ export function App() {
   }, [applyConfiguration]);
 
   useConfigurationChanges(handleConfigurationFileChange);
+
+  // Let the editor's value completions resolve the services the open apps expose.
+  useEffect(() => {
+    setValueCompletionApps(apps);
+  }, [apps]);
 
   useEffect(() => {
     monaco.editor.setTheme(monacoTheme(colorMode));

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -1,8 +1,10 @@
 import * as monaco from "monaco-editor";
 import { useEffect, useRef } from "react";
+import { App } from "./apps";
 import { formatTypeScript, formatTypeScriptWithCursor } from "./formatter";
 import { findTimestamps, timestampToDate, formatDateForDisplay } from "./timestampPicker";
 import { TimestampPickerContentWidget } from "./TimestampPickerWidget";
+import { suggestValues } from "./valueCompletions";
 
 self.MonacoEnvironment = {
   getWorkerUrl: function (_, label) {
@@ -112,6 +114,67 @@ monaco.languages.registerCompletionItemProvider("typescript", {
           additionalTextEdits: [{ range: new monaco.Range(1, 1, 1, 1), text: 'import { kaja } from "kaja";\n' }],
         },
       ],
+    };
+  },
+});
+
+// Apps the value completions resolve service names against. Kept in sync from
+// App.tsx as apps compile.
+let valueCompletionApps: App[] = [];
+
+export function setValueCompletionApps(apps: App[]): void {
+  valueCompletionApps = apps;
+}
+
+function truncate(text: string): string {
+  return text.length > 60 ? text.slice(0, 59) + "…" : text;
+}
+
+// Escape a value so it survives being dropped between quotes, whichever quote
+// style the literal under the cursor uses.
+function escapeForStringLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "\\'").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
+}
+
+// Values from earlier calls are offered here rather than written into the
+// generated request, so filling a field in stays a deliberate keystroke.
+monaco.languages.registerCompletionItemProvider("typescript", {
+  triggerCharacters: ['"', "'", ":", " "],
+  provideCompletionItems(model, position) {
+    if (valueCompletionApps.length === 0) {
+      return { suggestions: [] };
+    }
+
+    const suggested = suggestValues(model.getValue(), model.getOffsetAt(position), valueCompletionApps);
+    if (!suggested) {
+      return { suggestions: [] };
+    }
+
+    const stringRange = suggested.position.stringRange;
+    let range: monaco.Range;
+    if (stringRange) {
+      const start = model.getPositionAt(stringRange.start);
+      const end = model.getPositionAt(stringRange.end);
+      range = new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column);
+    } else {
+      const word = model.getWordUntilPosition(position);
+      range = new monaco.Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn);
+    }
+
+    return {
+      suggestions: suggested.values.map((remembered, index) => {
+        const text = String(remembered.value);
+        const typeName = remembered.typeName.slice(remembered.typeName.lastIndexOf(".") + 1);
+        return {
+          label: truncate(text),
+          kind: monaco.languages.CompletionItemKind.Value,
+          detail: `${typeName}.${remembered.fieldName} · ${remembered.origin === "request" ? "sent to" : "returned by"} ${remembered.method}`,
+          insertText: stringRange ? escapeForStringLiteral(text) : JSON.stringify(remembered.value),
+          filterText: text,
+          sortText: String(index).padStart(3, "0"),
+          range,
+        };
+      }),
     };
   },
 });

--- a/ui/src/defaultInput.ts
+++ b/ui/src/defaultInput.ts
@@ -1,7 +1,6 @@
 import { EnumInfo, FieldInfo, IMessageType, ScalarType } from "@protobuf-ts/runtime";
 import ts from "typescript";
 import { findEnum, Source, Sources } from "./sources";
-import { getScalarMemorizedValue, getMessageMemorizedValue } from "./typeMemory";
 
 export function defaultMessage<T extends object>(
   message: IMessageType<T>,
@@ -39,10 +38,10 @@ export function defaultMessage<T extends object>(
       // makes multiple operators look "set". Repeated message and enum fields keep
       // one element: there the element carries a nested shape or a concrete valid
       // value that the field name alone doesn't convey.
-      const elements = field.kind === "scalar" ? [] : [defaultMessageField(field, sources, imports, nested, typeName)];
+      const elements = field.kind === "scalar" ? [] : [defaultMessageField(field, sources, imports, nested)];
       value = ts.factory.createArrayLiteralExpression(elements);
     } else {
-      value = defaultMessageField(field, sources, imports, nested, typeName);
+      value = defaultMessageField(field, sources, imports, nested);
     }
 
     properties.push(ts.factory.createPropertyAssignment(field.localName, value));
@@ -67,21 +66,11 @@ export function addImport(imports: Imports, name: string, source: Source): Impor
   return imports;
 }
 
-function defaultMessageField(field: FieldInfo, sources: Sources, imports: Imports, visiting: Set<string>, parentTypeName?: string): ts.Expression {
-  // For scalar fields, try to get memorized value
+function defaultMessageField(field: FieldInfo, sources: Sources, imports: Imports, visiting: Set<string>): ts.Expression {
+  // Scalars start at their zero value. Values from earlier calls are offered as
+  // editor completions instead (see valueCompletions), so what is generated
+  // here is only ever the shape of the request, never a guess at its contents.
   if (field.kind === "scalar") {
-    // First check type memory (more specific - values seen in this exact type)
-    if (parentTypeName) {
-      const typeMemorized = getMessageMemorizedValue(parentTypeName, field.localName);
-      if (typeMemorized !== undefined) {
-        return valueToExpression(typeMemorized);
-      }
-    }
-    // Fall back to scalar memory (broader - any field with this name and protobuf type)
-    const memorized = getScalarMemorizedValue(field.localName, field.T);
-    if (memorized !== undefined) {
-      return valueToExpression(memorized);
-    }
     return defaultScalar(field.T);
   }
 
@@ -128,22 +117,6 @@ function defaultMessageField(field: FieldInfo, sources: Sources, imports: Import
     return defaultMessage(messageType, sources, imports, visiting);
   }
 
-  return ts.factory.createNull();
-}
-
-function valueToExpression(value: any): ts.Expression {
-  if (typeof value === "string") {
-    return ts.factory.createStringLiteral(value);
-  }
-  if (typeof value === "number") {
-    if (value < 0) {
-      return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.MinusToken, ts.factory.createNumericLiteral(Math.abs(value)));
-    }
-    return ts.factory.createNumericLiteral(value);
-  }
-  if (typeof value === "boolean") {
-    return value ? ts.factory.createTrue() : ts.factory.createFalse();
-  }
   return ts.factory.createNull();
 }
 

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,6 +1,6 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
-import { captureValues } from "./typeMemory";
+import { rememberValues } from "./typeMemory";
 
 // Thrown when the user cancels a `kaja.ask(...)` prompt. The task runner
 // swallows it so a cancelled prompt quietly stops the script.
@@ -108,13 +108,12 @@ class KajaInternal {
 
   methodCallUpdate(methodCall: MethodCall) {
     if (methodCall.output && !methodCall.error) {
-      // Capture input values by input type
+      const method = `${methodCall.service.name}.${methodCall.method.name}`;
       if (methodCall.inputTypeName) {
-        captureValues(methodCall.inputTypeName, methodCall.input, methodCall.inputType);
+        rememberValues(methodCall.inputTypeName, methodCall.input, methodCall.inputType, { method, origin: "request" });
       }
-      // Capture output values by output type
       if (methodCall.outputTypeName) {
-        captureValues(methodCall.outputTypeName, methodCall.output, methodCall.outputType);
+        rememberValues(methodCall.outputTypeName, methodCall.output, methodCall.outputType, { method, origin: "response" });
       }
     }
     this.#onMethodCallUpdate(methodCall);

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,6 +6,7 @@ import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import { monacoTheme } from "./monacoTheme";
 import { getPersistedValue, initializeStorage } from "./storage";
+import { pruneTypeMemory } from "./typeMemory";
 import { installUiLog } from "./uiLog";
 
 export * from "@protobuf-ts/runtime";
@@ -14,6 +15,8 @@ export * from "@protobuf-ts/runtime-rpc";
 installUiLog();
 
 initializeStorage().then(() => {
+  pruneTypeMemory();
+
   const colorMode = getPersistedValue<"day" | "night">("colorMode") ?? "night";
   monaco.editor.setTheme(monacoTheme(colorMode));
   document.body.style.backgroundColor = colorMode === "night" ? "#0d1117" : "#ffffff";

--- a/ui/src/typeMemory.test.ts
+++ b/ui/src/typeMemory.test.ts
@@ -1,26 +1,12 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { IMessageType, ScalarType } from "@protobuf-ts/runtime";
-import {
-  captureValues,
-  getMessageMemorizedValue,
-  getScalarMemorizedValue,
-  getScalarMemorizedValues,
-  clearTypeMemory,
-  getAllStoredMessages,
-  getAllStoredScalars,
-} from "./typeMemory";
+import { rememberValues, recallValues, clearTypeMemory, getAllRememberedFields, ValueSource } from "./typeMemory";
 
 // Helper to create a minimal mock message type for testing
-function mockMessageType(typeName: string, fields: { name: string; scalarType: ScalarType }[]): IMessageType<any> {
+function mockMessageType(typeName: string, fields: any[]): IMessageType<any> {
   return {
     typeName,
-    fields: fields.map((f, i) => ({
-      no: i + 1,
-      name: f.name,
-      localName: f.name,
-      kind: "scalar" as const,
-      T: f.scalarType,
-    })),
+    fields: fields.map((field, index) => ({ no: index + 1, localName: field.name, ...field })),
     // Minimal stubs for required methods
     create: () => ({}),
     fromBinary: () => ({}),
@@ -38,205 +24,166 @@ function mockMessageType(typeName: string, fields: { name: string; scalarType: S
   } as unknown as IMessageType<any>;
 }
 
+function scalars(typeName: string, fields: { name: string; scalarType: ScalarType }[]): IMessageType<any> {
+  return mockMessageType(
+    typeName,
+    fields.map((field) => ({ name: field.name, kind: "scalar", T: field.scalarType })),
+  );
+}
+
+const request: ValueSource = { method: "ExampleService.GetCustomer", origin: "request" };
+const response: ValueSource = { method: "ExampleService.ListCustomers", origin: "response" };
+
 describe("typeMemory", () => {
   beforeEach(() => {
     clearTypeMemory();
   });
 
-  describe("captureValues with schema", () => {
-    it("captures scalar values by protobuf type and field name", () => {
-      const messageType = mockMessageType("example.Customer", [
+  describe("rememberValues", () => {
+    it("remembers scalar values with where they came from", () => {
+      const customer = scalars("example.Customer", [
         { name: "id", scalarType: ScalarType.STRING },
-        { name: "name", scalarType: ScalarType.STRING },
         { name: "count", scalarType: ScalarType.INT32 },
         { name: "active", scalarType: ScalarType.BOOL },
       ]);
 
-      captureValues(
-        "example.Customer",
-        {
-          id: "cust-123",
-          name: "Acme Corp",
-          count: 42,
-          active: true,
-        },
-        messageType,
-      );
+      rememberValues("example.Customer", { id: "cust-123", count: 42, active: true }, customer, response);
 
-      // Check scalar memory (field name + protobuf type)
-      expect(getScalarMemorizedValue("id", ScalarType.STRING)).toBe("cust-123");
-      expect(getScalarMemorizedValue("name", ScalarType.STRING)).toBe("Acme Corp");
-      expect(getScalarMemorizedValue("count", ScalarType.INT32)).toBe(42);
-      expect(getScalarMemorizedValue("active", ScalarType.BOOL)).toBe(true);
+      const [id] = recallValues("example.Customer", "id", ScalarType.STRING);
+      expect(id.value).toBe("cust-123");
+      expect(id.typeName).toBe("example.Customer");
+      expect(id.origin).toBe("response");
+      expect(id.method).toBe("ExampleService.ListCustomers");
 
-      // Check type memory (message type + field path)
-      expect(getMessageMemorizedValue("example.Customer", "id")).toBe("cust-123");
-      expect(getMessageMemorizedValue("example.Customer", "name")).toBe("Acme Corp");
+      expect(recallValues("example.Customer", "count", ScalarType.INT32)[0].value).toBe(42);
+      expect(recallValues("example.Customer", "active", ScalarType.BOOL)[0].value).toBe(true);
     });
 
-    it("returns most recently used value", () => {
-      const messageType = mockMessageType("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
+    it("keeps several values per field, most recent first", () => {
+      const customer = scalars("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
 
-      captureValues("example.Customer", { id: "cust-1" }, messageType);
-      captureValues("example.Customer", { id: "cust-2" }, messageType);
-      captureValues("example.Customer", { id: "cust-3" }, messageType);
+      rememberValues("example.Customer", { id: "cust-1" }, customer, request);
+      rememberValues("example.Customer", { id: "cust-2" }, customer, request);
+      rememberValues("example.Customer", { id: "cust-3" }, customer, request);
 
-      // Most recent value should be returned
-      expect(getScalarMemorizedValue("id", ScalarType.STRING)).toBe("cust-3");
-      expect(getMessageMemorizedValue("example.Customer", "id")).toBe("cust-3");
+      expect(recallValues("example.Customer", "id", ScalarType.STRING).map((value) => value.value)).toEqual(["cust-3", "cust-2", "cust-1"]);
 
-      // Using an old value again makes it most recent
-      captureValues("example.Customer", { id: "cust-1" }, messageType);
-      expect(getScalarMemorizedValue("id", ScalarType.STRING)).toBe("cust-1");
-    });
-  });
-
-  describe("captureValues without schema (type memory only)", () => {
-    it("captures to type memory but not scalar memory", () => {
-      captureValues("example.Customer", {
-        id: "cust-123",
-        name: "Acme Corp",
-      });
-
-      // Type memory should work
-      expect(getMessageMemorizedValue("example.Customer", "id")).toBe("cust-123");
-      expect(getMessageMemorizedValue("example.Customer", "name")).toBe("Acme Corp");
-
-      // Scalar memory should be empty (no schema = no protobuf type info)
-      expect(getAllStoredScalars()).toHaveLength(0);
+      // Re-using an older value moves it back to the front rather than duplicating it.
+      rememberValues("example.Customer", { id: "cust-1" }, customer, request);
+      expect(recallValues("example.Customer", "id", ScalarType.STRING).map((value) => value.value)).toEqual(["cust-1", "cust-3", "cust-2"]);
     });
 
-    it("captures only top-level scalar fields (nested objects are different types)", () => {
-      captureValues("example.Order", {
-        orderId: "order-456",
-        customer: {
-          id: "cust-789",
-          name: "Test Customer",
-        },
-        total: 99.99,
-      });
+    it("keeps at most five values per field", () => {
+      const customer = scalars("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
 
-      // Only top-level scalars are captured
-      expect(getMessageMemorizedValue("example.Order", "orderId")).toBe("order-456");
-      expect(getMessageMemorizedValue("example.Order", "total")).toBe(99.99);
-      // Nested objects are not captured without schema (we don't know their type)
-      expect(getMessageMemorizedValue("example.Order", "customer.id")).toBeUndefined();
+      for (let index = 0; index < 8; index++) {
+        rememberValues("example.Customer", { id: `cust-${index}` }, customer, request);
+      }
+
+      expect(recallValues("example.Customer", "id", ScalarType.STRING)).toHaveLength(5);
     });
 
-    it("ignores null/undefined values", () => {
-      captureValues("example.Customer", null);
-      captureValues("example.Customer", undefined);
-
-      expect(getAllStoredMessages()).toHaveLength(0);
-      expect(getAllStoredScalars()).toHaveLength(0);
-    });
-
-    it("ignores empty type names", () => {
-      captureValues("", { id: "test" });
-
-      expect(getAllStoredMessages()).toHaveLength(0);
-      expect(getAllStoredScalars()).toHaveLength(0);
-    });
-  });
-
-  describe("scalar memory with protobuf types", () => {
-    it("shares scalar values across different message types with same field name", () => {
-      const responseType = mockMessageType("example.GetCustomerResponse", [
-        { name: "id", scalarType: ScalarType.STRING },
-        { name: "name", scalarType: ScalarType.STRING },
+    it("remembers nested messages under their own type", () => {
+      const address = scalars("example.Address", [{ name: "city", scalarType: ScalarType.STRING }]);
+      const customer = mockMessageType("example.Customer", [
+        { name: "id", kind: "scalar", T: ScalarType.STRING },
+        { name: "address", kind: "message", T: () => address },
       ]);
 
-      captureValues(
-        "example.GetCustomerResponse",
-        {
-          id: "cust-123",
-          name: "Acme Corp",
-        },
-        responseType,
-      );
+      rememberValues("example.Customer", { id: "cust-1", address: { city: "Berlin" } }, customer, response);
 
-      // The same "id" field name should be available for any STRING field named "id"
-      expect(getScalarMemorizedValue("id", ScalarType.STRING)).toBe("cust-123");
-      expect(getScalarMemorizedValue("name", ScalarType.STRING)).toBe("Acme Corp");
+      expect(recallValues("example.Address", "city", ScalarType.STRING)[0].value).toBe("Berlin");
+      expect(getAllRememberedFields()).toContain("example.Address:city");
+      expect(getAllRememberedFields()).not.toContain("example.Customer:city");
     });
 
-    it("separates same field name with different protobuf types", () => {
-      const typeA = mockMessageType("example.TypeA", [{ name: "count", scalarType: ScalarType.INT32 }]);
-      const typeB = mockMessageType("example.TypeB", [{ name: "count", scalarType: ScalarType.INT64 }]);
+    it("remembers the elements of repeated fields", () => {
+      const customer = scalars("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
+      const list = mockMessageType("example.CustomerList", [{ name: "customers", kind: "message", repeat: 2, T: () => customer }]);
 
-      captureValues("example.TypeA", { count: 42 }, typeA);
-      captureValues("example.TypeB", { count: "100" }, typeB);
+      rememberValues("example.CustomerList", { customers: [{ id: "cust-1" }, { id: "cust-2" }] }, list, response);
 
-      // Different protobuf scalar types are stored separately
-      expect(getScalarMemorizedValue("count", ScalarType.INT32)).toBe(42);
-      expect(getScalarMemorizedValue("count", ScalarType.INT64)).toBe("100");
+      expect(recallValues("example.Customer", "id", ScalarType.STRING).map((value) => value.value)).toEqual(["cust-2", "cust-1"]);
+    });
+
+    it("ignores null, undefined and empty type names", () => {
+      rememberValues("example.Customer", null, undefined, request);
+      rememberValues("example.Customer", undefined, undefined, request);
+      rememberValues("", { id: "test" }, undefined, request);
+
+      expect(getAllRememberedFields()).toHaveLength(0);
+    });
+
+    it("remembers top-level scalars when there is no schema", () => {
+      rememberValues("example.Order", { orderId: "order-456", customer: { id: "cust-789" }, total: 99.99 }, undefined, response);
+
+      expect(recallValues("example.Order", "orderId")[0].value).toBe("order-456");
+      expect(recallValues("example.Order", "total")[0].value).toBe(99.99);
+      // Without a schema there is no way to know the nested object's type.
+      expect(getAllRememberedFields()).not.toContain("example.Customer:id");
     });
   });
 
-  describe("getScalarMemorizedValues", () => {
-    it("returns memorized values for a field", () => {
-      const messageType = mockMessageType("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
+  describe("recallValues", () => {
+    it("offers values from a same-named field of another type, after the exact ones", () => {
+      const customer = scalars("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
+      const getRequest = scalars("example.GetCustomerRequest", [{ name: "id", scalarType: ScalarType.STRING }]);
 
-      captureValues("example.Customer", { id: "cust-1" }, messageType);
+      rememberValues("example.Customer", { id: "from-response" }, customer, response);
+      rememberValues("example.GetCustomerRequest", { id: "from-request" }, getRequest, request);
 
-      const values = getScalarMemorizedValues("id", ScalarType.STRING);
-      expect(values).toHaveLength(1);
-      expect(values).toContain("cust-1");
+      const values = recallValues("example.GetCustomerRequest", "id", ScalarType.STRING);
+      expect(values.map((value) => value.value)).toEqual(["from-request", "from-response"]);
+      expect(values[1].typeName).toBe("example.Customer");
     });
 
-    it("returns empty array for non-existent field", () => {
-      const values = getScalarMemorizedValues("nonExistent", ScalarType.STRING);
-      expect(values).toEqual([]);
+    it("does not mix up same-named fields of different scalar types", () => {
+      const typeA = scalars("example.TypeA", [{ name: "count", scalarType: ScalarType.INT32 }]);
+      const typeB = scalars("example.TypeB", [{ name: "count", scalarType: ScalarType.INT64 }]);
+
+      rememberValues("example.TypeA", { count: 42 }, typeA, request);
+      rememberValues("example.TypeB", { count: "100" }, typeB, request);
+
+      expect(recallValues("example.TypeC", "count", ScalarType.INT32).map((value) => value.value)).toEqual([42]);
+      expect(recallValues("example.TypeC", "count", ScalarType.INT64).map((value) => value.value)).toEqual(["100"]);
+    });
+
+    it("offers nothing across types without a scalar type to match on", () => {
+      const customer = scalars("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
+      rememberValues("example.Customer", { id: "cust-1" }, customer, response);
+
+      expect(recallValues("example.GetCustomerRequest", "id")).toHaveLength(0);
+    });
+
+    it("returns nothing for a field that was never seen", () => {
+      expect(recallValues("example.Customer", "nonExistent", ScalarType.STRING)).toEqual([]);
     });
   });
 
   describe("clearTypeMemory", () => {
-    it("clears all memory", () => {
-      const messageType = mockMessageType("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
-
-      captureValues("example.Customer", { id: "cust-123" }, messageType);
-
-      expect(getScalarMemorizedValue("id", ScalarType.STRING)).toBe("cust-123");
+    it("forgets everything", () => {
+      const customer = scalars("example.Customer", [{ name: "id", scalarType: ScalarType.STRING }]);
+      rememberValues("example.Customer", { id: "cust-123" }, customer, request);
 
       clearTypeMemory();
 
-      expect(getScalarMemorizedValue("id", ScalarType.STRING)).toBeUndefined();
-      expect(getMessageMemorizedValue("example.Customer", "id")).toBeUndefined();
+      expect(recallValues("example.Customer", "id", ScalarType.STRING)).toEqual([]);
+      expect(getAllRememberedFields()).toHaveLength(0);
     });
   });
 
   describe("key eviction", () => {
-    it("evicts oldest keys when exceeding 2x max", () => {
-      // Each message creates 2 keys (1 message + 1 scalar)
-      // Max is 100, eviction triggers at >200
-      // Create 102 types = 204 keys without eviction
-      for (let i = 0; i < 102; i++) {
-        const msgType = mockMessageType(`example.Type${i}`, [{ name: `field${i}`, scalarType: ScalarType.STRING }]);
-        captureValues(`example.Type${i}`, { [`field${i}`]: `value${i}` }, msgType);
+    it("evicts the oldest keys when the store grows past its limit", () => {
+      // Each captured field creates two keys (the field and its by-name index),
+      // so 500 fields is well past the 400-key limit and its 2x eviction point.
+      for (let index = 0; index < 500; index++) {
+        const messageType = scalars(`example.Type${index}`, [{ name: `field${index}`, scalarType: ScalarType.STRING }]);
+        rememberValues(`example.Type${index}`, { [`field${index}`]: `value${index}` }, messageType, request);
       }
 
-      // After eviction, should be around 100 keys (not 204)
-      const allKeys = [...getAllStoredMessages(), ...getAllStoredScalars()];
-      expect(allKeys.length).toBeLessThanOrEqual(105);
-      expect(allKeys.length).toBeGreaterThan(50);
-
-      // Most recent keys should still exist
-      expect(getMessageMemorizedValue("example.Type101", "field101")).toBe("value101");
-    });
-  });
-
-  describe("undefined lookups", () => {
-    it("returns undefined for non-existent type", () => {
-      expect(getMessageMemorizedValue("nonExistent.Type", "id")).toBeUndefined();
-    });
-
-    it("returns undefined for non-existent field in type", () => {
-      captureValues("example.Customer", { id: "cust-123" });
-      expect(getMessageMemorizedValue("example.Customer", "nonExistent")).toBeUndefined();
-    });
-
-    it("returns undefined for non-existent scalar field", () => {
-      expect(getScalarMemorizedValue("nonExistent", ScalarType.STRING)).toBeUndefined();
+      expect(getAllRememberedFields().length).toBeLessThan(500);
+      // The most recent ones survive.
+      expect(recallValues("example.Type499", "field499", ScalarType.STRING)[0].value).toBe("value499");
     });
   });
 });

--- a/ui/src/typeMemory.ts
+++ b/ui/src/typeMemory.ts
@@ -1,47 +1,68 @@
 import { IMessageType, ScalarType } from "@protobuf-ts/runtime";
 import { clearTypeMemoryStore, deleteTypeMemoryValue, getAllTypeMemoryKeys, getTypeMemoryKeyCount, getTypeMemoryValue, setTypeMemoryValue } from "./storage";
 
-const MAX_VALUES_PER_FIELD = 1;
-const MAX_KEYS = 100;
+// Remembered values are offered as editor completions, never written into
+// generated code, so a handful per field is a list worth picking from rather
+// than a silent guess.
+const MAX_VALUES_PER_FIELD = 5;
+const MAX_TYPES_PER_NAME = 10;
+const MAX_KEYS = 400;
+// A list response repeats the same shape many times over; the first few
+// elements already carry everything worth suggesting.
+const MAX_ELEMENTS = 10;
+const MAX_DEPTH = 8;
 
-// Key prefixes for the memory store
-const MESSAGE_PREFIX = "message:";
-const SCALAR_PREFIX = "scalar:";
+// field:<typeName>:<fieldName> -> the values seen on that exact field.
+const FIELD_PREFIX = "field:";
+// name:<scalarType>:<fieldName> -> the type names that have such a field, so a
+// value seen on one type can be offered on a same-named field of another.
+const NAME_PREFIX = "name:";
 
-// Storage format: { t: timestamp, v: values[] }
-// Message memory: v = complete object snapshots
-// Scalar memory: v = individual values
+export type ScalarValue = string | number | boolean;
 
-interface StoredEntry {
+// Where a value came from: what the user sent, or what a service sent back.
+export type ValueOrigin = "request" | "response";
+
+export interface ValueSource {
+  // Method the value passed through, e.g. "MoviesService.ListMovies".
+  method: string;
+  origin: ValueOrigin;
+}
+
+export interface RememberedValue extends ValueSource {
+  value: ScalarValue;
+  // Message type the value was seen on, e.g. "movies.v1.Movie".
+  typeName: string;
+  fieldName: string;
+  // When it was last seen.
+  t: number;
+}
+
+interface StoredEntry<T> {
   t: number; // last updated timestamp
-  v: any[]; // values (FILO)
+  v: T[]; // values, most recent first
 }
 
 /**
- * Capture values from an object (request input or response output).
- * - Message fields are stored under the message name
- * - Scalar fields are stored by scalar type + field name
- * - If messageType is provided, nested messages are properly captured under their own names
+ * Record the scalar values of a request or response so they can be suggested
+ * later. Nested messages are recorded under their own type names.
  */
-export function captureValues(messageName: string, obj: any, messageType?: IMessageType<any>): void {
-  if (!messageName || !obj || typeof obj !== "object") {
+export function rememberValues(typeName: string, obj: any, messageType: IMessageType<any> | undefined, source: ValueSource): void {
+  if (!typeName || !obj || typeof obj !== "object") {
     return;
   }
 
   if (messageType) {
-    walkAndCaptureWithSchema(obj, messageName, messageType);
+    walkWithSchema(obj, typeName, messageType, source, 0);
   } else {
-    walkAndCapture(obj, messageName);
+    walkWithoutSchema(obj, typeName, source);
   }
 }
 
-function walkAndCaptureWithSchema(obj: any, messageName: string, messageType: IMessageType<any>): void {
-  if (obj === null || obj === undefined) {
+function walkWithSchema(obj: any, typeName: string, messageType: IMessageType<any>, source: ValueSource, depth: number): void {
+  if (!obj || typeof obj !== "object" || depth > MAX_DEPTH) {
     return;
   }
-
-  // Collect scalar fields for this message's snapshot
-  const snapshot: Record<string, any> = {};
 
   for (const field of messageType.fields) {
     const value = obj[field.localName];
@@ -50,258 +71,157 @@ function walkAndCaptureWithSchema(obj: any, messageName: string, messageType: IM
     }
 
     if (field.kind === "scalar") {
-      if (isScalar(value)) {
-        snapshot[field.localName] = value;
-        addToScalarMemory(field.localName, field.T, value);
+      if (field.repeat && Array.isArray(value)) {
+        value.slice(0, MAX_ELEMENTS).forEach((element) => remember(typeName, field.localName, element, field.T, source));
+      } else {
+        remember(typeName, field.localName, value, field.T, source);
       }
     } else if (field.kind === "message") {
       const nestedType = field.T();
-      if (field.repeat) {
-        // Repeated message field (array)
-        if (Array.isArray(value)) {
-          value.forEach((item) => {
-            if (item && typeof item === "object") {
-              walkAndCaptureWithSchema(item, nestedType.typeName, nestedType);
-            }
-          });
-        }
+      if (field.repeat && Array.isArray(value)) {
+        value.slice(0, MAX_ELEMENTS).forEach((element) => walkWithSchema(element, nestedType.typeName, nestedType, source, depth + 1));
       } else {
-        // Single message field - recurse to capture under nested type's name
-        if (typeof value === "object") {
-          walkAndCaptureWithSchema(value, nestedType.typeName, nestedType);
-        }
+        walkWithSchema(value, nestedType.typeName, nestedType, source, depth + 1);
       }
-    } else if (field.kind === "map") {
-      // Map fields - capture values if they're scalars
-      if (typeof value === "object" && field.V.kind === "scalar") {
-        for (const mapKey of Object.keys(value)) {
-          const mapValue = value[mapKey];
-          if (isScalar(mapValue)) {
-            addToScalarMemory(field.localName, field.V.T, mapValue);
-          }
-        }
+    } else if (field.kind === "map" && field.V.kind === "scalar" && typeof value === "object") {
+      for (const mapKey of Object.keys(value).slice(0, MAX_ELEMENTS)) {
+        remember(typeName, field.localName, value[mapKey], field.V.T, source);
       }
     }
-    // Enums are not captured as they're typically fixed values
-  }
-
-  // Store the snapshot if we captured any scalar fields
-  if (Object.keys(snapshot).length > 0) {
-    addMessageSnapshot(messageName, snapshot);
+    // Enums are not remembered; the generated code already names their values.
   }
 }
 
-function walkAndCapture(obj: any, messageName: string): void {
-  if (obj === null || obj === undefined) {
-    return;
-  }
-
-  // For non-schema capture, store the entire object as a snapshot
-  // Extract only scalar values (nested objects are different messages)
-  const snapshot = extractScalars(obj);
-
-  if (Object.keys(snapshot).length > 0) {
-    addMessageSnapshot(messageName, snapshot);
-  }
-}
-
-function extractScalars(obj: any): Record<string, any> {
-  const result: Record<string, any> = {};
-
-  if (obj === null || obj === undefined || typeof obj !== "object") {
-    return result;
-  }
-
+function walkWithoutSchema(obj: any, typeName: string, source: ValueSource): void {
+  // Without a schema there is no way to tell which type a nested object has, so
+  // only the top-level scalars are remembered, and without a scalar type they
+  // stay off the by-name index.
   for (const key of Object.keys(obj)) {
-    const value = obj[key];
-    if (isScalar(value)) {
-      result[key] = value;
-    }
-    // Don't recurse into nested objects - they would be different types
+    remember(typeName, key, obj[key], undefined, source);
   }
-
-  return result;
 }
 
-function isScalar(value: any): boolean {
-  if (value === null || value === undefined) {
-    return false;
-  }
+function isScalar(value: any): value is ScalarValue {
   const type = typeof value;
   return type === "string" || type === "number" || type === "boolean";
 }
 
-function getScalarKey(fieldName: string, scalarType: ScalarType): string {
-  return `${SCALAR_PREFIX}${scalarType}:${fieldName}`;
+function fieldKey(typeName: string, fieldName: string): string {
+  return `${FIELD_PREFIX}${typeName}:${fieldName}`;
 }
 
-function getMessageKey(messageName: string): string {
-  return `${MESSAGE_PREFIX}${messageName}`;
+function nameKey(fieldName: string, scalarType: ScalarType): string {
+  return `${NAME_PREFIX}${scalarType}:${fieldName}`;
 }
 
-function normalizeEntry(raw: any): StoredEntry {
-  // Handle migration from old formats or corrupted data
-  if (!raw || typeof raw !== "object") {
+function readEntry<T>(key: string): StoredEntry<T> {
+  const raw = getTypeMemoryValue<any>(key);
+  if (!raw || typeof raw !== "object" || !Array.isArray(raw.v)) {
     return { t: 0, v: [] };
   }
-  // Old format was plain array
-  if (Array.isArray(raw)) {
-    return { t: 0, v: raw };
-  }
-  // Current format
-  if (Array.isArray(raw.v)) {
-    return { t: raw.t ?? 0, v: raw.v };
-  }
-  return { t: 0, v: [] };
+  return { t: raw.t ?? 0, v: raw.v };
 }
 
-function stableStringify(obj: any): string {
-  // Sort keys for consistent comparison
-  return JSON.stringify(obj, Object.keys(obj).sort());
+// Move `value` to the front of the entry, dropping any earlier occurrence, and
+// trim the entry to `max`.
+function promote<T>(entry: StoredEntry<T>, value: T, max: number, matches: (candidate: T) => boolean): StoredEntry<T> {
+  const kept = entry.v.filter((candidate) => !matches(candidate));
+  kept.unshift(value);
+  kept.length = Math.min(kept.length, max);
+  return { t: Date.now(), v: kept };
 }
 
-function addMessageSnapshot(messageName: string, snapshot: any): void {
-  const key = getMessageKey(messageName);
-  const entry = normalizeEntry(getTypeMemoryValue(key));
-
-  // Check if this exact snapshot already exists (deep equality check with stable key order)
-  const snapshotStr = stableStringify(snapshot);
-  const existingIndex = entry.v.findIndex((v) => stableStringify(v) === snapshotStr);
-
-  if (existingIndex >= 0) {
-    // Remove from current position
-    entry.v.splice(existingIndex, 1);
+function remember(typeName: string, fieldName: string, value: any, scalarType: ScalarType | undefined, source: ValueSource): void {
+  if (!isScalar(value)) {
+    return;
   }
 
-  // Add to front (most recent)
-  entry.v.unshift(snapshot);
+  const key = fieldKey(typeName, fieldName);
+  const remembered: RememberedValue = { value, typeName, fieldName, method: source.method, origin: source.origin, t: Date.now() };
+  setTypeMemoryValue(
+    key,
+    promote(readEntry<RememberedValue>(key), remembered, MAX_VALUES_PER_FIELD, (candidate) => candidate.value === value),
+  );
 
-  // Keep only the max values
-  if (entry.v.length > MAX_VALUES_PER_FIELD) {
-    entry.v.length = MAX_VALUES_PER_FIELD;
+  if (scalarType !== undefined) {
+    const index = nameKey(fieldName, scalarType);
+    setTypeMemoryValue(
+      index,
+      promote(readEntry<string>(index), typeName, MAX_TYPES_PER_NAME, (candidate) => candidate === typeName),
+    );
   }
 
-  // Update timestamp
-  entry.t = Date.now();
-
-  setTypeMemoryValue(key, entry);
-  evictOldKeys();
-}
-
-function addToScalarMemory(fieldName: string, scalarType: ScalarType, value: any): void {
-  const key = getScalarKey(fieldName, scalarType);
-  const entry = normalizeEntry(getTypeMemoryValue(key));
-
-  const existingIndex = entry.v.indexOf(value);
-
-  if (existingIndex >= 0) {
-    // Remove from current position
-    entry.v.splice(existingIndex, 1);
-  }
-
-  // Add to front (most recent)
-  entry.v.unshift(value);
-
-  // Keep only the max values
-  if (entry.v.length > MAX_VALUES_PER_FIELD) {
-    entry.v.length = MAX_VALUES_PER_FIELD;
-  }
-
-  // Update timestamp
-  entry.t = Date.now();
-
-  setTypeMemoryValue(key, entry);
   evictOldKeys();
 }
 
 function evictOldKeys(): void {
   // O(1) check - only evict when at 2x the limit
-  const count = getTypeMemoryKeyCount();
-  if (count <= MAX_KEYS * 2) {
+  if (getTypeMemoryKeyCount() <= MAX_KEYS * 2) {
     return;
   }
 
-  // Get all entries with their timestamps
-  const keys = getAllTypeMemoryKeys();
-  const entries: { key: string; t: number }[] = [];
-  for (const key of keys) {
-    const entry = normalizeEntry(getTypeMemoryValue(key));
-    entries.push({ key, t: entry.t });
-  }
-
-  // Sort by timestamp (oldest first)
+  const entries = getAllTypeMemoryKeys().map((key) => ({ key, t: readEntry(key).t }));
   entries.sort((a, b) => a.t - b.t);
 
-  // Delete oldest entries until we're at max
-  const toDelete = entries.slice(0, entries.length - MAX_KEYS);
-  for (const { key } of toDelete) {
+  for (const { key } of entries.slice(0, entries.length - MAX_KEYS)) {
     deleteTypeMemoryValue(key);
   }
 }
 
 /**
- * Get memorized value for a message field.
- * Extracts the field from the most recent snapshot of this message type.
+ * Values to suggest for a field, most recent first: the ones seen on this exact
+ * field, then the ones seen on same-named fields of other message types.
  */
-export function getMessageMemorizedValue(messageName: string, fieldName: string): any | undefined {
-  const key = getMessageKey(messageName);
-  const entry = normalizeEntry(getTypeMemoryValue(key));
-  if (entry.v.length === 0) {
-    return undefined;
+export function recallValues(typeName: string, fieldName: string, scalarType?: ScalarType): RememberedValue[] {
+  const exact = readEntry<RememberedValue>(fieldKey(typeName, fieldName)).v;
+
+  const related: RememberedValue[] = [];
+  if (scalarType !== undefined) {
+    for (const otherType of readEntry<string>(nameKey(fieldName, scalarType)).v) {
+      if (otherType !== typeName) {
+        related.push(...readEntry<RememberedValue>(fieldKey(otherType, fieldName)).v);
+      }
+    }
+    related.sort((a, b) => b.t - a.t);
   }
 
-  // Get from the most recent snapshot
-  const snapshot = entry.v[0];
-  if (!snapshot || typeof snapshot !== "object") {
-    return undefined;
+  const seen = new Set<string>();
+  const values: RememberedValue[] = [];
+  for (const remembered of [...exact, ...related]) {
+    const key = typeof remembered.value + ":" + String(remembered.value);
+    if (!seen.has(key)) {
+      seen.add(key);
+      values.push(remembered);
+    }
   }
-  return snapshot[fieldName];
+
+  return values;
 }
 
 /**
- * Get memorized value for a scalar field by field name and protobuf scalar type.
- * Used when generating defaults for scalar fields.
+ * Drop entries left behind by an earlier layout of the store, which are unread
+ * by the current keys but still count against the key budget.
  */
-export function getScalarMemorizedValue(fieldName: string, scalarType: ScalarType): any | undefined {
-  const key = `${SCALAR_PREFIX}${scalarType}:${fieldName}`;
-  const entry = normalizeEntry(getTypeMemoryValue(key));
-
-  if (entry.v.length === 0) {
-    return undefined;
+export function pruneTypeMemory(): void {
+  for (const key of getAllTypeMemoryKeys()) {
+    if (!key.startsWith(FIELD_PREFIX) && !key.startsWith(NAME_PREFIX)) {
+      deleteTypeMemoryValue(key);
+    }
   }
-
-  return entry.v[0];
 }
 
 /**
- * Get all memorized values for a scalar field (for suggestions).
- */
-export function getScalarMemorizedValues(fieldName: string, scalarType: ScalarType): any[] {
-  const entry = normalizeEntry(getTypeMemoryValue(`${SCALAR_PREFIX}${scalarType}:${fieldName}`));
-  return entry.v;
-}
-
-/**
- * Clear all type memory.
+ * Forget every remembered value.
  */
 export function clearTypeMemory(): void {
   clearTypeMemoryStore();
 }
 
 /**
- * Get all stored message names (for debugging).
+ * All fields that have remembered values, as "<typeName>:<fieldName>".
  */
-export function getAllStoredMessages(): string[] {
+export function getAllRememberedFields(): string[] {
   return getAllTypeMemoryKeys()
-    .filter((key) => key.startsWith(MESSAGE_PREFIX))
-    .map((key) => key.slice(MESSAGE_PREFIX.length));
-}
-
-/**
- * Get all stored scalar keys (for debugging).
- */
-export function getAllStoredScalars(): string[] {
-  return getAllTypeMemoryKeys()
-    .filter((key) => key.startsWith(SCALAR_PREFIX))
-    .map((key) => key.slice(SCALAR_PREFIX.length));
+    .filter((key) => key.startsWith(FIELD_PREFIX))
+    .map((key) => key.slice(FIELD_PREFIX.length));
 }

--- a/ui/src/valueCompletions.test.ts
+++ b/ui/src/valueCompletions.test.ts
@@ -57,10 +57,15 @@ function moviesApp(): App {
 
 const imports = `import { MoviesService } from "demo/proto/movies";\n\n`;
 
-// Resolve at the position marked with | in the code (the marker is removed).
-function resolveAt(code: string, apps: App[] = [moviesApp()]) {
+// Split code at the | marking the cursor, into the code without it and its offset.
+function atMarker(code: string): { code: string; offset: number } {
   const offset = code.indexOf("|");
-  return resolveValuePosition(code.replace("|", ""), offset, apps);
+  return { code: code.slice(0, offset) + code.slice(offset + 1), offset };
+}
+
+function resolveAt(marked: string, apps: App[] = [moviesApp()]) {
+  const { code, offset } = atMarker(marked);
+  return resolveValuePosition(code, offset, apps);
 }
 
 describe("resolveValuePosition", () => {
@@ -125,9 +130,9 @@ describe("suggestValues", () => {
     clearTypeMemory();
   });
 
-  function suggestAt(code: string) {
-    const offset = code.indexOf("|");
-    return suggestValues(code.replace("|", ""), offset, [moviesApp()]);
+  function suggestAt(marked: string) {
+    const { code, offset } = atMarker(marked);
+    return suggestValues(code, offset, [moviesApp()]);
   }
 
   it("offers nothing when nothing has been called yet", () => {

--- a/ui/src/valueCompletions.test.ts
+++ b/ui/src/valueCompletions.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { IMessageType, ScalarType } from "@protobuf-ts/runtime";
+import ts from "typescript";
+import { App } from "./apps";
+import { clearTypeMemory, rememberValues } from "./typeMemory";
+import { resolveValuePosition, suggestValues } from "./valueCompletions";
+
+function messageType(typeName: string, fields: any[]): IMessageType<any> {
+  return {
+    typeName,
+    fields: fields.map((field, index) => ({ no: index + 1, localName: field.name, ...field })),
+  } as unknown as IMessageType<any>;
+}
+
+const genre = messageType("movies.v1.Genre", [{ name: "name", kind: "scalar", T: ScalarType.STRING }]);
+
+const movie = messageType("movies.v1.Movie", [
+  { name: "id", kind: "scalar", T: ScalarType.STRING },
+  { name: "year", kind: "scalar", T: ScalarType.INT32 },
+  { name: "genre", kind: "message", T: () => genre },
+  { name: "labels", kind: "map", K: ScalarType.STRING, V: { kind: "scalar", T: ScalarType.STRING } },
+]);
+
+const getMovieRequest = messageType("movies.v1.GetMovieRequest", [{ name: "id", kind: "scalar", T: ScalarType.STRING }]);
+
+const saveMovieRequest = messageType("movies.v1.SaveMovieRequest", [{ name: "movie", kind: "message", T: () => movie }]);
+
+// An app exposing MoviesService.GetMovie and MoviesService.SaveMovie, shaped
+// the way loadApp builds one.
+function moviesApp(): App {
+  const path = "demo/proto/movies.ts";
+  return {
+    stub: {
+      demo$proto$movies: {
+        MoviesService: {
+          typeName: "movies.v1.Movies",
+          methods: [
+            { name: "GetMovie", I: getMovieRequest, O: movie },
+            { name: "SaveMovie", I: saveMovieRequest, O: movie },
+          ],
+        },
+      },
+    },
+    sources: [
+      {
+        path,
+        importPath: "demo/proto/movies",
+        stubModuleId: "demo$proto$movies",
+        file: ts.createSourceFile(path, "", ts.ScriptTarget.Latest),
+        serviceNames: ["MoviesService"],
+        interfaces: {},
+        enums: {},
+      },
+    ],
+  } as unknown as App;
+}
+
+const imports = `import { MoviesService } from "demo/proto/movies";\n\n`;
+
+// Resolve at the position marked with | in the code (the marker is removed).
+function resolveAt(code: string, apps: App[] = [moviesApp()]) {
+  const offset = code.indexOf("|");
+  return resolveValuePosition(code.replace("|", ""), offset, apps);
+}
+
+describe("resolveValuePosition", () => {
+  it("resolves a scalar field inside a string literal", () => {
+    const position = resolveAt(`${imports}MoviesService.GetMovie({ id: "|" });`);
+
+    expect(position?.typeName).toBe("movies.v1.GetMovieRequest");
+    expect(position?.fieldName).toBe("id");
+    expect(position?.scalarType).toBe(ScalarType.STRING);
+    expect(position?.stringRange).toBeDefined();
+  });
+
+  it("resolves a number field outside a string literal", () => {
+    const position = resolveAt(`${imports}MoviesService.SaveMovie({ movie: { year: 0| } });`);
+
+    expect(position?.typeName).toBe("movies.v1.Movie");
+    expect(position?.fieldName).toBe("year");
+    expect(position?.scalarType).toBe(ScalarType.INT32);
+    expect(position?.stringRange).toBeUndefined();
+  });
+
+  it("resolves a field of a nested message", () => {
+    const position = resolveAt(`${imports}MoviesService.SaveMovie({ movie: { genre: { name: "|" } } });`);
+
+    expect(position?.typeName).toBe("movies.v1.Genre");
+    expect(position?.fieldName).toBe("name");
+  });
+
+  it("resolves a map value to the map field", () => {
+    const position = resolveAt(`${imports}MoviesService.SaveMovie({ movie: { labels: { key: "|" } } });`);
+
+    expect(position?.typeName).toBe("movies.v1.Movie");
+    expect(position?.fieldName).toBe("labels");
+    expect(position?.scalarType).toBe(ScalarType.STRING);
+  });
+
+  it("ignores the property name side", () => {
+    expect(resolveAt(`${imports}MoviesService.GetMovie({ i|d: "" });`)).toBeUndefined();
+  });
+
+  it("ignores a field that is not a scalar", () => {
+    expect(resolveAt(`${imports}MoviesService.SaveMovie({ movie: {| } });`)).toBeUndefined();
+  });
+
+  it("ignores calls to an unknown service", () => {
+    expect(resolveAt(`${imports}OtherService.GetMovie({ id: "|" });`)).toBeUndefined();
+  });
+
+  it("ignores a service imported from another app", () => {
+    const code = `import { MoviesService } from "other/proto/movies";\n\nMoviesService.GetMovie({ id: "|" });`;
+    expect(resolveAt(code)).toBeUndefined();
+  });
+
+  it("resolves a service without an import, as scripts may write it", () => {
+    const position = resolveAt(`MoviesService.GetMovie({ id: "|" });`);
+    expect(position?.fieldName).toBe("id");
+  });
+});
+
+describe("suggestValues", () => {
+  beforeEach(() => {
+    clearTypeMemory();
+  });
+
+  function suggestAt(code: string) {
+    const offset = code.indexOf("|");
+    return suggestValues(code.replace("|", ""), offset, [moviesApp()]);
+  }
+
+  it("offers nothing when nothing has been called yet", () => {
+    expect(suggestAt(`${imports}MoviesService.GetMovie({ id: "|" });`)).toBeUndefined();
+  });
+
+  it("offers the ids a response came back with", () => {
+    rememberValues("movies.v1.Movie", { id: "movie-7" }, movie, { method: "MoviesService.ListMovies", origin: "response" });
+
+    const suggested = suggestAt(`${imports}MoviesService.GetMovie({ id: "|" });`);
+
+    expect(suggested?.values.map((value) => value.value)).toEqual(["movie-7"]);
+    expect(suggested?.values[0].origin).toBe("response");
+    expect(suggested?.values[0].typeName).toBe("movies.v1.Movie");
+  });
+
+  it("puts what was sent to this exact field first", () => {
+    rememberValues("movies.v1.Movie", { id: "from-response" }, movie, { method: "MoviesService.ListMovies", origin: "response" });
+    rememberValues("movies.v1.GetMovieRequest", { id: "from-request" }, getMovieRequest, { method: "MoviesService.GetMovie", origin: "request" });
+
+    const suggested = suggestAt(`${imports}MoviesService.GetMovie({ id: "|" });`);
+
+    expect(suggested?.values.map((value) => value.value)).toEqual(["from-request", "from-response"]);
+  });
+});

--- a/ui/src/valueCompletions.ts
+++ b/ui/src/valueCompletions.ts
@@ -1,0 +1,234 @@
+import { IMessageType, ScalarType } from "@protobuf-ts/runtime";
+import { ServiceInfo } from "@protobuf-ts/runtime-rpc";
+import ts from "typescript";
+import { App } from "./apps";
+import { findInStub, Source } from "./sources";
+import { recallValues, RememberedValue } from "./typeMemory";
+
+// A scalar value position inside a request literal, resolved back to the proto
+// field it fills in.
+export interface ValuePosition {
+  // Message type holding the field, e.g. "movies.v1.GetMovieRequest".
+  typeName: string;
+  fieldName: string;
+  scalarType: ScalarType;
+  // Set when the cursor sits inside a string literal: the offsets of its
+  // contents, so a suggestion replaces what is between the quotes.
+  stringRange?: { start: number; end: number };
+}
+
+export interface ValueSuggestions {
+  position: ValuePosition;
+  values: RememberedValue[];
+}
+
+/**
+ * Values seen in earlier calls that fit the field under the cursor, or
+ * undefined when the cursor isn't in a field's value.
+ */
+export function suggestValues(code: string, offset: number, apps: App[]): ValueSuggestions | undefined {
+  const position = resolveValuePosition(code, offset, apps);
+  if (!position) {
+    return undefined;
+  }
+
+  const values = recallValues(position.typeName, position.fieldName, position.scalarType);
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  return { position, values };
+}
+
+export function resolveValuePosition(code: string, offset: number, apps: App[]): ValuePosition | undefined {
+  const file = ts.createSourceFile("completion.ts", code, ts.ScriptTarget.Latest, /*setParentNodes*/ true, ts.ScriptKind.TS);
+
+  const node = nodeAt(file, offset);
+  if (!node) {
+    return undefined;
+  }
+
+  const enclosing = enclosingCall(node, offset);
+  if (!enclosing) {
+    return undefined;
+  }
+
+  const inputType = resolveInputType(file, enclosing.call, apps);
+  if (!inputType) {
+    return undefined;
+  }
+
+  const field = fieldAtPath(inputType, enclosing.path);
+  if (!field) {
+    return undefined;
+  }
+
+  const literal = stringLiteralAt(node, offset);
+
+  return {
+    ...field,
+    stringRange: literal ? { start: literal.getStart(file) + 1, end: literal.getEnd() - 1 } : undefined,
+  };
+}
+
+function nodeAt(file: ts.SourceFile, offset: number): ts.Node | undefined {
+  let found: ts.Node | undefined = undefined;
+
+  const visit = (node: ts.Node) => {
+    if (offset < node.getStart(file) || offset > node.getEnd()) {
+      return;
+    }
+    found = node;
+    node.forEachChild(visit);
+  };
+
+  file.forEachChild(visit);
+
+  return found;
+}
+
+function stringLiteralAt(node: ts.Node, offset: number): ts.StringLiteral | undefined {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isStringLiteral(current) && offset > current.getStart() && offset < current.getEnd()) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+// Walk out of the node under the cursor to the call it is an argument of,
+// collecting the property names passed on the way, e.g. ["movie", "title"].
+function enclosingCall(node: ts.Node, offset: number): { call: ts.CallExpression; path: string[] } | undefined {
+  const path: string[] = [];
+  let child: ts.Node = node;
+  let current: ts.Node | undefined = node;
+
+  while (current) {
+    if (ts.isPropertyAssignment(current)) {
+      // The cursor has to be past the property name; sitting on the name itself
+      // is a property completion, which TypeScript already handles.
+      if (offset < current.name.getEnd()) {
+        return undefined;
+      }
+      path.unshift(propertyName(current));
+    } else if (ts.isCallExpression(current)) {
+      if (path.length === 0 || !current.arguments.includes(child as ts.Expression)) {
+        return undefined;
+      }
+      return { call: current, path };
+    }
+    child = current;
+    current = current.parent;
+  }
+
+  return undefined;
+}
+
+function propertyName(property: ts.PropertyAssignment): string {
+  const name = property.name;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return "";
+}
+
+// Resolve `SomeService.SomeMethod(...)` to the method's input message type. The
+// service identifier is matched through its import so two apps declaring the
+// same service name stay apart.
+function resolveInputType(file: ts.SourceFile, call: ts.CallExpression, apps: App[]): IMessageType<any> | undefined {
+  if (!ts.isPropertyAccessExpression(call.expression) || !ts.isIdentifier(call.expression.expression)) {
+    return undefined;
+  }
+
+  const serviceName = call.expression.expression.text;
+  const methodName = call.expression.name.text;
+  const importPath = importPathOf(file, serviceName);
+
+  const serviceInfo = findServiceInfo(apps, serviceName, importPath);
+  if (!serviceInfo) {
+    return undefined;
+  }
+
+  const method = serviceInfo.methods.find((candidate) => candidate.name.toLowerCase() === methodName.toLowerCase());
+
+  return method?.I;
+}
+
+function importPathOf(file: ts.SourceFile, localName: string): string | undefined {
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement) || !statement.importClause || !ts.isStringLiteral(statement.moduleSpecifier)) {
+      continue;
+    }
+    const bindings = statement.importClause.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) {
+      continue;
+    }
+    if (bindings.elements.some((element) => element.name.text === localName)) {
+      return statement.moduleSpecifier.text;
+    }
+  }
+  return undefined;
+}
+
+function findServiceInfo(apps: App[], serviceName: string, importPath: string | undefined): ServiceInfo | undefined {
+  const candidates: { app: App; source: Source }[] = [];
+
+  for (const app of apps) {
+    for (const source of app.sources) {
+      if (!source.serviceNames.includes(serviceName)) {
+        continue;
+      }
+      if (importPath === undefined || source.importPath === importPath) {
+        candidates.push({ app, source });
+      }
+    }
+  }
+
+  for (const { app, source } of candidates) {
+    const serviceInfo: ServiceInfo | undefined = findInStub(app.stub, source, serviceName);
+    if (serviceInfo) {
+      return serviceInfo;
+    }
+  }
+
+  return undefined;
+}
+
+function fieldAtPath(messageType: IMessageType<any>, path: string[]): { typeName: string; fieldName: string; scalarType: ScalarType } | undefined {
+  let current = messageType;
+
+  for (let index = 0; index < path.length; index++) {
+    const name = path[index];
+    const field = current.fields.find((candidate) => candidate.localName === name || candidate.name === name);
+    const last = index === path.length - 1;
+
+    if (!field) {
+      // A oneof is nested one level deeper than its members ({ kind: { oneofKind,
+      // <member> } }), so the wrapper is not a field of its own.
+      if (!last && current.fields.some((candidate) => candidate.oneof === name)) {
+        continue;
+      }
+      return undefined;
+    }
+
+    if (field.kind === "scalar" && last) {
+      return { typeName: current.typeName, fieldName: field.localName, scalarType: field.T };
+    }
+
+    // A map's entries are keyed by the map key, so the field is one level above
+    // the value the cursor is in.
+    if (field.kind === "map" && field.V.kind === "scalar" && index === path.length - 2) {
+      return { typeName: current.typeName, fieldName: field.localName, scalarType: field.V.T };
+    }
+
+    if (field.kind !== "message") {
+      return undefined;
+    }
+
+    current = field.T();
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Generated requests are back to plain zero values — no more silently filling fields from earlier calls (including from *responses*, and from same-named fields in unrelated apps). What was seen is still remembered, but it is now offered as an editor completion labelled with the field and call it came from, so inserting it is a deliberate keystroke.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4QNX6B7sELZBPWg2zvq1)_