### PR TITLE
Pinned the Wails CLI to the version desktop/go.mod requires

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -24,7 +24,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.13.0
+        run: go install "github.com/wailsapp/wails/v2/cmd/wails@$(go -C desktop list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)"
 
       - name: Build desktop app
         run: wails build

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -38,7 +38,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.13.0
+        run: go install "github.com/wailsapp/wails/v2/cmd/wails@$(go -C desktop list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)"
 
       - name: Build and upload
         run: scripts/testflight

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Only add code comments for really tricky parts; otherwise keep it clean.
 - If API is called "getConfiguration", use "configuration" not "config" in code.
 - Don't run `go build` directly; use `scripts/server`, `scripts/desktop`, or `scripts/docker`. Kill `scripts/server` when done. Make sure the server port is not in use.
+- The Wails CLI rewrites `desktop/go.mod` to whatever version the CLI is. `desktop/go.mod` is the source of truth: `scripts/desktop` installs that version into `server/build` and puts it first on `PATH`, and `scripts/testflight` and CI refuse to build with a CLI that disagrees. Don't run a globally installed `wails` against this repo.
 - Don't run `scripts/build-ui` separately; when `scripts/server` is running, the UI is recompiled automatically on page load.
 - The UI uses shadcn/ui-style primitives built on Base UI (`@base-ui-components/react`) + Tailwind CSS, stock neutral theme. Reusable primitives live in `ui/src/components/`; compose them and style with Tailwind utility classes. Reach for a raw HTML element + Tailwind before adding a new primitive.
 - Don't update generated files directly; they will be overwritten.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ After:
 
 ## Development
 
-The development scripts require [Go](https://go.dev/doc/install) and [Bun](https://bun.sh/) installed. If not installed, they will offer to install them for you via [Homebrew](https://brew.sh).
+The development scripts require [Go](https://go.dev/doc/install) and [Bun](https://bun.sh/) installed. If not installed, they will offer to install them for you via [Homebrew](https://brew.sh). `scripts/desktop` installs the [Wails](https://wails.io) CLI itself, pinned to the version `desktop/go.mod` requires — the CLI rewrites `go.mod` to whatever version it is, so a different one on `PATH` would change the dependency.
 
 - Run in local server: `scripts/server`
 - Run in Docker: `scripts/docker`

--- a/desktop/variable_store_darwin.go
+++ b/desktop/variable_store_darwin.go
@@ -14,6 +14,11 @@ package main
 // asks for the environment instead.
 
 /*
+// kSecUseDataProtectionKeychain arrived in macOS 10.15, later than the 10.13
+// deployment target Go's cgo defaults to, so this file states its own. Nothing
+// is lost: the Go toolchain this builds with already requires a newer macOS
+// than either number.
+#cgo CFLAGS: -mmacosx-version-min=10.15
 #cgo LDFLAGS: -framework CoreFoundation -framework Security
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/scripts/common
+++ b/scripts/common
@@ -21,3 +21,31 @@ install_protoc() {
     mv "$BUILD_DIR/protoc-go" "$BUILD_DIR/protoc"
 }
 
+# Read the Wails version desktop/go.mod requires. That is the single source of
+# truth for which CLI to run.
+wails_version() {
+    (cd "$PWD/desktop" && go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
+}
+
+# Install the Wails CLI to a target directory, pinned to wails_version.
+# The CLI rewrites desktop/go.mod to its own version on every run, so an older
+# CLI on PATH (Homebrew's formula lags) silently downgrades the dependency.
+#
+# Usage: install_wails [target_dir]
+#   target_dir: Directory to install to (defaults to $PWD/server/build)
+install_wails() {
+    local BUILD_DIR="${1:-$PWD/server/build}"
+
+    mkdir -p "$BUILD_DIR"
+
+    local VERSION
+    VERSION=$(wails_version)
+
+    if [ -x "$BUILD_DIR/wails" ] && "$BUILD_DIR/wails" version 2>/dev/null | grep -qF "$VERSION"; then
+        return
+    fi
+
+    echo "Installing Wails $VERSION..."
+    GOBIN="$BUILD_DIR" go install "github.com/wailsapp/wails/v2/cmd/wails@$VERSION"
+}
+

--- a/scripts/desktop
+++ b/scripts/desktop
@@ -3,22 +3,6 @@ set -e
 
 source "$(dirname "$0")/common"
 
-# Check if Wails is installed
-if ! command -v wails &> /dev/null
-then
-    if [ -t 0 ]; then
-        echo "Wails is not installed."
-        read -p "Would you like to install Wails using Homebrew? (y/n) " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            echo "Wails installation skipped. Exiting script."
-            exit 1
-        fi
-    fi
-    echo "Installing Wails using Homebrew..."
-    brew install wails
-fi
-
 # Check if Bun is installed (wails dev invokes it via frontend:install)
 if ! command -v bun &> /dev/null
 then
@@ -39,6 +23,11 @@ cd "$(dirname "$0")/.."
 
 export GOBIN=$PWD/server/build
 export PATH=$GOBIN:$PATH
+
+# The Wails CLI must match what desktop/go.mod requires; it rewrites go.mod to
+# its own version otherwise. Keep it in server/build so PATH prefers it over
+# whatever `wails` is installed globally.
+install_wails
 
 # Frontend prep (bun install + bundle UI + copy static assets) is now driven
 # by Wails via the frontend:install / frontend:build / frontend:dev:watcher

--- a/scripts/testflight
+++ b/scripts/testflight
@@ -55,8 +55,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+WAILS_VERSION=$(cd "$DESKTOP_DIR" && go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
+WAILS_INSTALL="go install github.com/wailsapp/wails/v2/cmd/wails@$WAILS_VERSION"
+
 if ! command -v wails &>/dev/null; then
-    echo "error: wails not found. Install with: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0"
+    echo "error: wails not found. Install with: $WAILS_INSTALL"
+    exit 1
+fi
+
+# The CLI rewrites desktop/go.mod to its own version, so a release must not be
+# built with one that disagrees with the pinned dependency.
+if ! wails version 2>/dev/null | grep -qF "$WAILS_VERSION"; then
+    echo "error: wails $(wails version 2>/dev/null | tr -d '[:space:]') is on PATH, but desktop/go.mod requires $WAILS_VERSION."
+    echo "       Install the pinned version with: $WAILS_INSTALL"
     exit 1
 fi
 


### PR DESCRIPTION
The Wails CLI rewrites `desktop/go.mod` to its own version on every run, so Homebrew's older formula was silently downgrading the dependency during `scripts/desktop` — the scripts and CI now all resolve the version from `desktop/go.mod` instead. Also stated the 10.15 deployment target the data protection keychain needs, which silences the `kSecUseDataProtectionKeychain` availability warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Cn6KFdEWK25pmWSycUhyc)_