### PR TITLE
Fixed generated requests for oneof fields, including google.protobuf.Value

### DIFF
--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -1,5 +1,6 @@
 import { GrpcWebFetchTransport } from "@protobuf-ts/grpcweb-transport";
-import type { RpcMetadata, RpcOptions, ServerStreamingCall, UnaryCall } from "@protobuf-ts/runtime-rpc";
+import type { IMessageType } from "@protobuf-ts/runtime";
+import type { MethodInfo, RpcMetadata, RpcOptions, ServerStreamingCall, UnaryCall } from "@protobuf-ts/runtime-rpc";
 import { TwirpFetchTransport } from "@protobuf-ts/twirp-transport";
 import { appHeaders } from "./appTypes";
 import { MethodCall, MethodCallHeaders } from "./kaja";
@@ -103,6 +104,7 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
 
   for (const method of service.methods) {
     const isServerStreaming = method.serverStreaming && !method.clientStreaming;
+    const inputType: IMessageType<any> | undefined = (clientStub.methods as MethodInfo[] | undefined)?.find((m) => m.name === method.name)?.I;
 
     client.methods[method.name] = async (input: any) => {
       // Capture request headers from appRef at request time
@@ -127,7 +129,14 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
         // The run's abort signal is read here rather than captured with the
         // client, so every call a script makes joins the run that issued it.
         const abort = client.kaja?._internal.abortSignal;
-        const call = clientStub[lcfirst(method.name)](input, abort ? { ...options, abort } : options);
+        // A request is a hand-written object literal, so it is routinely partial:
+        // a deleted field, or a oneof left unset, reaches the serializer as
+        // `undefined` and fails there with an error that names neither. create()
+        // fills those in with the zero values the wire format omits anyway. The
+        // literal itself stays on the method call, so the console and the value
+        // completions keep showing what was actually written.
+        const message = inputType ? inputType.create(input) : input;
+        const call = clientStub[lcfirst(method.name)](message, abort ? { ...options, abort } : options);
 
         if (isServerStreaming) {
           const streamCall = call as ServerStreamingCall<any, any>;

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -54,24 +54,106 @@ test("defaultInput uses empty arrays for repeated scalars, one element for messa
   expect(expr).toContain("name:");
 });
 
-// google.protobuf.Value (used for free-form / polymorphic OpenAPI fields) must
-// not recurse into its "kind" oneof — that would emit every member at once, an
-// invalid shape. It renders as an empty, editable placeholder instead.
-test("defaultInput renders google.protobuf.Value as an empty placeholder", () => {
-  const value: MessageType<any> = new MessageType("google.protobuf.Value", [
+const anyValue = (): MessageType<any> =>
+  new MessageType("google.protobuf.Value", [
     { no: 1, name: "null_value", kind: "enum", oneof: "kind", T: () => ["google.protobuf.NullValue", {}] },
     { no: 3, name: "string_value", kind: "scalar", oneof: "kind", T: 9 /*ScalarType.STRING*/ },
     { no: 4, name: "bool_value", kind: "scalar", oneof: "kind", T: 8 /*ScalarType.BOOL*/ },
   ]);
-  const request: MessageType<any> = new MessageType("openapi.demo.Request", [{ no: 1, name: "data", kind: "message", T: () => value }]);
+
+// google.protobuf.Value (used for free-form / polymorphic OpenAPI fields) has no
+// fillable default: its "kind" oneof can neither be flattened into fields (not a
+// valid shape) nor left unset (the JSON encoder rejects it on send). A singular
+// one is omitted, the way a recursive field is.
+test("defaultInput omits a google.protobuf.Value field", () => {
+  const request: MessageType<any> = new MessageType("openapi.demo.Request", [
+    { no: 1, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+    { no: 2, name: "data", kind: "message", T: anyValue },
+    { no: 3, name: "values", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: anyValue },
+  ]);
 
   const sources: Sources = [];
   const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
 
-  expect(expr).toContain("kind: { oneofKind: undefined }");
-  // No flat oneof members leaked out.
+  expect(expr).toContain("id:");
+  expect(expr).not.toContain("data:");
+  // Repeated: an empty array, not an element that can't be sent.
+  expect(expr).toContain("values: []");
+  // No flat oneof members, and no empty group, leaked out.
   expect(expr).not.toContain("stringValue");
-  expect(expr).not.toContain("boolValue");
+  expect(expr).not.toContain("oneofKind");
+});
+
+// A free-form OpenAPI object becomes map<string, google.protobuf.Value>. The map
+// itself is fine to send, so it stays — empty, for the caller to fill in.
+test("defaultInput renders a map of google.protobuf.Value as an empty map", () => {
+  const request: MessageType<any> = new MessageType("openapi.demo.Request", [
+    { no: 1, name: "schema_fields", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "message", T: anyValue } },
+  ]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
+
+  expect(expr).toContain("schemaFields: {}");
+});
+
+// A oneof of any kind is a single { oneofKind, <member> } property: its members
+// are never fields of their own.
+test("defaultInput renders a oneof as a single empty group", () => {
+  const request: MessageType<any> = new MessageType("demo.Request", [
+    { no: 1, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+    { no: 2, name: "by_name", kind: "scalar", oneof: "selector", T: 9 /*ScalarType.STRING*/ },
+    { no: 3, name: "by_index", kind: "scalar", oneof: "selector", T: 5 /*ScalarType.INT32*/ },
+  ]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
+
+  expect(expr).toContain("id:");
+  expect(expr).toContain("selector: { oneofKind: undefined }");
+  expect(expr).not.toContain("byName");
+  expect(expr).not.toContain("byIndex");
+});
+
+// The point of the shape: a generated request has to survive the serializer.
+// A flattened oneof leaves the group itself missing, and protobuf-ts fails on
+// it with an error that names neither the field nor the request.
+test("defaultInput generates a request that serializes", () => {
+  const selector: MessageType<any> = new MessageType("demo.Selector", [
+    { no: 1, name: "by_name", kind: "scalar", oneof: "target", T: 9 /*ScalarType.STRING*/ },
+    { no: 2, name: "by_index", kind: "scalar", oneof: "target", T: 5 /*ScalarType.INT32*/ },
+  ]);
+  const request: MessageType<any> = new MessageType("openapi.demo.Request", [
+    { no: 1, name: "page_size", kind: "scalar", T: 5 /*ScalarType.INT32*/ },
+    { no: 2, name: "selector", kind: "message", T: () => selector },
+    { no: 3, name: "schema_fields", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "message", T: anyValue } },
+  ]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
+  const generated = new Function(`return ${expr.replace(/;\s*$/, "")}`)();
+
+  expect(() => request.toBinary(generated)).not.toThrow();
+});
+
+// The Timestamp default applies wherever a Timestamp appears, including as a
+// map value.
+test("defaultInput fills in a Timestamp map value", () => {
+  const timestamp: MessageType<any> = new MessageType("google.protobuf.Timestamp", [
+    { no: 1, name: "seconds", kind: "scalar", T: 3 /*ScalarType.INT64*/ },
+    { no: 2, name: "nanos", kind: "scalar", T: 5 /*ScalarType.INT32*/ },
+  ]);
+  const request: MessageType<any> = new MessageType("demo.Request", [
+    { no: 1, name: "seen_at", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "message", T: () => timestamp } },
+  ]);
+
+  const sources: Sources = [];
+  const expr = printStatements([ts.factory.createExpressionStatement(defaultMessage(request, sources, {}))]);
+
+  expect(expr).toContain("seconds:");
+  expect(expr).toContain("nanos:");
+  // The current time, not the "0"/0 the generic recursion would produce.
+  expect(expr).not.toContain('seconds: "0"');
 });
 
 // A cycle across two messages (A -> B -> A) must also terminate.

--- a/ui/src/defaultInput.ts
+++ b/ui/src/defaultInput.ts
@@ -2,27 +2,71 @@ import { EnumInfo, FieldInfo, IMessageType, ScalarType } from "@protobuf-ts/runt
 import ts from "typescript";
 import { findEnum, Source, Sources } from "./sources";
 
+// google.protobuf.Value holds arbitrary JSON through a "kind" oneof, and an
+// OpenAPI spec's free-form properties are generated as one. It has no fillable
+// default: leaving the oneof unset is rejected on send ("none of the oneof
+// fields is set" from the JSON encoder), and picking a member would invent a
+// value. So, like a recursive type, it is left out of the generated request
+// rather than placed there only to fail.
+const unfillable = "google.protobuf.Value";
+
+// omitMessage reports whether a message type has no default worth generating:
+// either it is unfillable, or it is already on the recursion path.
+function omitMessage(typeName: string, visiting: Set<string>): boolean {
+  return typeName === unfillable || visiting.has(typeName);
+}
+
 export function defaultMessage<T extends object>(
   message: IMessageType<T>,
   sources: Sources,
   imports: Imports,
   visiting: Set<string> = new Set(),
 ): ts.ObjectLiteralExpression {
+  const typeName = message.typeName;
+
+  // Special case for Timestamp - default to current time
+  if (typeName === "google.protobuf.Timestamp") {
+    const now = new Date();
+    const seconds = Math.floor(now.getTime() / 1000);
+    const nanos = (now.getTime() % 1000) * 1_000_000;
+    return ts.factory.createObjectLiteralExpression([
+      ts.factory.createPropertyAssignment("seconds", ts.factory.createStringLiteral(seconds.toString())),
+      ts.factory.createPropertyAssignment("nanos", ts.factory.createNumericLiteral(nanos)),
+    ]);
+  }
+
   let properties: ts.PropertyAssignment[] = [];
 
-  const typeName = message.typeName;
   // Track the message types on the current recursion path so a self-referential
   // message (e.g. a recursive filter/expression type from an OpenAPI spec) stops
   // instead of recursing until the stack overflows.
   const nested = new Set(visiting).add(typeName);
+  const oneofs = new Set<string>();
 
   message.fields.forEach((field) => {
-    // Break recursive message cycles. A field whose message type is already on
-    // the current path can't be filled in without recursing forever: a repeated
-    // field defaults to an empty array and a singular (optional) field is omitted
-    // entirely, so the generated code stays type-correct instead of holding an
-    // unfillable placeholder.
-    if (field.kind === "message" && nested.has(field.T().typeName)) {
+    // A oneof's members live under a single `{ oneofKind, <member> }` property,
+    // so emitting them as fields would be both a type error and, since the group
+    // itself would then be missing, a serialization crash. It is generated once,
+    // empty: which member to set is the caller's choice.
+    if (field.oneof) {
+      if (!oneofs.has(field.oneof)) {
+        oneofs.add(field.oneof);
+        properties.push(
+          ts.factory.createPropertyAssignment(
+            field.oneof,
+            ts.factory.createObjectLiteralExpression([ts.factory.createPropertyAssignment("oneofKind", ts.factory.createIdentifier("undefined"))]),
+          ),
+        );
+      }
+      return;
+    }
+
+    // A field with no default worth generating — an unfillable type, or a
+    // message type already on the current path, which can't be filled in without
+    // recursing forever — is left out: a repeated field defaults to an empty
+    // array and a singular (optional) field is omitted entirely, so the generated
+    // code stays type-correct instead of holding a placeholder that can't be sent.
+    if (field.kind === "message" && omitMessage(field.T().typeName, nested)) {
       if (field.repeat) {
         properties.push(ts.factory.createPropertyAssignment(field.localName, ts.factory.createArrayLiteralExpression([])));
       }
@@ -75,9 +119,9 @@ function defaultMessageField(field: FieldInfo, sources: Sources, imports: Import
   }
 
   if (field.kind === "map") {
-    // An empty map is valid; if the value type would recurse into the current
-    // path, leave the map empty rather than emit an unfillable entry.
-    if (field.V.kind === "message" && visiting.has(field.V.T().typeName)) {
+    // An empty map is valid, so a value type with no default worth generating
+    // leaves the map empty rather than holding an entry that can't be sent.
+    if (field.V.kind === "message" && omitMessage(field.V.T().typeName, visiting)) {
       return ts.factory.createObjectLiteralExpression([]);
     }
     const properties: ts.PropertyAssignment[] = [];
@@ -91,30 +135,8 @@ function defaultMessageField(field: FieldInfo, sources: Sources, imports: Import
   }
 
   if (field.kind === "message") {
-    const messageType = field.T();
-    // Special case for Timestamp - default to current time
-    if (messageType.typeName === "google.protobuf.Timestamp") {
-      const now = new Date();
-      const seconds = Math.floor(now.getTime() / 1000);
-      const nanos = (now.getTime() % 1000) * 1_000_000;
-      return ts.factory.createObjectLiteralExpression([
-        ts.factory.createPropertyAssignment("seconds", ts.factory.createStringLiteral(seconds.toString())),
-        ts.factory.createPropertyAssignment("nanos", ts.factory.createNumericLiteral(nanos)),
-      ]);
-    }
-    // google.protobuf.Value holds arbitrary JSON through a "kind" oneof (used for
-    // free-form / polymorphic fields). Recursing would emit every oneof member at
-    // once, an invalid shape; an empty value is a valid, editable placeholder.
-    if (messageType.typeName === "google.protobuf.Value") {
-      return ts.factory.createObjectLiteralExpression([
-        ts.factory.createPropertyAssignment(
-          "kind",
-          ts.factory.createObjectLiteralExpression([ts.factory.createPropertyAssignment("oneofKind", ts.factory.createIdentifier("undefined"))]),
-        ),
-      ]);
-    }
     // For nested message types, recurse with the nested type name
-    return defaultMessage(messageType, sources, imports, visiting);
+    return defaultMessage(field.T(), sources, imports, visiting);
   }
 
   return ts.factory.createNull();


### PR DESCRIPTION
A oneof's members were generated as fields of their own, so the request neither type-checked nor serialized — hence `undefined is not an object (evaluating 'message.kind.oneofKind')`. A oneof is now generated once and empty, and `google.protobuf.Value` (what a spec's free-form properties become, and which the JSON encoder rejects unset) is left out entirely: a map defaults to empty, a repeated field to an empty array, a singular field is omitted.

Requests are also normalized through the message type before sending, so a hand-trimmed literal no longer fails on a field that was deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_0124GEXkevSzvhVsmaKzZodq)_