### PR TITLE
Added kaja.value, kaja.struct and kaja.listValue

### DIFF
--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -47,6 +47,23 @@ Scripts can import a `kaja` object with `import { kaja } from "kaja";`:
   script quietly stops. Avoid `kaja.ask` in scripts you run via MCP unless the
   user is present, since it blocks on a human.
 - `kaja.uuid.v4(): string` — generate a random version 4 UUID.
+- `kaja.value(input): Value`, `kaja.struct(input): Struct`,
+  `kaja.listValue(input): ListValue` — build `google.protobuf.Value`, `Struct`
+  and `ListValue` from plain JSON. Do not hand-write the `kind` oneof, and do
+  not declare your own `str`/`num`/`bool` helpers for it.
+
+```ts
+import { kaja } from "kaja";
+import { Seating } from "seating/";
+
+await Seating.Annotate({
+  performanceId: "matinee-1",
+  // A google.protobuf.Value field.
+  note: kaja.value("held for the box office"),
+  // A google.protobuf.Struct field. Objects and arrays convert all the way down.
+  attributes: kaja.struct({ rows: ["F", "G"], accessible: true, holds: 2 }),
+});
+```
 
 ## Working effectively
 

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -52,7 +52,31 @@ function kajaVariablesType(variableNames: string[]): string {
 // go-to-definition lands here. Called again whenever the configured variables
 // change (see App.tsx) to refresh the typed `variables` member.
 export function registerKajaModule(variableNames: string[]): void {
-  const content = `/** The Kaja runtime object. Import it with: import { kaja } from "kaja"; */
+  const content = `/** A plain JSON value, as accepted by kaja.value and friends. */
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+/** google.protobuf.Value. */
+export interface Value {
+  kind:
+    | { oneofKind: "nullValue"; nullValue: 0 }
+    | { oneofKind: "numberValue"; numberValue: number }
+    | { oneofKind: "stringValue"; stringValue: string }
+    | { oneofKind: "boolValue"; boolValue: boolean }
+    | { oneofKind: "structValue"; structValue: Struct }
+    | { oneofKind: "listValue"; listValue: ListValue };
+}
+
+/** google.protobuf.Struct. */
+export interface Struct {
+  fields: { [key: string]: Value };
+}
+
+/** google.protobuf.ListValue. */
+export interface ListValue {
+  values: Value[];
+}
+
+/** The Kaja runtime object. Import it with: import { kaja } from "kaja"; */
 export declare const kaja: {
   /**
    * The selected text passed in when the script is launched from the macOS
@@ -82,6 +106,26 @@ export declare const kaja: {
      */
     v4(): string;
   };
+  /**
+   * Build a google.protobuf.Value from a plain JSON value, instead of writing
+   * its oneof out by hand. Objects and arrays are converted all the way down.
+   *
+   *   kaja.value("ready");
+   *   kaja.value({ retries: 3, tags: ["a", "b"] });
+   */
+  value(input: JsonValue): Value;
+  /**
+   * Build a google.protobuf.Struct from a plain object.
+   *
+   *   kaja.struct({ region: "eu", replicas: 2 });
+   */
+  struct(input: { [key: string]: JsonValue }): Struct;
+  /**
+   * Build a google.protobuf.ListValue from a plain array.
+   *
+   *   kaja.listValue(["a", 1, true]);
+   */
+  listValue(input: JsonValue[]): ListValue;
 };
 `;
   const uri = monaco.Uri.parse("ts:/kaja.ts");
@@ -109,7 +153,7 @@ monaco.languages.registerCompletionItemProvider("typescript", {
           label: { label: "kaja", description: 'import from "kaja"' },
           kind: monaco.languages.CompletionItemKind.Variable,
           detail: 'Add import from "kaja"',
-          documentation: "The Kaja runtime object (kaja.input, kaja.variables, kaja.ask).",
+          documentation: "The Kaja runtime object (kaja.input, kaja.variables, kaja.ask, kaja.value).",
           insertText: "kaja",
           range: new monaco.Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn),
           additionalTextEdits: [{ range: new monaco.Range(1, 1, 1, 1), text: 'import { kaja } from "kaja";\n' }],

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -15,6 +15,58 @@ export interface AskRequest {
   (message: string): Promise<string>;
 }
 
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+// google.protobuf.Value and friends, declared structurally so they match the
+// types protoc-gen-kaja generates for any app that uses them.
+export interface Value {
+  kind:
+    | { oneofKind: "nullValue"; nullValue: 0 }
+    | { oneofKind: "numberValue"; numberValue: number }
+    | { oneofKind: "stringValue"; stringValue: string }
+    | { oneofKind: "boolValue"; boolValue: boolean }
+    | { oneofKind: "structValue"; structValue: Struct }
+    | { oneofKind: "listValue"; listValue: ListValue };
+}
+
+export interface Struct {
+  fields: { [key: string]: Value };
+}
+
+export interface ListValue {
+  values: Value[];
+}
+
+function toValue(input: JsonValue | undefined): Value {
+  if (input === null || input === undefined) {
+    return { kind: { oneofKind: "nullValue", nullValue: 0 } };
+  }
+  switch (typeof input) {
+    case "string":
+      return { kind: { oneofKind: "stringValue", stringValue: input } };
+    case "number":
+      return { kind: { oneofKind: "numberValue", numberValue: input } };
+    case "boolean":
+      return { kind: { oneofKind: "boolValue", boolValue: input } };
+  }
+  if (Array.isArray(input)) {
+    return { kind: { oneofKind: "listValue", listValue: toListValue(input) } };
+  }
+  return { kind: { oneofKind: "structValue", structValue: toStruct(input) } };
+}
+
+function toStruct(input: { [key: string]: JsonValue }): Struct {
+  const fields: { [key: string]: Value } = {};
+  for (const [name, value] of Object.entries(input)) {
+    fields[name] = toValue(value);
+  }
+  return { fields };
+}
+
+function toListValue(input: JsonValue[]): ListValue {
+  return { values: input.map((item) => toValue(item)) };
+}
+
 export class Kaja {
   readonly _internal: KajaInternal;
   // Text passed in when a script is run from the macOS "Run Kaja Script" text
@@ -51,6 +103,20 @@ export class Kaja {
   // with the submitted text; rejects (aborting the script) if the user cancels.
   ask(message: string): Promise<string> {
     return this.#onAsk(message);
+  }
+
+  // Builders for google.protobuf.Value, Struct and ListValue, so a field of one
+  // of those types is written as the JSON it stands for.
+  value(input: JsonValue): Value {
+    return toValue(input);
+  }
+
+  struct(input: { [key: string]: JsonValue }): Struct {
+    return toStruct(input);
+  }
+
+  listValue(input: JsonValue[]): ListValue {
+    return toListValue(input);
   }
 }
 

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -107,3 +107,88 @@ describe("kaja.uuid", () => {
     expect(kaja.uuid.v4()).not.toBe(kaja.uuid.v4());
   });
 });
+
+// The shape protoc-gen-kaja generates for google/protobuf/struct.proto. The
+// builders are only useful if what they return drops into a generated request,
+// so the assignments below are the test - tsc fails if they drift apart.
+enum GeneratedNullValue {
+  NULL_VALUE = 0,
+}
+interface GeneratedValue {
+  kind:
+    | { oneofKind: "nullValue"; nullValue: GeneratedNullValue }
+    | { oneofKind: "numberValue"; numberValue: number }
+    | { oneofKind: "stringValue"; stringValue: string }
+    | { oneofKind: "boolValue"; boolValue: boolean }
+    | { oneofKind: "structValue"; structValue: GeneratedStruct }
+    | { oneofKind: "listValue"; listValue: GeneratedListValue }
+    | { oneofKind: undefined };
+}
+interface GeneratedStruct {
+  fields: { [key: string]: GeneratedValue };
+}
+interface GeneratedListValue {
+  values: GeneratedValue[];
+}
+
+describe("kaja.value", () => {
+  it("builds a Value from each JSON type", () => {
+    const kaja = makeKaja();
+
+    expect(kaja.value("held")).toEqual({ kind: { oneofKind: "stringValue", stringValue: "held" } });
+    expect(kaja.value(3)).toEqual({ kind: { oneofKind: "numberValue", numberValue: 3 } });
+    expect(kaja.value(true)).toEqual({ kind: { oneofKind: "boolValue", boolValue: true } });
+    expect(kaja.value(null)).toEqual({ kind: { oneofKind: "nullValue", nullValue: 0 } });
+  });
+
+  it("converts objects and arrays all the way down", () => {
+    const kaja = makeKaja();
+
+    expect(kaja.value({ tags: ["a"], nested: { n: 1 } })).toEqual({
+      kind: {
+        oneofKind: "structValue",
+        structValue: {
+          fields: {
+            tags: { kind: { oneofKind: "listValue", listValue: { values: [{ kind: { oneofKind: "stringValue", stringValue: "a" } }] } } },
+            nested: { kind: { oneofKind: "structValue", structValue: { fields: { n: { kind: { oneofKind: "numberValue", numberValue: 1 } } } } } },
+          },
+        },
+      },
+    });
+  });
+
+  it("builds a Struct and a ListValue", () => {
+    const kaja = makeKaja();
+
+    expect(kaja.struct({ region: "eu" })).toEqual({ fields: { region: { kind: { oneofKind: "stringValue", stringValue: "eu" } } } });
+    expect(kaja.listValue([1])).toEqual({ values: [{ kind: { oneofKind: "numberValue", numberValue: 1 } }] });
+    expect(kaja.struct({})).toEqual({ fields: {} });
+    expect(kaja.listValue([])).toEqual({ values: [] });
+  });
+
+  it("returns values a generated request field accepts", () => {
+    const kaja = makeKaja();
+
+    const value: GeneratedValue = kaja.value({ rows: ["F", "G"], accessible: true, holds: null });
+    const struct: GeneratedStruct = kaja.struct({ region: "eu" });
+    const list: GeneratedListValue = kaja.listValue(["a", 1, true]);
+
+    expect([value, struct, list]).toHaveLength(3);
+  });
+
+  it("builds values from scripts", async () => {
+    const kaja = makeKaja();
+
+    const run = await runTaskCaptured(`import { kaja } from "kaja";\nreturn kaja.value(["a", 1]);`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toEqual({
+      kind: {
+        oneofKind: "listValue",
+        listValue: {
+          values: [{ kind: { oneofKind: "stringValue", stringValue: "a" } }, { kind: { oneofKind: "numberValue", numberValue: 1 } }],
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Scripts that touch a `google.protobuf.Value` kept growing the same local `str`/`num`/`bool` helpers, so the builders now live on the `kaja` object: they take plain JSON and convert objects and arrays all the way down.

The editor's `kaja` module declares them and the MCP guide points agents at them instead of writing their own.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177soojYoctSDXqNpgfHYZt)_