### PR TITLE
Added a "Show Config in Finder" menu item

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -179,11 +179,20 @@ func (a *App) buildAppMenu(scriptsEnabled bool) *menu.Menu {
 	appMenu.Append(menu.WindowMenu())
 
 	helpMenu := appMenu.AddSubmenu("Help")
+	helpMenu.AddText("Show Config in Finder", nil, func(_ *menu.CallbackData) {
+		a.showConfigurationInFinder()
+	})
 	helpMenu.AddText("Show Logs in Finder", nil, func(_ *menu.CallbackData) {
 		a.showLogsInFinder()
 	})
 
 	return appMenu
+}
+
+// showConfigurationInFinder reveals kaja.json in the system file browser with
+// the file itself selected.
+func (a *App) showConfigurationInFinder() {
+	revealFileInFinder(filepath.Join(a.workspaceDir, "kaja.json"))
 }
 
 // showLogsInFinder reveals the logs directory (see LogFromUI) in the system

--- a/desktop/reveal_darwin.go
+++ b/desktop/reveal_darwin.go
@@ -8,6 +8,7 @@ package main
 
 // Defined in reveal_darwin.m.
 void revealPathInFinder(char *path);
+void selectPathInFinder(char *path);
 */
 import "C"
 
@@ -19,4 +20,12 @@ func revealInFinder(path string) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	C.revealPathInFinder(cpath)
+}
+
+// revealFileInFinder opens the given file's directory in Finder with the file
+// selected.
+func revealFileInFinder(path string) {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	C.selectPathInFinder(cpath)
 }

--- a/desktop/reveal_darwin.m
+++ b/desktop/reveal_darwin.m
@@ -13,3 +13,18 @@ void revealPathInFinder(char *path) {
         });
     }
 }
+
+// Opens the given file's directory in Finder with the file selected. Called
+// from Go (reveal_darwin.go).
+void selectPathInFinder(char *path) {
+    @autoreleasepool {
+        NSString *p = [NSString stringWithUTF8String:path];
+        if (p == nil) {
+            return;
+        }
+        NSURL *url = [NSURL fileURLWithPath:p isDirectory:NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[ url ]];
+        });
+    }
+}

--- a/desktop/reveal_other.go
+++ b/desktop/reveal_other.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os/exec"
+	"path/filepath"
 	"runtime"
 )
 
@@ -14,4 +15,14 @@ func revealInFinder(path string) {
 		return
 	}
 	_ = exec.Command("xdg-open", path).Start()
+}
+
+// revealFileInFinder opens the given file's directory in the system file
+// browser with the file selected, where the browser supports it.
+func revealFileInFinder(path string) {
+	if runtime.GOOS == "windows" {
+		_ = exec.Command("explorer", "/select,"+path).Start()
+		return
+	}
+	_ = exec.Command("xdg-open", filepath.Dir(path)).Start()
 }


### PR DESCRIPTION
Adds "Show Config in Finder" as the first item in the desktop Help menu, revealing `kaja.json` in the system file browser with the file itself selected (`activateFileViewerSelectingURLs` on macOS, `explorer /select,` on Windows, the parent folder on Linux).

---
_Generated by [Claude Code](https://claude.ai/code/session_011p9yhuw8Ndo3SfpUwFEMNW)_