### PR TITLE
Showed the server's own error in the desktop app

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -425,6 +425,17 @@ func (a *App) Twirp(method string, req []byte) ([]byte, error) {
 	response := recorder.Body.Bytes()
 	slog.Info("Twirp response", "status", recorder.Code, "response_length", len(response))
 
+	// A failed call answers with a Twirp error - JSON, not the protobuf the
+	// caller is about to decode - so it travels as an error instead of a body.
+	// It is the same JSON the browser's fetch transport reads, so both transports
+	// arrive at the same RpcError instead of one of them at a decoding failure.
+	if recorder.Code != http.StatusOK {
+		if len(response) == 0 {
+			return nil, errors.New(http.StatusText(recorder.Code))
+		}
+		return nil, errors.New(string(response))
+	}
+
 	return response, nil
 }
 

--- a/ui/src/server/wails-transport.test.ts
+++ b/ui/src/server/wails-transport.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { apiError } from "./wails-transport";
+
+// The desktop side answers a failed API call with the Twirp error itself, so the
+// sentence the server wrote is the one the tab shows.
+test("recovers the server's message and code from a Twirp error", () => {
+  const error = apiError(JSON.stringify({ code: "invalid_argument", msg: 'variable name "a b" must start with a letter' }));
+  expect(error?.message).toBe('variable name "a b" must start with a letter');
+  expect(error?.code).toBe("invalid_argument");
+});
+
+test("reads the same error out of an Error rejection", () => {
+  expect(apiError(new Error(JSON.stringify({ code: "internal", msg: "failed to save configuration" })))?.message).toBe("failed to save configuration");
+});
+
+// Anything that isn't a Twirp error is a transport failure, and keeps saying so.
+test("leaves a transport failure alone", () => {
+  expect(apiError("premature EOF")).toBeUndefined();
+  expect(apiError(new Error("Unknown error"))).toBeUndefined();
+  expect(apiError('{"not":"a twirp error"}')).toBeUndefined();
+  expect(apiError("{ truncated")).toBeUndefined();
+});

--- a/ui/src/server/wails-transport.ts
+++ b/ui/src/server/wails-transport.ts
@@ -8,7 +8,9 @@ import type {
   RpcTransport,
   UnaryCall,
 } from "@protobuf-ts/runtime-rpc";
-import { Deferred, RpcOutputStreamController, ServerStreamingCall, UnaryCall as UnaryCallImpl } from "@protobuf-ts/runtime-rpc";
+import { Deferred, RpcError, RpcOutputStreamController, ServerStreamingCall, UnaryCall as UnaryCallImpl } from "@protobuf-ts/runtime-rpc";
+import { parseTwirpErrorResponse } from "@protobuf-ts/twirp-transport";
+import { isJsonObject, type JsonValue } from "@protobuf-ts/runtime";
 import { Twirp, Target, TargetServerStream, CancelStream } from "../wailsjs/go/main/App";
 import { EventsOn } from "../wailsjs/runtime";
 import { appHeaders } from "../appTypes";
@@ -29,6 +31,24 @@ function wailsErrorMessage(error: unknown): string {
     if (typeof message === "string" && message) return message;
   }
   return "Unknown error";
+}
+
+// apiError recovers the error a failed API call carries. The desktop side hands
+// the Twirp error JSON back as the rejection - the same body the browser's fetch
+// transport reads - so a server's own message ("variable name ... must start
+// with a letter") reaches the UI as itself, instead of as whatever decoding that
+// JSON as protobuf happens to fail with.
+export function apiError(error: unknown): RpcError | undefined {
+  const message = wailsErrorMessage(error);
+  if (!message.startsWith("{")) return undefined;
+  let failure: JsonValue;
+  try {
+    failure = JSON.parse(message);
+  } catch {
+    return undefined;
+  }
+  if (!isJsonObject(failure) || typeof failure.code !== "string" || typeof failure.msg !== "string") return undefined;
+  return parseTwirpErrorResponse(failure);
 }
 
 // UpstreamError is an HTTP error response from the invoked app's upstream API
@@ -319,6 +339,10 @@ export class WailsTransport implements RpcTransport {
       console.error(`Wails ${this.mode} call failed:`, error);
       if (error instanceof UpstreamError) {
         throw error;
+      }
+      const failure = this.mode === "api" ? apiError(error) : undefined;
+      if (failure) {
+        throw failure;
       }
       throw new Error(`Wails ${this.mode} transport error: ${wailsErrorMessage(error)}`);
     }


### PR DESCRIPTION
The desktop Wails binding returned a failed API call's Twirp error JSON as if it were the protobuf response, so every server-side failure — a rejected save, a keychain write, a config the server won't write — reached the UI as `Wails api transport error: premature EOF`. The binding now returns it as an error and the transport rebuilds the same `RpcError` the browser's fetch transport does, so a failed save says why.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186TqxeVJQnnX1i4BMukoeL)_