### PR TITLE
Made the console report runs and applied the sidebar feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,16 @@ calls, and three unrelated rows say nothing about the thing you actually pressed
   run with its call count, today's above a dimmed date header for older ones.
   `⌃↑`/`⌃↓` step through runs. Selecting a call fills the response below;
   selecting the run header shows the run's own summary instead.
+- **A new run always takes the console** (`followSelection`), because pressing Run
+  is a request to see what it did — from an older run stepped back to as much as
+  from the last one. Everything short of a new run stays where it is put: a call
+  landing in a later run leaves a stepped-back one alone, and only inside the run
+  being watched does the cursor follow the newest call, which is what selects one
+  in flight the moment it is issued rather than when its response lands.
 - **Run names reuse the derived script names**, so the console and the sidebar
-  speak the same language.
+  speak the same language. The window title follows the same name, from the
+  scratch list rather than the view — running or appending re-derives a title
+  without the view itself changing.
 - **Live and last-time are different states, and the header is the only place
   that can say which.** Reopening a script gives you its code and, if we still
   hold it, its last run (`runStore.ts`): the header carries a `Last run` pill and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,14 +86,77 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   to tell two same-named calls in different apps apart. **Nothing in the method
   tree is ever "current"** — the tree is the API's catalog, not a reflection of
   what you are looking at, and a scratch is free to grow past the method it came
-  from anyway.
+  from anyway. A **hairline** separates the two halves, because a script and the
+  method it was written from can carry the same label a few rows apart and must
+  never read as one list.
+- **The browsing buffer says so.** "An untouched one gets taken over, a
+  worked-in one doesn't" is a good rule you could otherwise only learn by being
+  surprised by it, so it has a tell: a scratch that is still `isUntouched` is
+  **dimmed** — label and icon, in the sidebar row and in the finder's trigger and
+  rows (`provisional` on `ViewIdentity` and on a finder `Destination`) — and
+  resolves to full weight the moment it is edited or run. Not italics, and not a
+  word; the dim is the reading. Beside it, `titleParts` splits the qualifier the
+  naming rule produced (`· vera-lune`, `· 5, 3`) off the name so the row can dim
+  that too.
+- **Delete and discard are different words for different consequences.** A saved
+  row's menu is `Rename…` / **`Delete file`**, destructive and confirmed, because
+  it takes a file off disk. An unsaved row's is `Save…` / **`Discard`**, neutral
+  and **undoable** — the row goes and a bar offers it back for eight seconds
+  (`UNDO_DISCARD_MS`) — because nothing was anywhere to remove. Saving proposes
+  the filename from the derived name, so the section converges on one naming
+  convention instead of splitting into files and not-files by casing.
+- **Rows reserve their trailing slot.** `TreeView.TrailingVisual` is a fixed 24px
+  whether or not it holds anything, so a label's truncation point doesn't move
+  under the cursor when the row grows a kebab on hover.
 - **The web is the same app minus one verb.** Scratches are IndexedDB on both
   platforms, so the list, the titles and the history are identical; only Save is
   missing, because only the desktop has a disk to write to.
-- **Not built yet**: the console still keeps one global stream in memory, so
-  reopening an old scratch gives you the code without last time's responses.
-  Storing code is free; storing responses is not, so that needs its own
-  retention rule (most recent N scratches, or a size cap).
+
+## The console reports runs
+
+**A run is the unit** (`runs.ts`): one press of Run, one header, one duration,
+one verdict, with the calls it made nested under it. One script can make three
+calls, and three unrelated rows say nothing about the thing you actually pressed.
+
+- **Three rules make the grouping hold.** ① A run's status is the **worst status
+  it contains** (`worstStatus`) — there is no "partially succeeded", and the
+  header dot is the only thing anyone needs to read after a press. ② A
+  **single-item run renders as one row**, header and call merged, so the 90% case
+  stays as flat as it was. ③ Calls inside a run are ordered by start, never
+  re-sorted, and keep their own durations; the header's duration is **wall time
+  for the whole script**, which is the number that differs from the sum when
+  calls run concurrently.
+- **The history lists runs, not calls.** Same select, one level up: each row is a
+  run with its call count, today's above a dimmed date header for older ones.
+  `⌃↑`/`⌃↓` step through runs. Selecting a call fills the response below;
+  selecting the run header shows the run's own summary instead.
+- **Run names reuse the derived script names**, so the console and the sidebar
+  speak the same language.
+- **Live and last-time are different states, and the header is the only place
+  that can say which.** Reopening a script gives you its code and, if we still
+  hold it, its last run (`runStore.ts`): the header carries a `Last run` pill and
+  a date instead of a clock, and the body sits at 70% opacity. Pressing Run
+  replaces it in place — a run made in this session always wins over a stored
+  one. Retention can be short because **expiry is a stated state, not a silent
+  hole**: headers are kept for the fifty most recently run files, payloads for
+  seven days (or dropped at once if they don't fit), and a run whose payloads have
+  gone keeps its header over a single line — `Response no longer kept — run to
+  see it live`. Clearing the history clears the store too.
+- **With no run there is nothing to select.** The console drops its header
+  entirely until something has been run, rather than showing Response as
+  selected and the other two as disabled over an empty panel.
+
+## The empty state
+
+With nothing open, the pane has one job: **say that clicking a call in the tree
+writes you a script** (`NoFileBlankslate.tsx`). That sentence is the whole model
+of the product and is said nowhere else. Under it sit the last few things you
+were in, and `⌘P find a call` · `⌘N blank script`.
+
+The people who see this screen most are not new — every missed `⌘P` and every
+fresh window lands here — so it is a shortcut rather than a teaching
+illustration, and it degrades correctly: on a first run the recent list is
+**absent**, not an empty box, leaving the sentence and the two keys.
 
 ## The command row and the finder
 
@@ -138,11 +201,17 @@ inset only when the sidebar is collapsed).
   non-script surfaces. Its disabled state and the trigger's `N errors` state come
   from the same `useSyntaxErrors` (`RunButton.tsx`), so the row never disagrees
   with itself.
-- **Shortcuts** — `⌘P` finder on the previous place · `⌘K` same surface · `⌘⏎`/F5
-  run · `⌘J` JSON view · `⌘B` sidebar · `⌘S` save. `⌃Tab`, `⌘1–9` and `⌘W` are
-  gone: there are no positions to number and nothing to close.
-- **Split panes** are specified but not built; when they are, the row divides at
-  the pane seam and each half gets its own finder.
+- **Shortcuts** — `⌘P` finder on the previous place · `⌘K` same surface · `⌘N`
+  blank script · `⌘⏎`/F5 run · `⌘J` JSON view · `⌘B` sidebar · `⌘S` save.
+  `⌃Tab`, `⌘1–9` and `⌘W` are gone: there are no positions to number and nothing
+  to close.
+- **Split panes are cut, not deferred.** The pane holds one thing by
+  construction; splitting it reintroduces "which one is current", which is the
+  exact question removing the strip answered — two panes, one trigger, one `⌘P`.
+  Comparing one response against another is a console problem, and the run
+  history above is where it belongs, not the editor. (The `Columns2`/`Rows2`
+  control in the row is not this: it decides whether the console sits beside the
+  editor or under it, which is one file either way.)
 
 ## Experimental (Preview)
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,8 +10,10 @@ import * as monaco from "monaco-editor";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "./cn";
 import { CommandRow } from "./CommandRow";
-import { Console, ConsoleItem } from "./Console";
-import { NoFileBlankslate } from "./NoFileBlankslate";
+import { Console } from "./Console";
+import { ConsoleItem, newItemId, newRunId, Run } from "./runs";
+import { loadLastRun, clearArchive, saveLastRun, LoadedRun } from "./runStore";
+import { NoFileBlankslate, RecentFile } from "./NoFileBlankslate";
 import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
@@ -20,6 +22,7 @@ import { AskCancelledError, isCallInFlight, Kaja, MethodCall } from "./kaja";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
 import { appendCall, createScratch, isUntouched, markRun, pruneScratches, Scratch, ScratchOrigin, takeOver, withCode } from "./scratches";
+import { deriveScratchTitle } from "./scratchTitle";
 import { generateMethodEditorCode } from "./appLoader";
 import { RunButton, useSyntaxErrors } from "./RunButton";
 import { Sidebar, TRAFFIC_LIGHTS_INSET } from "./Sidebar";
@@ -77,6 +80,11 @@ import { runTask, runTaskCaptured } from "./taskRunner";
 
 // Maximum number of console items kept in memory; older calls are dropped.
 const MAX_CONSOLE_ITEMS = 500;
+// Runs are the unit the console reports, so the history is capped in runs too.
+const MAX_RUNS = 100;
+// How long a discarded scratch is held before it is really gone. Nothing was on
+// disk, so this is undo rather than a confirmation.
+const UNDO_DISCARD_MS = 8000;
 
 // Scratch ids the last session had open, so start-up pruning can't drop one
 // that is about to reopen.
@@ -180,7 +188,19 @@ export function App() {
     window.innerWidth >= SIDE_BY_SIDE_MIN_WIDTH ? "horizontal" : "vertical",
   );
   const [colorMode, setColorMode] = usePersistedState<ColorMode>("colorMode", "night");
+  // What the console reports: one run per press of Run, and the calls and log
+  // lines that ran under it.
   const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([]);
+  const [runs, setRuns] = useState<Run[]>([]);
+  const runsRef = useRef(runs);
+  runsRef.current = runs;
+  // The run calls are being attributed to. Cleared once the run settles, so a
+  // stray call afterwards starts one of its own rather than joining a run that
+  // is over.
+  const currentRunRef = useRef<Run | null>(null);
+  // The last run of the file on screen, read back from the store. It happened in
+  // an earlier session and is shown as such — never as something live.
+  const [staleRun, setStaleRun] = useState<LoadedRun | undefined>();
   // Whether the finder is open, and where it opened: ⌘P lands on the
   // previous file so ⌘P⏎ goes back, everything else on the first row.
   const [finder, setFinder] = useState<"first" | "previous">();
@@ -243,7 +263,13 @@ export function App() {
   // The run in flight, if any: which tab issued it, when it started, and the
   // controller its Stop button aborts. `settled` marks the script itself as
   // finished — the run is only over once its calls have landed too.
-  const [activeRun, setActiveRun] = useState<{ viewId: string; startedAt: number; controller: AbortController; settled: boolean } | null>(null);
+  const [activeRun, setActiveRun] = useState<{ runId: string; viewId?: string; startedAt: number; controller?: AbortController; settled: boolean } | null>(
+    null,
+  );
+  // A discarded scratch, held long enough to take it back. Nothing was on disk,
+  // so discarding is undoable rather than confirmed.
+  const [discarded, setDiscarded] = useState<Scratch | null>(null);
+  const discardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Pending debounced disk writes for open script views, keyed by tab id.
   const scriptSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   // Tab ids whose next content change is a programmatic revalidation poke (see
@@ -338,34 +364,63 @@ export function App() {
     [disposeView, persistViews],
   );
 
-  const onMethodCallUpdate = useCallback((methodCall: MethodCall) => {
-    const collector = mcpRunCollectorRef.current;
-    if (collector) {
-      const i = collector.findIndex((m) => m.id === methodCall.id);
-      if (i > -1) collector[i] = methodCall;
-      else collector.push(methodCall);
-    }
-    setConsoleItems((consoleItems) => {
-      const index = consoleItems.findIndex((item) => "id" in item && item.id === methodCall.id);
-      if (index > -1) {
-        return consoleItems.map((item, i) => (i === index ? { ...methodCall } : item));
-      }
-      const next = [...consoleItems, { ...methodCall }];
+  // One press of Run opens a run; everything the script does lands under it.
+  // Nothing else creates one, except a call that arrives with no run open —
+  // which gets a run of its own rather than joining one that is over.
+  const beginRun = useCallback((title: string, sourceId?: string, viewId?: string, controller?: AbortController): Run => {
+    const run: Run = { id: newRunId(), title, sourceId, startedAt: Date.now() };
+    currentRunRef.current = run;
+    setRuns((list) => {
+      const next = [...list, run];
+      return next.length > MAX_RUNS ? next.slice(next.length - MAX_RUNS) : next;
+    });
+    setActiveRun({ runId: run.id, viewId, startedAt: run.startedAt, controller, settled: false });
+    return run;
+  }, []);
+
+  const beginRunRef = useRef(beginRun);
+  beginRunRef.current = beginRun;
+
+  const appendConsoleItem = useCallback((item: ConsoleItem) => {
+    setConsoleItems((items) => {
+      const next = [...items, item];
       // Cap history so a long session can't grow the console unbounded.
       return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
     });
   }, []);
 
+  const onMethodCallUpdate = useCallback(
+    (methodCall: MethodCall) => {
+      const collector = mcpRunCollectorRef.current;
+      if (collector) {
+        const i = collector.findIndex((m) => m.id === methodCall.id);
+        if (i > -1) collector[i] = methodCall;
+        else collector.push(methodCall);
+      }
+      const run = currentRunRef.current ?? beginRun(methodCall.method.name);
+      setConsoleItems((items) => {
+        const index = items.findIndex((item) => item.call?.id === methodCall.id);
+        if (index > -1) {
+          return items.map((item, i) => (i === index ? { ...item, call: { ...methodCall } } : item));
+        }
+        const next = [...items, { id: newItemId(), runId: run.id, timestamp: methodCall.timestamp, call: { ...methodCall } }];
+        return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
+      });
+    },
+    [beginRun],
+  );
+
   // Show a failed script run in the console; a script that dies silently looks
   // like it succeeded. Mirrored to console.error so it also lands in kaja.log.
-  const onScriptError = useCallback((error: unknown) => {
-    console.error("Script error:", error);
-    const message = error instanceof Error ? (error.name === "Error" ? error.message : `${error.name}: ${error.message}`) : String(error);
-    setConsoleItems((consoleItems) => {
-      const next: ConsoleItem[] = [...consoleItems, [{ level: LogLevel.LEVEL_ERROR, message }]];
-      return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
-    });
-  }, []);
+  const onScriptError = useCallback(
+    (error: unknown) => {
+      console.error("Script error:", error);
+      const message = error instanceof Error ? (error.name === "Error" ? error.message : `${error.name}: ${error.message}`) : String(error);
+      const run = currentRunRef.current ?? beginRun("Script error");
+      appendConsoleItem({ id: newItemId(), runId: run.id, timestamp: Date.now(), logs: [{ level: LogLevel.LEVEL_ERROR, message }] });
+    },
+    [appendConsoleItem, beginRun],
+  );
 
   // Open the input dialog for a `kaja.ask(...)` call, resolving once the user
   // submits. Rejecting on cancel is handled by the dialog itself.
@@ -380,8 +435,14 @@ export function App() {
     kajaRef.current = new Kaja(onMethodCallUpdate, onAsk);
   }
 
+  // Clearing the history clears what is being held for next time too; leaving
+  // yesterday's run behind would make "cleared" a half-truth.
   const onClearConsole = useCallback(() => {
     setConsoleItems([]);
+    setRuns([]);
+    setStaleRun(undefined);
+    currentRunRef.current = null;
+    clearArchive();
   }, []);
 
   // Kept in sync during render so the first drag can pick up wherever the gutter
@@ -711,6 +772,12 @@ export function App() {
         setFinder(e.key === "p" ? "previous" : "first");
         return;
       }
+      // A blank script — the other half of "pick a call and Kaja writes one".
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "n") {
+        e.preventDefault();
+        onNewScratchRef.current();
+        return;
+      }
       // The same key as the </> button in the command row, on every file that
       // has a JSON representation.
       if ((e.metaKey || e.ctrlKey) && e.key === "j") {
@@ -876,14 +943,37 @@ export function App() {
     [applyViews],
   );
 
-  const onDeleteScratch = useCallback(
+  // Discarding an unsaved script takes nothing off disk, so it is undone rather
+  // than confirmed: the row goes, and a bar offers it back for a few seconds.
+  const onDiscardScratch = useCallback(
     (scratch: Scratch) => {
       const shown = viewsRef.current.find((view) => view.type === "scratch" && view.scratchId === scratch.id);
       if (shown) applyViews((views) => dropView(views, shown.id));
       applyScratches((list) => list.filter((candidate) => candidate.id !== scratch.id));
+      if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
+      setDiscarded(scratch);
+      discardTimerRef.current = setTimeout(() => setDiscarded(null), UNDO_DISCARD_MS);
     },
     [applyScratches, applyViews],
   );
+
+  const onUndoDiscard = useCallback(() => {
+    if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
+    setDiscarded((scratch) => {
+      if (scratch) applyScratches((list) => [scratch, ...list]);
+      return null;
+    });
+  }, [applyScratches]);
+
+  // A blank script, for when you know what you want to write and don't need a
+  // call to start it. The empty state names the key, so it has to exist.
+  const onNewScratch = useCallback(() => {
+    const scratch = createScratch("", undefined, Date.now());
+    applyScratches((list) => [scratch, ...list]);
+    applyViews((views) => showScratch(views, scratch));
+  }, [applyScratches, applyViews]);
+  const onNewScratchRef = useRef(onNewScratch);
+  onNewScratchRef.current = onNewScratch;
 
   const onScriptSelect = useCallback(
     async (script: Script) => {
@@ -926,12 +1016,15 @@ export function App() {
         await onScriptSelect({ path: file.path, name: file.name });
         const kaja = kajaRef.current!;
         kaja.input = text;
-        runTask(file.content, kaja, apps, onScriptError);
+        const run = beginRun(file.name, file.path);
+        runTask(file.content, kaja, apps, onScriptError).finally(() =>
+          setActiveRun((active) => (active?.runId === run.id ? { ...active, settled: true } : active)),
+        );
       } catch (err) {
         showFileError(`Run failed: ${err}`);
       }
     },
-    [pinnedScriptPath, onScriptSelect, apps, showFileError, onScriptError],
+    [pinnedScriptPath, onScriptSelect, apps, showFileError, onScriptError, beginRun],
   );
 
   const runContextMenuScriptRef = useRef(runContextMenuScript);
@@ -1071,6 +1164,7 @@ export function App() {
       const collected: MethodCall[] = [];
       mcpRunCollectorRef.current = collected;
       let result: { console: string[]; result?: unknown; error?: string; methodCalls: unknown[] };
+      const run = beginRunRef.current(payload.path ? payload.path.split("/").pop()! : "Agent script", payload.path || undefined);
       try {
         let source = payload.code;
         if (payload.path) {
@@ -1085,6 +1179,7 @@ export function App() {
         result = { console: [], error: err instanceof Error ? err.message : String(err), methodCalls: collected.map(toMethodCallLog) };
       } finally {
         mcpRunCollectorRef.current = null;
+        setActiveRun((active) => (active?.runId === run.id ? { ...active, settled: true } : active));
       }
       MCPScriptResult(payload.id, JSON.stringify(result)).catch(() => {});
     });
@@ -1359,34 +1454,62 @@ export function App() {
     if (!editor) {
       return;
     }
+    const code = editor.getValue();
     const controller = new AbortController();
-    setActiveRun({ viewId: tab.id, startedAt: Date.now(), controller, settled: false });
-    runTask(editor.getValue(), kajaRef.current!, apps, onScriptError, controller.signal).finally(() =>
+    // Run names reuse the derived script names, so the console and the sidebar
+    // speak the same language.
+    const title = tab.type === "script" ? tab.script.name : (deriveScratchTitle(code) ?? viewIdentity(tab, scratchesRef.current).name);
+    const sourceId = tab.type === "script" ? tab.script.path : tab.scratchId;
+    beginRun(title, sourceId, tab.id, controller);
+    runTask(code, kajaRef.current!, apps, onScriptError, controller.signal).finally(() =>
       setActiveRun((run) => (run?.controller === controller ? { ...run, settled: true } : run)),
     );
     // A run is the punctuation that settles a scratch: it is when the title is
     // re-read from the code, rather than jittering as you type.
     if (tab.type === "scratch") {
-      updateScratch(tab.scratchId, (scratch) => markRun(scratch, editor.getValue(), Date.now()));
+      updateScratch(tab.scratchId, (scratch) => markRun(scratch, code, Date.now()));
     }
-  }, [apps, applyViews, onScriptError, updateScratch]);
+  }, [apps, beginRun, onScriptError, updateScratch]);
 
   // A generated method-call script issues its call without awaiting it, so the
   // script's own promise settles well before the response lands. The run is over
-  // once the script has settled and nothing it started is still in flight.
+  // once the script has settled and nothing it started is still in flight — and
+  // that is when its wall duration is known and it is worth keeping for the next
+  // time the file is opened.
   useEffect(() => {
     if (!activeRun?.settled) return;
-    const inFlight = consoleItems.some((item) => "method" in item && item.timestamp >= activeRun.startedAt && isCallInFlight(item));
-    if (!inFlight) {
-      setActiveRun(null);
+    const items = consoleItems.filter((item) => item.runId === activeRun.runId);
+    if (items.some((item) => item.call !== undefined && isCallInFlight(item.call))) return;
+
+    const finished = runsRef.current.find((run) => run.id === activeRun.runId);
+    if (finished) {
+      const settled: Run = { ...finished, durationMs: Date.now() - activeRun.startedAt };
+      setRuns((list) => list.map((run) => (run.id === settled.id ? settled : run)));
+      if (settled.sourceId) saveLastRun(settled.sourceId, settled, items);
     }
+    if (currentRunRef.current?.id === activeRun.runId) currentRunRef.current = null;
+    setActiveRun(null);
   }, [consoleItems, activeRun]);
+
+  // Which file the console is reporting on, so its last run can be found again.
+  const currentSourceId = currentView?.type === "script" ? currentView.script.path : currentView?.type === "scratch" ? currentView.scratchId : undefined;
+
+  // Reopening a script gives you its code and, if we still hold it, its last
+  // run. A run made in this session already says what happened, so the stored
+  // one only appears when there isn't one.
+  useEffect(() => {
+    if (!currentSourceId || runs.some((run) => run.sourceId === currentSourceId)) {
+      setStaleRun(undefined);
+      return;
+    }
+    setStaleRun(loadLastRun(currentSourceId));
+  }, [currentSourceId, runs]);
 
   // Stop aborts the calls the run has in flight; the script itself stops at the
   // call it was awaiting.
   const onStopActiveRun = useCallback(() => {
     setActiveRun((run) => {
-      run?.controller.abort();
+      run?.controller?.abort();
       return null;
     });
   }, []);
@@ -1611,6 +1734,7 @@ export function App() {
         path: "Scripts",
         origin: scratch.origin?.appName ?? "",
         icon: PenLine,
+        provisional: isUntouched(scratch),
         go: () => onScratchSelect(scratch),
       });
     }
@@ -1641,6 +1765,35 @@ export function App() {
 
     return destinations;
   }, [apps, scratches, scripts, views, onScratchSelect, onScriptSelect, onFinderMethodSelect, onVariablesClick, onShowCompileLog]);
+
+  // The console reports runs. A run whose calls have all aged out of the item
+  // cap would be a header with nothing under it, so it goes with them; the one
+  // in flight is kept even before it has produced anything.
+  const consoleRuns = useMemo(() => {
+    const withItems = new Set(consoleItems.map((item) => item.runId));
+    const live = runs.filter((run) => withItems.has(run.id) || run.id === activeRun?.runId);
+    return staleRun ? [staleRun.run, ...live] : live;
+  }, [runs, consoleItems, activeRun?.runId, staleRun]);
+
+  const consoleEntries = useMemo(() => (staleRun ? [...staleRun.items, ...consoleItems] : consoleItems), [staleRun, consoleItems]);
+
+  // What the empty state offers instead of an illustration: the last few things
+  // you were in. On a first run there are none and the list is simply absent.
+  const recentFiles = useMemo<RecentFile[]>(() => {
+    const files: RecentFile[] = scratches.slice(0, 3).map((scratch) => ({
+      key: scratch.id,
+      name: scratch.title,
+      icon: PenLine,
+      updatedAt: scratch.updatedAt,
+      saved: false,
+      go: () => onScratchSelect(scratch),
+    }));
+    for (const script of scripts ?? []) {
+      if (files.length >= 3) break;
+      files.push({ key: script.path, name: script.name, icon: FileCode, saved: true, go: () => void onScriptSelect(script) });
+    }
+    return files;
+  }, [scratches, scripts, onScratchSelect, onScriptSelect]);
 
   const running = currentView !== undefined && activeRun?.viewId === currentView.id;
   const action = currentIsEditor ? (
@@ -1703,7 +1856,7 @@ export function App() {
                 scratches={scratches}
                 currentScratchId={currentView?.type === "scratch" ? currentView.scratchId : undefined}
                 onScratchSelect={onScratchSelect}
-                onDeleteScratch={onDeleteScratch}
+                onDeleteScratch={onDiscardScratch}
                 onSaveScratch={isWailsEnvironment() ? onSaveScratch : undefined}
                 onShowAllScratches={() => setFinder("first")}
                 currentScriptPath={currentView?.type === "script" ? currentView.script.path : undefined}
@@ -1741,7 +1894,9 @@ export function App() {
               onToggleLayout={onToggleEditorLayout}
             />
             {views.length === 0 && configurationLoaded && apps.length === 0 && <FirstAppBlankslate onNewAppClick={onNewAppClick} />}
-            {views.length === 0 && (apps.length > 0 || !configurationLoaded) && <NoFileBlankslate onOpenSwitcher={() => setFinder("first")} />}
+            {views.length === 0 && (apps.length > 0 || !configurationLoaded) && (
+              <NoFileBlankslate onOpenFinder={() => setFinder("first")} onNewScratch={onNewScratch} recent={recentFiles} />
+            )}
             {views.length > 0 && (
               <div style={{ flex: 1, display: "flex", flexDirection: isHorizontalLayout ? "row" : "column", minHeight: 0 }}>
                 <div
@@ -1820,7 +1975,7 @@ export function App() {
                         flexDirection: "column",
                       }}
                     >
-                      <Console items={consoleItems} onClear={onClearConsole} />
+                      <Console runs={consoleRuns} items={consoleEntries} onClear={onClearConsole} />
                     </div>
                   </>
                 )}
@@ -1857,9 +2012,13 @@ export function App() {
           <FormControl>
             <FormControl.Label>Name</FormControl.Label>
             <div className="relative">
+              {/* Saved rows read as filenames and unsaved ones as call names;
+                  proposing the filename from the derived name is what keeps the
+                  section from splitting into two conventions the icon was
+                  supposed to carry alone. */}
               <Input
                 autoFocus
-                className="pr-9"
+                className="pr-9 font-mono"
                 value={saveAs.name}
                 onChange={(e) => setSaveAs((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
                 onKeyDown={(e) => {
@@ -1869,11 +2028,12 @@ export function App() {
                   }
                 }}
               />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">.ts</span>
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 font-mono text-sm text-muted-foreground">.ts</span>
             </div>
             {saveAsError && <FormControl.Validation variant="error">{saveAsError}</FormControl.Validation>}
             <FormControl.Caption>
-              Writes the script to disk, where agents and other tools can see it. Unsaved ones are kept in Kaja either way.
+              Proposed from the script's contents. Renaming here is the only rename there is — it writes the file to disk, where agents and other tools can see
+              it.
             </FormControl.Caption>
           </FormControl>
         </Dialog>
@@ -1968,197 +2128,21 @@ export function App() {
           Permanently delete <strong>{deleteScript.name}</strong>?
         </ConfirmationDialog>
       )}
-      {renameScript && (
-        <Dialog
-          title="Rename script"
-          onClose={() => {
-            setRenameScript(null);
-            setRenameError(undefined);
-          }}
-          footerButtons={[
-            { content: "Cancel", onClick: () => setRenameScript(null) },
-            { content: "Rename", variant: "default", onClick: onConfirmRenameScript },
-          ]}
-        >
-          <FormControl>
-            <FormControl.Label>Name</FormControl.Label>
-            <div className="relative">
-              <Input
-                autoFocus
-                className="pr-9"
-                value={renameScript.name}
-                onChange={(e) => setRenameScript((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onConfirmRenameScript();
-                  }
-                }}
-              />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">.ts</span>
-            </div>
-            {renameError && <FormControl.Validation variant="error">{renameError}</FormControl.Validation>}
-          </FormControl>
-        </Dialog>
-      )}
-      {deleteScript && (
-        <ConfirmationDialog
-          title="Delete script?"
-          confirmButtonContent="Delete"
-          confirmButtonType="danger"
-          onClose={(gesture) => {
-            const script = deleteScript;
-            setDeleteScript(null);
-            if (gesture === "confirm" && script) onConfirmDeleteScript(script);
-          }}
-        >
-          Permanently delete <strong>{deleteScript.name}</strong>?
-        </ConfirmationDialog>
-      )}
-      {renameScript && (
-        <Dialog
-          title="Rename script"
-          onClose={() => {
-            setRenameScript(null);
-            setRenameError(undefined);
-          }}
-          footerButtons={[
-            { content: "Cancel", onClick: () => setRenameScript(null) },
-            { content: "Rename", variant: "default", onClick: onConfirmRenameScript },
-          ]}
-        >
-          <FormControl>
-            <FormControl.Label>Name</FormControl.Label>
-            <div className="relative">
-              <Input
-                autoFocus
-                className="pr-9"
-                value={renameScript.name}
-                onChange={(e) => setRenameScript((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onConfirmRenameScript();
-                  }
-                }}
-              />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">.ts</span>
-            </div>
-            {renameError && <FormControl.Validation variant="error">{renameError}</FormControl.Validation>}
-          </FormControl>
-        </Dialog>
-      )}
-      {deleteScript && (
-        <ConfirmationDialog
-          title="Delete script?"
-          confirmButtonContent="Delete"
-          confirmButtonType="danger"
-          onClose={(gesture) => {
-            const script = deleteScript;
-            setDeleteScript(null);
-            if (gesture === "confirm" && script) onConfirmDeleteScript(script);
-          }}
-        >
-          Permanently delete <strong>{deleteScript.name}</strong>?
-        </ConfirmationDialog>
-      )}
-      {renameScript && (
-        <Dialog
-          title="Rename script"
-          onClose={() => {
-            setRenameScript(null);
-            setRenameError(undefined);
-          }}
-          footerButtons={[
-            { content: "Cancel", onClick: () => setRenameScript(null) },
-            { content: "Rename", variant: "default", onClick: onConfirmRenameScript },
-          ]}
-        >
-          <FormControl>
-            <FormControl.Label>Name</FormControl.Label>
-            <div className="relative">
-              <Input
-                autoFocus
-                className="pr-9"
-                value={renameScript.name}
-                onChange={(e) => setRenameScript((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onConfirmRenameScript();
-                  }
-                }}
-              />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">.ts</span>
-            </div>
-            {renameError && <FormControl.Validation variant="error">{renameError}</FormControl.Validation>}
-          </FormControl>
-        </Dialog>
-      )}
-      {deleteScript && (
-        <ConfirmationDialog
-          title="Delete script?"
-          confirmButtonContent="Delete"
-          confirmButtonType="danger"
-          onClose={(gesture) => {
-            const script = deleteScript;
-            setDeleteScript(null);
-            if (gesture === "confirm" && script) onConfirmDeleteScript(script);
-          }}
-        >
-          Permanently delete <strong>{deleteScript.name}</strong>?
-        </ConfirmationDialog>
-      )}
-      {renameScript && (
-        <Dialog
-          title="Rename script"
-          onClose={() => {
-            setRenameScript(null);
-            setRenameError(undefined);
-          }}
-          footerButtons={[
-            { content: "Cancel", onClick: () => setRenameScript(null) },
-            { content: "Rename", variant: "default", onClick: onConfirmRenameScript },
-          ]}
-        >
-          <FormControl>
-            <FormControl.Label>Name</FormControl.Label>
-            <div className="relative">
-              <Input
-                autoFocus
-                className="pr-9"
-                value={renameScript.name}
-                onChange={(e) => setRenameScript((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onConfirmRenameScript();
-                  }
-                }}
-              />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">.ts</span>
-            </div>
-            {renameError && <FormControl.Validation variant="error">{renameError}</FormControl.Validation>}
-          </FormControl>
-        </Dialog>
-      )}
-      {deleteScript && (
-        <ConfirmationDialog
-          title="Delete script?"
-          confirmButtonContent="Delete"
-          confirmButtonType="danger"
-          onClose={(gesture) => {
-            const script = deleteScript;
-            setDeleteScript(null);
-            if (gesture === "confirm" && script) onConfirmDeleteScript(script);
-          }}
-        >
-          Permanently delete <strong>{deleteScript.name}</strong>?
-        </ConfirmationDialog>
-      )}
       {fileError && (
         <div style={{ position: "fixed", top: 36, left: "50%", transform: "translateX(-50%)", zIndex: 1000, maxWidth: 640 }}>
           <Alert variant="danger">{fileError}</Alert>
+        </div>
+      )}
+      {/* Nothing was on disk, so discarding is taken back rather than confirmed
+          up front. */}
+      {discarded && (
+        <div className="fixed bottom-10 left-1/2 z-[1000] flex h-9 -translate-x-1/2 items-center gap-3 rounded-md border border-border bg-popover px-3 shadow-lg">
+          <span className="text-sm text-muted-foreground">
+            Discarded <span className="text-foreground">{discarded.title}</span>
+          </span>
+          <button type="button" className="text-sm font-medium text-foreground hover:underline" onClick={onUndoDiscard}>
+            Undo
+          </button>
         </div>
       )}
     </>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -718,11 +718,15 @@ export function App() {
     document.documentElement.classList.toggle("dark", colorMode === "night");
   }, [colorMode]);
 
+  // A scratch names itself from its own code, so the window follows the list
+  // rather than the view: running or appending re-derives the title without the
+  // view itself changing, and reading it through a ref would leave the window on
+  // the name the row has already stopped showing.
   useEffect(() => {
     const current = views[0];
     let title = "Kaja";
     if (current?.type === "scratch") {
-      title = `${viewIdentity(current, scratchesRef.current).name} - Kaja`;
+      title = `${viewIdentity(current, scratches).name} - Kaja`;
     } else if (current?.type === "script") {
       title = `${current.script.name} - Kaja`;
     }
@@ -730,7 +734,7 @@ export function App() {
     if (isWailsEnvironment()) {
       WindowSetTitle(title);
     }
-  }, [views]);
+  }, [views, scratches]);
 
   // Load the global scripts directory (desktop only). Scripts are independent
   // of apps; they bind to an app at run time via their import paths.

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "./components/spinner";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
 import { MethodCall } from "./kaja";
-import { callCount, ConsoleItem, groupRuns, itemName, itemStatus, Run, RunGroup, RunStatus } from "./runs";
+import { callCount, ConsoleItem, followSelection, groupRuns, itemName, itemStatus, Run, RunGroup, RunSelection, RunStatus } from "./runs";
 import { runShortcutLabel } from "./RunButton";
 import { Log, LogLevel } from "./server/api";
 
@@ -32,13 +32,6 @@ const consoleTabActiveClass = "font-medium text-foreground";
 // beside them.
 const utilityButtonClass = "h-6 w-6 rounded-md hover:bg-accent hover:text-foreground";
 
-// Which run is being looked at, and which of its calls. No call means the run
-// header itself is selected, which shows the run's own summary.
-interface Selection {
-  runId: string;
-  itemId?: string;
-}
-
 interface ConsoleProps {
   runs: Run[];
   items: ConsoleItem[];
@@ -46,7 +39,7 @@ interface ConsoleProps {
 }
 
 export function Console({ runs, items, onClear }: ConsoleProps) {
-  const [selection, setSelection] = useState<Selection | null>(null);
+  const [selection, setSelection] = useState<RunSelection | null>(null);
   const [activeTab, setActiveTab] = useState<ConsoleTab>("response");
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState(false);
@@ -67,19 +60,15 @@ export function Console({ runs, items, onClear }: ConsoleProps) {
     return () => clearInterval(interval);
   }, [hasInFlight]);
 
-  // Follow the newest run, and the newest call inside it, so a call in flight is
-  // selected the moment it is issued instead of after its response lands. A run
-  // you deliberately stepped back to is left alone.
+  // The newest run the console has followed, which is what tells a run arriving
+  // apart from a call arriving inside the one already on screen.
+  const followedRunRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
-    if (!newest) {
-      setSelection(null);
-      return;
-    }
-    setSelection((current) => {
-      if (current && current.runId !== newest.run.id && groups.some((group) => group.run.id === current.runId)) return current;
-      const last = newest.items[newest.items.length - 1];
-      return { runId: newest.run.id, itemId: last?.id };
-    });
+    const isNewRun = followedRunRef.current !== newest?.run.id;
+    followedRunRef.current = newest?.run.id;
+    setSelection((current) => followSelection(current, groups, isNewRun));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newest?.run.id, newest?.items.length, groups.length]);
 
   // Opening a file whose last run we still hold is a reason to show that run:

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -1,5 +1,5 @@
-import { Check, ChevronDown, ChevronUp, ChevronsUpDown, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
-import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, ChevronRight, ChevronUp, ChevronsUpDown, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatClockTime, formatDayLabel, formatElapsed, isSameDay } from "./callTime";
 import { cn } from "./cn";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
@@ -7,17 +7,17 @@ import { IconButton } from "./components/icon-button";
 import { Spinner } from "./components/spinner";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
-import { isCallInFlight, MethodCall } from "./kaja";
-import { methodId } from "./apps";
+import { MethodCall } from "./kaja";
+import { callCount, ConsoleItem, groupRuns, itemName, itemStatus, Run, RunGroup, RunStatus } from "./runs";
 import { runShortcutLabel } from "./RunButton";
 import { Log, LogLevel } from "./server/api";
 
-export type ConsoleItem = Log[] | MethodCall;
+export type { ConsoleItem } from "./runs";
 
 // The dropdown is a fixed 420px and scrolls after eight rows, so a long session
 // never turns the console header into a full-height surface.
-const CALL_ROW_HEIGHT = 32;
-const MAX_VISIBLE_CALL_ROWS = 8;
+const RUN_ROW_HEIGHT = 32;
+const MAX_VISIBLE_RUN_ROWS = 8;
 // Beyond this the qualified call name is truncated from the left, so the method
 // — the part that identifies the call — survives.
 const MAX_TRIGGER_NAME_LENGTH = 28;
@@ -32,23 +32,34 @@ const consoleTabActiveClass = "font-medium text-foreground";
 // beside them.
 const utilityButtonClass = "h-6 w-6 rounded-md hover:bg-accent hover:text-foreground";
 
+// Which run is being looked at, and which of its calls. No call means the run
+// header itself is selected, which shows the run's own summary.
+interface Selection {
+  runId: string;
+  itemId?: string;
+}
+
 interface ConsoleProps {
+  runs: Run[];
   items: ConsoleItem[];
   onClear?: () => void;
 }
 
-export function Console({ items, onClear }: ConsoleProps) {
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+export function Console({ runs, items, onClear }: ConsoleProps) {
+  const [selection, setSelection] = useState<Selection | null>(null);
   const [activeTab, setActiveTab] = useState<ConsoleTab>("response");
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState(false);
 
   const jsonViewerRef = useRef<JsonViewerHandle | null>(null);
 
+  const groups = useMemo(() => groupRuns(runs, items), [runs, items]);
+  const newest = groups[groups.length - 1];
+
   // A settled call shows the wall-clock time it was made, which never changes —
   // so the clock only runs while something is still in flight, counting up in
   // tenths for the call that is.
-  const hasInFlight = items.some((item) => !Array.isArray(item) && isCallInFlight(item));
+  const hasInFlight = groups.some((group) => group.inFlight);
 
   useEffect(() => {
     if (!hasInFlight) return;
@@ -56,44 +67,59 @@ export function Console({ items, onClear }: ConsoleProps) {
     return () => clearInterval(interval);
   }, [hasInFlight]);
 
-  // Reset selectedIndex when items are cleared or become invalid
+  // Follow the newest run, and the newest call inside it, so a call in flight is
+  // selected the moment it is issued instead of after its response lands. A run
+  // you deliberately stepped back to is left alone.
   useEffect(() => {
-    if (items.length === 0) {
-      setSelectedIndex(null);
-    } else if (selectedIndex !== null && selectedIndex >= items.length) {
-      setSelectedIndex(null);
+    if (!newest) {
+      setSelection(null);
+      return;
     }
-  }, [items.length, selectedIndex]);
+    setSelection((current) => {
+      if (current && current.runId !== newest.run.id && groups.some((group) => group.run.id === current.runId)) return current;
+      const last = newest.items[newest.items.length - 1];
+      return { runId: newest.run.id, itemId: last?.id };
+    });
+  }, [newest?.run.id, newest?.items.length, groups.length]);
 
-  const selectedItem = selectedIndex !== null ? items[selectedIndex] : undefined;
-  const selectedMethodCall = selectedItem && "method" in selectedItem ? selectedItem : null;
-  const selectedLogs = Array.isArray(selectedItem) ? selectedItem : null;
+  // Opening a file whose last run we still hold is a reason to show that run:
+  // it is what happened here, even though it isn't live.
+  const staleRunId = groups.find((group) => group.run.stale)?.run.id;
 
-  // Follow the newest item, so an in-flight call is selected the moment it is
-  // issued instead of after its response lands.
   useEffect(() => {
-    if (items.length === 0) return;
-    const lastIndex = items.length - 1;
-    if (selectedIndex === null || selectedIndex >= lastIndex - 1) {
-      setSelectedIndex(lastIndex);
-    }
-  }, [items.length]);
+    if (!staleRunId) return;
+    const group = groups.find((candidate) => candidate.run.id === staleRunId);
+    if (group) setSelection({ runId: staleRunId, itemId: group.items[group.items.length - 1]?.id });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [staleRunId]);
 
-  // ⌃↑ / ⌃↓ step through the history without opening the dropdown.
+  const selectedGroup = groups.find((group) => group.run.id === selection?.runId);
+  const selectedItem = selectedGroup?.items.find((item) => item.id === selection?.itemId);
+  const selectedCall = selectedItem?.call;
+  const selectedLogs = selectedItem?.logs;
+
+  const selectRun = useCallback((group: RunGroup) => {
+    const last = group.items[group.items.length - 1];
+    setSelection({ runId: group.run.id, itemId: last?.id });
+  }, []);
+
+  // ⌃↑ / ⌃↓ step through the runs without opening the dropdown.
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!event.ctrlKey || event.metaKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
-      if (items.length === 0) return;
+      if (groups.length === 0) return;
       event.preventDefault();
-      setSelectedIndex((index) => {
-        const current = index ?? items.length - 1;
-        const next = event.key === "ArrowUp" ? current - 1 : current + 1;
-        return Math.max(0, Math.min(items.length - 1, next));
+      setSelection((current) => {
+        const index = groups.findIndex((group) => group.run.id === current?.runId);
+        const from = index === -1 ? groups.length - 1 : index;
+        const next = Math.max(0, Math.min(groups.length - 1, from + (event.key === "ArrowUp" ? -1 : 1)));
+        const group = groups[next];
+        return { runId: group.run.id, itemId: group.items[group.items.length - 1]?.id };
       });
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [items.length]);
+  }, [groups]);
 
   const handleCopy = useCallback(() => {
     jsonViewerRef.current?.copyToClipboard();
@@ -101,54 +127,66 @@ export function Console({ items, onClear }: ConsoleProps) {
     setTimeout(() => setCopied(false), 1200);
   }, []);
 
-  const showUtilities = selectedMethodCall !== null && (activeTab === "request" || activeTab === "response");
-  const position = selectedIndex === null ? items.length : selectedIndex + 1;
+  // With no run there is no selection to show and no tabs to choose between:
+  // a selected Response over an empty panel implies a state the console doesn't
+  // have. The empty line is the only thing that should speak.
+  if (groups.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-background text-xs text-muted-foreground">
+        Run a script to see its calls here — <span className="ml-1 font-mono">{runShortcutLabel}</span>
+      </div>
+    );
+  }
+
+  const showUtilities = selectedCall !== undefined && (activeTab === "request" || activeTab === "response");
+  const position = selectedGroup ? groups.indexOf(selectedGroup) + 1 : groups.length;
+  // The header row is what ties a script's calls to the press that made them, so
+  // it appears whenever there is more than one — and on a stale run, where it is
+  // the only place that can say "this is not live".
+  const showRunHeader = selectedGroup !== undefined && (selectedGroup.items.length > 1 || selectedGroup.run.stale === true);
+  const showRunChildren = (selectedGroup?.items.length ?? 0) > 1;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
-      {/* One row spanning the full console width: which call, how to step through
-          them, what to look at, and what to do with it. Its height is the tab
-          strip's, so side by side the two headers rule the same line.
-          Narrowing it never wraps a second line. Everything holds its size and
-          leaves in order of what it is worth — the call's time, then its
-          duration, then the stepper (whose history the trigger and ⌃↑/⌃↓ still
-          reach), then the payload utilities — and the call's name truncates
-          through all of it. */}
+      {/* One row spanning the full console width: which run, how to step through
+          them, what to look at, and what to do with it. Narrowing it never wraps
+          a second line. Everything holds its size and leaves in order of what it
+          is worth — the run's time, then its call count, then the stepper (whose
+          history the trigger and ⌃↑/⌃↓ still reach), then the payload utilities
+          — and the run's name truncates through all of it. */}
       <div className="@container flex h-[35px] shrink-0 items-center gap-3 overflow-hidden border-b border-border px-3">
-        {items.length === 0 ? (
-          <span className="shrink-0 text-xs text-muted-foreground">No calls yet</span>
-        ) : (
+        <Console.RunSelect groups={groups} selectedGroup={selectedGroup} onSelect={selectRun} onClear={onClear} now={now} />
+        <div className="flex shrink-0 items-center gap-1 @max-[540px]:hidden">
+          <IconButton
+            icon={ChevronUp}
+            aria-label="Previous run"
+            variant="ghost"
+            size="sm"
+            tooltip={false}
+            className="h-6 w-6"
+            disabled={position <= 1}
+            onClick={() => selectRun(groups[Math.max(0, position - 2)])}
+          />
+          <IconButton
+            icon={ChevronDown}
+            aria-label="Next run"
+            variant="ghost"
+            size="sm"
+            tooltip={false}
+            className="h-6 w-6"
+            disabled={position >= groups.length}
+            onClick={() => selectRun(groups[Math.min(groups.length - 1, position)])}
+          />
+          <span className="whitespace-nowrap font-mono text-xs tabular-nums text-muted-foreground">
+            {position} of {groups.length}
+          </span>
+        </div>
+        {selectedCall && (
           <>
-            <Console.CallSelect items={items} selectedIndex={selectedIndex} onSelect={setSelectedIndex} onClear={onClear} now={now} />
-            <div className="flex shrink-0 items-center gap-1 @max-[540px]:hidden">
-              <IconButton
-                icon={ChevronUp}
-                aria-label="Previous call"
-                variant="ghost"
-                size="sm"
-                tooltip={false}
-                className="h-6 w-6"
-                disabled={position <= 1}
-                onClick={() => setSelectedIndex((index) => Math.max(0, (index ?? items.length - 1) - 1))}
-              />
-              <IconButton
-                icon={ChevronDown}
-                aria-label="Next call"
-                variant="ghost"
-                size="sm"
-                tooltip={false}
-                className="h-6 w-6"
-                disabled={position >= items.length}
-                onClick={() => setSelectedIndex((index) => Math.min(items.length - 1, (index ?? items.length - 1) + 1))}
-              />
-              <span className="whitespace-nowrap font-mono text-xs tabular-nums text-muted-foreground">
-                {position} of {items.length}
-              </span>
-            </div>
+            <div className="h-4 w-px shrink-0 bg-border" />
+            <Console.DetailTabs methodCall={selectedCall} activeTab={activeTab} onTabChange={setActiveTab} />
           </>
         )}
-        <div className="h-4 w-px shrink-0 bg-border" />
-        <Console.DetailTabs methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} />
         {showUtilities && (
           <div className="ml-auto flex shrink-0 items-center gap-2 @max-[430px]:hidden">
             <IconButton
@@ -177,34 +215,60 @@ export function Console({ items, onClear }: ConsoleProps) {
           the same sunken surface as the editor — the split between them is a
           hairline, not a value step. */}
       <div className="flex min-h-0 flex-1 flex-col bg-background">
-        {selectedMethodCall ? (
-          <Console.DetailContent methodCall={selectedMethodCall} activeTab={activeTab} onTabChange={setActiveTab} jsonViewerRef={jsonViewerRef} />
-        ) : selectedLogs ? (
-          <Console.LogContent logs={selectedLogs} />
-        ) : (
-          <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
-            Run a script to see its calls here — <span className="ml-1 font-mono">{runShortcutLabel}</span>
-          </div>
+        {selectedGroup && showRunHeader && (
+          <Console.RunHeaderRow
+            group={selectedGroup}
+            selected={selection?.itemId === undefined}
+            expanded={showRunChildren}
+            onSelect={() => setSelection({ runId: selectedGroup.run.id })}
+            now={now}
+          />
         )}
+        {selectedGroup &&
+          showRunChildren &&
+          selectedGroup.items.map((item) => (
+            <Console.CallChildRow
+              key={item.id}
+              item={item}
+              selected={item.id === selection?.itemId}
+              onSelect={() => setSelection({ runId: selectedGroup.run.id, itemId: item.id })}
+              now={now}
+            />
+          ))}
+        <div className={cn("flex min-h-0 flex-1 flex-col", selectedGroup?.run.stale && "opacity-70")}>
+          {selectedGroup?.run.payloadsExpired ? (
+            <div className="flex items-center gap-2 px-4 py-3">
+              <span className="text-xs text-muted-foreground">Response no longer kept — run to see it live</span>
+              <span className="font-mono text-xs text-muted-foreground">{runShortcutLabel}</span>
+            </div>
+          ) : selectedCall ? (
+            <Console.DetailContent methodCall={selectedCall} activeTab={activeTab} onTabChange={setActiveTab} jsonViewerRef={jsonViewerRef} />
+          ) : selectedLogs ? (
+            <Console.LogContent logs={selectedLogs} />
+          ) : selectedGroup ? (
+            <Console.RunSummary group={selectedGroup} />
+          ) : null}
+        </div>
       </div>
     </div>
   );
 }
 
-interface CallSelectProps {
-  items: ConsoleItem[];
-  selectedIndex: number | null;
-  onSelect: (index: number) => void;
+interface RunSelectProps {
+  groups: RunGroup[];
+  selectedGroup?: RunGroup;
+  onSelect: (group: RunGroup) => void;
   onClear?: () => void;
   now: number;
 }
 
 // The whole history behind one 26px trigger: the trigger answers "which run am I
-// looking at", the list answers "which other ones are there".
-Console.CallSelect = function ({ items, selectedIndex, onSelect, onClear, now }: CallSelectProps) {
+// looking at", the list answers "which other ones are there". It lists runs
+// rather than calls, so everything under a date header is by definition not
+// live.
+Console.RunSelect = function ({ groups, selectedGroup, onSelect, onClear, now }: RunSelectProps) {
   const [open, setOpen] = useState(false);
-  const selected = selectedIndex !== null ? items[selectedIndex] : undefined;
-  const summary = selected ? itemSummary(selected, now) : undefined;
+  const summary = selectedGroup ? runSummary(selectedGroup, now) : undefined;
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -228,14 +292,19 @@ Console.CallSelect = function ({ items, selectedIndex, onSelect, onClear, now }:
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" side="bottom" className="w-[420px] p-0">
         <div className="flex items-center justify-between border-b border-border px-3 py-2">
-          <span className="text-xs tracking-[0.06em] text-muted-foreground">RECENT CALLS</span>
-          <span className="font-mono text-xs text-muted-foreground">{items.length}</span>
+          <span className="text-xs tracking-[0.06em] text-muted-foreground">RUNS</span>
+          <span className="font-mono text-xs text-muted-foreground">{groups.length}</span>
         </div>
-        <div className="overflow-y-auto" style={{ maxHeight: MAX_VISIBLE_CALL_ROWS * CALL_ROW_HEIGHT }}>
-          {dayGroupedRows(items, now).map(({ item, index, summary, dayLabel }) => (
-            <Fragment key={"method" in item ? `mc:${item.id}` : `log:${index}`}>
+        <div className="overflow-y-auto" style={{ maxHeight: MAX_VISIBLE_RUN_ROWS * RUN_ROW_HEIGHT }}>
+          {dayGroupedRows(groups, now).map(({ group, summary, dayLabel }) => (
+            <Fragment key={group.run.id}>
               {dayLabel && <div className="px-3 pb-1 pt-2 font-mono text-[11px] text-muted-foreground/70">{dayLabel}</div>}
-              <Console.CallRow {...summary} index={index} isSelected={index === selectedIndex} onSelect={onSelect} />
+              <Console.RunRow
+                {...summary}
+                stale={group.run.stale === true}
+                isSelected={group.run.id === selectedGroup?.run.id}
+                onSelect={() => onSelect(group)}
+              />
             </Fragment>
           ))}
         </div>
@@ -256,18 +325,22 @@ Console.CallSelect = function ({ items, selectedIndex, onSelect, onClear, now }:
   );
 };
 
-interface CallRowProps extends ItemSummary {
-  index: number;
+interface RunRowProps extends RunSummaryLine {
+  stale: boolean;
   isSelected: boolean;
-  onSelect: (index: number) => void;
+  onSelect: () => void;
 }
 
-// Memoized so the tick that counts up an in-flight call only re-renders that
-// call's row; every settled row holds a value that no longer changes. Both
+// Memoized so the tick that counts up an in-flight run only re-renders that
+// run's row; every settled row holds a value that no longer changes. Both
 // columns are rendered even when empty, so the list stays aligned.
-Console.CallRow = memo(function CallRow({ name, detail, time, dotClass, pending, index, isSelected, onSelect }: CallRowProps) {
+Console.RunRow = memo(function RunRow({ name, detail, time, dotClass, pending, stale, isSelected, onSelect }: RunRowProps) {
   return (
-    <DropdownMenuItem data-testid="console-row" className={cn("h-8 gap-3 rounded-none px-3", isSelected && "bg-accent")} onSelect={() => onSelect(index)}>
+    <DropdownMenuItem
+      data-testid="console-row"
+      className={cn("h-8 gap-3 rounded-none px-3", isSelected && "bg-accent", stale && "opacity-75")}
+      onSelect={onSelect}
+    >
       {pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass)} />}
       <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">{name}</span>
       <span className={DETAIL_COLUMN_CLASS} title={detail}>
@@ -278,20 +351,118 @@ Console.CallRow = memo(function CallRow({ name, detail, time, dotClass, pending,
   );
 });
 
+interface RunHeaderRowProps {
+  group: RunGroup;
+  selected: boolean;
+  expanded: boolean;
+  onSelect: () => void;
+  now: number;
+}
+
+// One press of Run, stated once: status, script name, what happened, wall
+// duration, clock. Its status is the worst status inside it, so a green run
+// means every call passed.
+Console.RunHeaderRow = function ({ group, selected, expanded, onSelect, now }: RunHeaderRowProps) {
+  const { run, status, inFlight, failures } = group;
+  const calls = callCount(group);
+
+  return (
+    <div
+      data-testid="console-run-header"
+      className={cn("flex h-8 shrink-0 cursor-pointer items-center gap-2 border-b border-border px-3", selected ? "bg-accent" : "bg-card")}
+      onClick={onSelect}
+    >
+      <span className="flex w-[13px] shrink-0 items-center justify-center text-muted-foreground">
+        {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+      </span>
+      {inFlight ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(status), run.stale && "opacity-50")} />}
+      <span className={cn("min-w-0 flex-1 truncate font-mono text-xs", run.stale ? "text-muted-foreground" : "font-medium text-foreground")}>{run.title}</span>
+      {run.stale && <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">Last run</span>}
+      {/* What failed is the news; how many calls there were is what the trigger
+          already carries. */}
+      {failures > 0 ? (
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">{failures} failed</span>
+      ) : (
+        calls > 1 && <span className="shrink-0 font-mono text-xs text-muted-foreground">{calls} calls</span>
+      )}
+      <span className={DETAIL_COLUMN_CLASS}>{inFlight ? formatElapsed(now - run.startedAt) : formatDuration(run.durationMs)}</span>
+      <span className={cn(TIME_COLUMN_CLASS, "opacity-75")}>{run.stale ? formatStaleTime(run.startedAt) : formatClockTime(run.startedAt)}</span>
+    </div>
+  );
+};
+
+interface CallChildRowProps {
+  item: ConsoleItem;
+  selected: boolean;
+  onSelect: () => void;
+  now: number;
+}
+
+// Calls inside a run are ordered by start, never re-sorted, and keep their own
+// durations; the run header's duration is the wall time for the whole script.
+Console.CallChildRow = function ({ item, selected, onSelect, now }: CallChildRowProps) {
+  const status = itemStatus(item);
+  const pending = item.call !== undefined && (status === "pending" || status === "streaming");
+  const errorCode = item.call ? callErrorCode(item.call) : undefined;
+
+  return (
+    <div
+      data-testid="console-call-row"
+      className={cn("flex h-[30px] shrink-0 cursor-pointer items-center gap-2 border-b border-border pl-[34px] pr-3", selected && "bg-accent")}
+      onClick={onSelect}
+    >
+      {pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(status))} />}
+      <span className={cn("min-w-0 flex-1 truncate font-mono text-xs", selected ? "text-foreground" : "text-muted-foreground")}>{itemName(item)}</span>
+      {errorCode && <span className="shrink-0 font-mono text-xs text-destructive">{errorCode}</span>}
+      <span className={DETAIL_COLUMN_CLASS}>{pending ? formatElapsed(now - item.timestamp) : formatDuration(item.call?.durationMs)}</span>
+    </div>
+  );
+};
+
+// What the run header selects: the press as a whole, rather than any one call it
+// made.
+Console.RunSummary = function ({ group }: { group: RunGroup }) {
+  const calls = callCount(group);
+  const label = { pending: "Running", streaming: "Streaming", success: "OK", error: "Failed" }[group.status];
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto px-4 py-3 font-mono text-xs">
+      <div className="flex items-center gap-3 pb-2">
+        <span className={cn("font-medium", statusClass(group.status))}>{label}</span>
+        <span className="text-muted-foreground">
+          {calls} {calls === 1 ? "call" : "calls"}
+        </span>
+        {group.run.durationMs !== undefined && <span className="tabular-nums text-muted-foreground">{formatDuration(group.run.durationMs)} wall</span>}
+      </div>
+      {group.items.length === 0 ? (
+        <div className="text-muted-foreground">This run made no calls.</div>
+      ) : (
+        group.items.map((item) => (
+          <div key={item.id} className="flex items-center gap-2 py-0.5">
+            <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(itemStatus(item)))} />
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">{itemName(item)}</span>
+            <span className="tabular-nums text-muted-foreground">{formatDuration(item.call?.durationMs)}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
 type ConsoleTab = "request" | "response" | "headers";
 
 interface DetailTabsProps {
-  methodCall: MethodCall | null;
+  methodCall: MethodCall;
   activeTab: ConsoleTab;
   onTabChange: (tab: ConsoleTab) => void;
 }
 
 Console.DetailTabs = function ({ methodCall, activeTab, onTabChange }: DetailTabsProps) {
-  const isStreaming = methodCall?.streamOutputs !== undefined;
-  const streamCount = isStreaming ? methodCall!.streamOutputs!.length : 0;
+  const isStreaming = methodCall.streamOutputs !== undefined;
+  const streamCount = isStreaming ? methodCall.streamOutputs!.length : 0;
 
   const tab = (id: ConsoleTab, label: string) => (
-    <span className={cn(consoleTabClass, activeTab === id && consoleTabActiveClass)} onClick={() => methodCall && onTabChange(id)}>
+    <span className={cn(consoleTabClass, activeTab === id && consoleTabActiveClass)} onClick={() => onTabChange(id)}>
       {label}
     </span>
   );
@@ -299,7 +470,7 @@ Console.DetailTabs = function ({ methodCall, activeTab, onTabChange }: DetailTab
   // A failed call colours its dot and its status line, and nothing else — the
   // header stays neutral.
   return (
-    <div className={cn("flex shrink-0 items-center gap-4", !methodCall && "pointer-events-none opacity-40")}>
+    <div className="flex shrink-0 items-center gap-4">
       {tab("request", "Request")}
       {tab("response", `Response${isStreaming && streamCount > 0 ? ` (${streamCount})` : ""}`)}
       {tab("headers", "Headers")}
@@ -486,61 +657,48 @@ Console.HeadersTable = function ({ headers }: HeadersTableProps) {
   );
 };
 
-interface ItemSummary {
+interface RunSummaryLine {
   name: string;
-  // Duration, or the status code of a failed call.
+  // The call count, or how many of them failed.
   detail?: string;
-  // Wall-clock time the call was made.
+  // Wall-clock time the run was made.
   time?: string;
-  timestamp?: number;
   dotClass: string;
   pending: boolean;
 }
 
 // The columns every row in the history shares — the trigger shows them for the
-// selected item, the list for all of them.
-function itemSummary(item: ConsoleItem, now: number): ItemSummary {
-  if (Array.isArray(item)) {
-    const level = item.length === 0 ? LogLevel.LEVEL_INFO : Math.max(...item.map((log) => log.level));
-    return {
-      name: item.length === 1 ? item[0].message.trim() : `${item.length} log messages`,
-      detail: labelForLogLevel(level),
-      dotClass: dotClassForLogLevel(level),
-      pending: false,
-    };
-  }
-
-  const status = callStatus(item);
-  const pending = status === "pending" || status === "streaming";
+// selected run, the list for all of them.
+function runSummary(group: RunGroup, now: number): RunSummaryLine {
+  const calls = callCount(group);
   return {
-    name: methodId(item.service, item.method),
-    // While the call is in flight its own elapsed time is the interesting
-    // number; once it lands, how long it took.
-    detail: pending ? formatElapsed(now - item.timestamp) : (callErrorCode(item) ?? formatDuration(item.durationMs)),
-    time: formatClockTime(item.timestamp),
-    timestamp: item.timestamp,
-    dotClass: dotClass(status),
-    pending,
+    name: group.run.title,
+    // While the run is in flight its own elapsed time is the interesting number;
+    // once it lands, how many calls it made — and for a run of one, where there
+    // is no count worth stating, how long it took.
+    detail: group.inFlight ? formatElapsed(now - group.run.startedAt) : calls > 1 ? `${calls} calls` : formatDuration(group.run.durationMs),
+    time: group.run.stale ? formatStaleTime(group.run.startedAt) : formatClockTime(group.run.startedAt),
+    dotClass: cn(dotClass(group.status), group.run.stale && "opacity-50"),
+    pending: group.inFlight,
   };
 }
 
 interface DayGroupedRow {
-  item: ConsoleItem;
-  index: number;
-  summary: ItemSummary;
+  group: RunGroup;
+  summary: RunSummaryLine;
   // Set on the first row of a day other than today, which is where the list
   // says what day it has moved to.
   dayLabel?: string;
 }
 
 // Newest first, so a label lands on the first row of each day the list moves
-// back into; today needs none.
-function dayGroupedRows(items: ConsoleItem[], now: number): DayGroupedRow[] {
-  const rows = items.map((item, index) => ({ item, index, summary: itemSummary(item, now) })).reverse();
+// back into; today needs none. Everything under a date header is by definition
+// not live.
+function dayGroupedRows(groups: RunGroup[], now: number): DayGroupedRow[] {
+  const rows = [...groups].reverse().map((group) => ({ group, summary: runSummary(group, now) }));
   let previousTimestamp = now;
   return rows.map((row) => {
-    const timestamp = row.summary.timestamp;
-    if (timestamp === undefined) return row;
+    const timestamp = row.group.run.startedAt;
     const dayLabel = isSameDay(timestamp, previousTimestamp) ? undefined : formatDayLabel(timestamp);
     previousTimestamp = timestamp;
     return { ...row, dayLabel };
@@ -553,16 +711,20 @@ function truncateStart(text: string, maxLength: number): string {
   return text.length > maxLength ? `…${text.slice(text.length - maxLength + 1)}` : text;
 }
 
-type CallStatus = "pending" | "streaming" | "success" | "error";
-
-function callStatus(methodCall: MethodCall): CallStatus {
+function callStatus(methodCall: MethodCall): RunStatus {
   if (methodCall.error) return "error";
   const isStreaming = methodCall.streamOutputs !== undefined;
   if (isStreaming && !methodCall.streamComplete) return "streaming";
   return methodCall.output ? "success" : "pending";
 }
 
-function statusClass(status: CallStatus): string {
+// A run that isn't live is dated rather than clocked, because the time of day it
+// happened on some other day is not the thing you need to read.
+function formatStaleTime(timestamp: number): string {
+  return isSameDay(timestamp, Date.now()) ? formatClockTime(timestamp) : formatDayLabel(timestamp);
+}
+
+function statusClass(status: RunStatus): string {
   return {
     pending: "text-muted-foreground",
     streaming: "text-primary",
@@ -571,7 +733,7 @@ function statusClass(status: CallStatus): string {
   }[status];
 }
 
-function dotClass(status: CallStatus): string {
+function dotClass(status: RunStatus): string {
   return {
     pending: "bg-muted-foreground",
     streaming: "bg-primary",
@@ -640,16 +802,5 @@ function classForLogLevel(level: LogLevel): string {
       return "text-amber-600 dark:text-amber-400";
     case LogLevel.LEVEL_ERROR:
       return "text-destructive";
-  }
-}
-
-function dotClassForLogLevel(level: LogLevel): string {
-  switch (level) {
-    case LogLevel.LEVEL_WARN:
-      return "bg-amber-500";
-    case LogLevel.LEVEL_ERROR:
-      return "bg-red-500";
-    default:
-      return "bg-muted-foreground";
   }
 }

--- a/ui/src/Finder.tsx
+++ b/ui/src/Finder.tsx
@@ -24,6 +24,9 @@ export interface Destination {
   // already the whole answer.
   origin: string;
   icon: LucideIcon;
+  // A browsing buffer — still exactly its generated code and never run. Dimmed
+  // here and in the sidebar, because the next call you pick takes it over.
+  provisional?: boolean;
   go: () => void;
 }
 
@@ -210,8 +213,10 @@ function Row({
       onMouseEnter={() => onHighlight(index)}
       onClick={() => onSelect(destination)}
     >
-      <Icon size={13} className="shrink-0 text-muted-foreground" />
-      <span className={cn("shrink-0 truncate text-sm", recent ? "text-foreground" : "text-muted-foreground")}>{destination.name}</span>
+      <Icon size={13} className={cn("shrink-0 text-muted-foreground", destination.provisional && "opacity-60")} />
+      <span className={cn("shrink-0 truncate text-sm", recent && !destination.provisional ? "text-foreground" : "text-muted-foreground")}>
+        {destination.name}
+      </span>
       <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{destination.path}</span>
       {highlighted && <span className="shrink-0 font-mono text-xs text-muted-foreground">⏎</span>}
     </div>
@@ -246,9 +251,9 @@ function TriggerContent({ destination, errorCount }: { destination?: Destination
           {qualifier && <span className="text-xs">{qualifier}</span>}
         </span>
       </span>
-      <Icon size={13} className={cn("shrink-0", errorCount > 0 ? "text-destructive" : "text-muted-foreground")} />
+      <Icon size={13} className={cn("shrink-0", errorCount > 0 ? "text-destructive" : "text-muted-foreground", destination.provisional && "opacity-60")} />
       <span
-        className="min-w-0 truncate text-sm font-medium text-foreground"
+        className={cn("min-w-0 truncate text-sm font-medium", destination.provisional ? "text-muted-foreground" : "text-foreground")}
         // Truncating from the left keeps the call name, which is the end of a
         // qualified one.
         style={{ direction: "rtl", textAlign: "left" }}

--- a/ui/src/NoFileBlankslate.tsx
+++ b/ui/src/NoFileBlankslate.tsx
@@ -1,23 +1,72 @@
-import { Blankslate } from "./components/blankslate";
-import { FileCode } from "lucide-react";
+import { FileCode, type LucideIcon } from "lucide-react";
+import { formatDayLabel } from "./callTime";
+import { cn } from "./cn";
 
-interface NoFileBlankslateProps {
-  onOpenSwitcher: () => void;
+export interface RecentFile {
+  key: string;
+  name: string;
+  icon: LucideIcon;
+  // When it was last worked in, for the unsaved ones. A file on disk has no
+  // timestamp worth showing here.
+  updatedAt?: number;
+  saved: boolean;
+  go: () => void;
 }
 
-// With no tab strip there is nothing left on screen to say the pane is empty, so
-// the pane says it itself — and offers the one gesture that fills it.
-export function NoFileBlankslate({ onOpenSwitcher }: NoFileBlankslateProps) {
+interface NoFileBlankslateProps {
+  onOpenFinder: () => void;
+  onNewScratch: () => void;
+  // The last few things you looked at. This is the only moment the cache behind
+  // the finder is worth showing as a list.
+  recent: RecentFile[];
+}
+
+/**
+ * The first screen of a new install, and where every "nothing open" moment
+ * lands. It has one job: say that picking a call in the tree writes you a
+ * script, which is the entire model of the product and is said nowhere else.
+ *
+ * Under the sentence sits your recent work, because the people who see this
+ * screen most are not new — every missed ⌘P and every fresh window comes here,
+ * and for them a shortcut beats an illustration. On a first run the list is
+ * absent rather than an empty box, which is the right amount for someone who has
+ * nothing yet.
+ */
+export function NoFileBlankslate({ onOpenFinder, onNewScratch, recent }: NoFileBlankslateProps) {
+  const modifier = navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+";
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col justify-center">
-      <Blankslate>
-        <Blankslate.Visual>
-          <FileCode size={40} />
-        </Blankslate.Visual>
-        <Blankslate.Heading>No file open</Blankslate.Heading>
-        <Blankslate.Description>Pick a call from the sidebar, or press {navigator.platform.startsWith("Mac") ? "⌘P" : "Ctrl+P"}.</Blankslate.Description>
-        <Blankslate.PrimaryAction onClick={onOpenSwitcher}>Open a file</Blankslate.PrimaryAction>
-      </Blankslate>
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-5 px-6">
+      <div className="flex flex-col items-center gap-2">
+        <FileCode size={28} className="text-muted-foreground" />
+        <p className="m-0 text-sm text-foreground">Pick a call in the sidebar and Kaja writes the script.</p>
+        <p className="m-0 text-xs text-muted-foreground">Everything here is a script. Edit it, run it, save it if it's worth keeping.</p>
+      </div>
+      {recent.length > 0 && (
+        <div className="flex w-[300px] flex-col gap-1">
+          {recent.map((file) => {
+            const Icon = file.icon;
+            return (
+              <button key={file.key} type="button" onClick={file.go} className="flex h-[30px] items-center gap-2 rounded-md px-2 text-left hover:bg-accent">
+                <Icon size={14} className="shrink-0 text-muted-foreground" />
+                <span className={cn("min-w-0 flex-1 truncate text-xs", file.saved ? "text-foreground" : "text-muted-foreground")}>{file.name}</span>
+                {file.updatedAt !== undefined && (
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground opacity-70">{formatDayLabel(file.updatedAt)}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <div className="flex items-center gap-3">
+        <button type="button" onClick={onOpenFinder} className="text-xs text-muted-foreground hover:text-foreground">
+          <span className="font-mono">{modifier}P</span> find a call
+        </button>
+        <div className="h-3 w-px bg-border" />
+        <button type="button" onClick={onNewScratch} className="text-xs text-muted-foreground hover:text-foreground">
+          <span className="font-mono">{modifier}N</span> blank script
+        </button>
+      </div>
     </div>
   );
 }

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -21,11 +21,13 @@ import {
   Ellipsis,
   PenLine,
   Plus as PlusIcon,
+  X,
 } from "lucide-react";
 import { appType, getAppType } from "./appTypes";
 import { SimpleTooltip } from "./components/tooltip";
 import { Method, App, Script, Service, methodId } from "./apps";
-import { Scratch } from "./scratches";
+import { isUntouched, Scratch } from "./scratches";
+import { titleParts } from "./scratchTitle";
 import { appWarnings, firstErrorMessage } from "./compileSummary";
 import { getPersistedValue, setPersistedValue } from "./storage";
 
@@ -550,9 +552,9 @@ export function Sidebar({
                   >
                     {/* Not saved: the pen is the whole difference. */}
                     <TreeView.LeadingVisual>
-                      <PenLine size={13} />
+                      <PenLine size={13} className={cn(isUntouched(scratch) && "opacity-60")} />
                     </TreeView.LeadingVisual>
-                    {scratch.title}
+                    <ScratchLabel scratch={scratch} />
                     <TreeView.TrailingVisual>
                       {(hoveredScratch === scratch.id || scratchMenu?.scratch.id === scratch.id) && (
                         <IconButton
@@ -585,6 +587,10 @@ export function Sidebar({
             )}
           </nav>
         )}
+        {/* Your scripts and the API's catalog are two different lists, and two
+            rows can carry the same name across the seam. A rule keeps nobody
+            reading them as one. */}
+        {(hasScripts || hasScratches) && apps.length > 0 && <div className="mx-[-4px] mt-3 h-px bg-border" />}
         {apps.map((app, appIndex) => {
           const appName = app.configuration.name;
           const isExpanded = expandedApps.has(appName);
@@ -789,8 +795,11 @@ export function Sidebar({
             }}
           >
             <Pencil size={16} />
-            Rename
+            Rename…
           </DropdownMenuItem>
+          {/* This one takes a file off disk, which is why it is confirmed and
+              why it says so. The unsaved row's menu below reads differently on
+              purpose. */}
           <DropdownMenuItem
             variant="danger"
             onSelect={() => {
@@ -799,7 +808,7 @@ export function Sidebar({
             }}
           >
             <Trash2 size={16} />
-            Delete
+            Delete file
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -821,18 +830,19 @@ export function Sidebar({
               }}
             >
               <FileCode size={16} />
-              Save
+              Save…
             </DropdownMenuItem>
           )}
+          {/* Nothing is on disk to remove, so this is a discard rather than a
+              delete: neutral, and undoable instead of confirmed. */}
           <DropdownMenuItem
-            variant="danger"
             onSelect={() => {
               if (scratchMenu) onDeleteScratch?.(scratchMenu.scratch);
               setScratchMenu(null);
             }}
           >
-            <Trash2 size={16} />
-            Delete
+            <X size={16} />
+            Discard
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -872,6 +882,25 @@ export function Sidebar({
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
+  );
+}
+
+/**
+ * An unsaved script's row. Two things are said here that the plain title can't:
+ * the qualifier the naming rule produced is dimmed, so a row never reads as the
+ * bare method name a few rows below it in the tree; and a scratch nobody has
+ * worked in yet is dimmed whole, because "the next call takes this one over" is
+ * otherwise a rule you can only learn by being surprised by it.
+ */
+function ScratchLabel({ scratch }: { scratch: Scratch }) {
+  const { name, qualifier } = titleParts(scratch.title);
+  const browsing = isUntouched(scratch);
+
+  return (
+    <span title={browsing ? "Browsing — the next call you pick takes this over" : undefined} className={cn(browsing && "text-muted-foreground")}>
+      {name}
+      {qualifier && <span className="ml-1 font-mono text-xs text-muted-foreground opacity-70">{qualifier}</span>}
+    </span>
   );
 }
 

--- a/ui/src/components/tree-view.tsx
+++ b/ui/src/components/tree-view.tsx
@@ -111,8 +111,10 @@ function LeadingVisual({ children }: { children: React.ReactNode }) {
   return <span className="flex shrink-0 items-center text-muted-foreground">{children}</span>;
 }
 
+// The slot keeps its width whether or not it holds anything, so a row that grows
+// a kebab on hover doesn't move the label's truncation point under the cursor.
 function TrailingVisual({ children }: { children: React.ReactNode }) {
-  return <span className="ml-auto flex shrink-0 items-center">{children}</span>;
+  return <span className="ml-auto flex w-6 shrink-0 items-center justify-center">{children}</span>;
 }
 
 TreeView.Item = Item;

--- a/ui/src/runStore.test.ts
+++ b/ui/src/runStore.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { MethodCall } from "./kaja";
+import { ConsoleItem, Run } from "./runs";
+import { deserializeRun, pruneArchive, RunArchive, serializeRun, StoredRun } from "./runStore";
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+const run: Run = { id: "r1", title: "ListShows", sourceId: "scratch-1", startedAt: NOW, durationMs: 212 };
+
+function call(output: unknown): ConsoleItem {
+  const methodCall = {
+    id: "call-1",
+    appName: "theatre",
+    service: { name: "Shows" },
+    method: { name: "ListShows" },
+    input: { pageSize: 20 },
+    output,
+    timestamp: NOW,
+    durationMs: 212,
+  } as MethodCall;
+  return { id: "item-1", runId: run.id, timestamp: NOW, call: methodCall };
+}
+
+describe("serializeRun", () => {
+  it("marks what it stores as stale, so it can never come back looking live", () => {
+    const stored = serializeRun(run, [call({ shows: [] })], NOW);
+    expect(stored.run.stale).toBe(true);
+    expect(stored.run.payloadsExpired).toBe(false);
+  });
+
+  it("keeps the header and drops the payloads when they are too big to hold", () => {
+    const stored = serializeRun(run, [call({ blob: "x".repeat(600 * 1024) })], NOW);
+    expect(stored.items).toEqual([]);
+    expect(stored.run.payloadsExpired).toBe(true);
+    expect(stored.run.title).toBe("ListShows");
+  });
+
+  it("round-trips a call back into something the console can render", () => {
+    const loaded = deserializeRun(serializeRun(run, [call({ shows: [1, 2] })], NOW));
+    expect(loaded.run.id).toBe("r1");
+    expect(loaded.items).toHaveLength(1);
+    expect(loaded.items[0].runId).toBe("r1");
+    expect(loaded.items[0].call?.service.name).toBe("Shows");
+    expect(loaded.items[0].call?.method.name).toBe("ListShows");
+    expect(loaded.items[0].call?.output).toEqual({ shows: [1, 2] });
+    expect(loaded.items[0].call?.durationMs).toBe(212);
+  });
+});
+
+function archiveEntry(sourceId: string, startedAt: number, storedAt: number): [string, StoredRun] {
+  return [
+    sourceId,
+    {
+      run: { ...run, id: sourceId, sourceId, startedAt, stale: true },
+      items: [call({})].map((item) => ({ id: item.id, timestamp: item.timestamp })),
+      storedAt,
+    },
+  ];
+}
+
+describe("pruneArchive", () => {
+  it("keeps a run's header past the payload cut-off, because expiry has to be a stated state", () => {
+    const archive: RunArchive = Object.fromEntries([archiveEntry("a", NOW - 10 * DAY, NOW - 10 * DAY)]);
+    const pruned = pruneArchive(archive, NOW);
+    expect(pruned.a.run.payloadsExpired).toBe(true);
+    expect(pruned.a.items).toEqual([]);
+    expect(pruned.a.run.title).toBe("ListShows");
+  });
+
+  it("leaves a recent run alone", () => {
+    const archive: RunArchive = Object.fromEntries([archiveEntry("a", NOW - DAY, NOW - DAY)]);
+    expect(pruneArchive(archive, NOW).a.run.payloadsExpired).toBeUndefined();
+    expect(pruneArchive(archive, NOW).a.items).toHaveLength(1);
+  });
+
+  it("holds the fifty most recently run files and no more", () => {
+    const entries = Array.from({ length: 60 }, (_, index) => archiveEntry(`s${index}`, NOW - index * 1000, NOW));
+    const pruned = pruneArchive(Object.fromEntries(entries), NOW);
+    expect(Object.keys(pruned)).toHaveLength(50);
+    expect(pruned.s0).toBeDefined();
+    expect(pruned.s59).toBeUndefined();
+  });
+});

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -1,0 +1,191 @@
+import { Method, Service } from "./apps";
+import { unwrapEnvelope } from "./httpEnvelope";
+import { MethodCall } from "./kaja";
+import { ConsoleItem, Run } from "./runs";
+import { Log } from "./server/api";
+import { getPersistedValue, setPersistedValue } from "./storage";
+
+// Storing code is free; storing responses is not. Headers are small and are kept
+// for the last fifty files you ran something in; the payloads under them are
+// dropped after a week, because expiry is only bearable when it is a stated
+// state rather than a silent hole.
+const MAX_STORED_RUNS = 50;
+const PAYLOAD_DAYS = 7;
+// A run whose payloads don't fit is stored without them rather than not at all:
+// the header is still worth having, and "no longer kept" is what the screen
+// already says.
+const MAX_PAYLOAD_BYTES = 512 * 1024;
+
+const STORAGE_KEY = "lastRuns";
+
+// A call flattened to what the console needs to render it again. The message
+// types can't survive the store, so the response is written already unwrapped —
+// the envelope is an encoding detail, and this is display state.
+interface StoredCall {
+  appName: string;
+  service: string;
+  method: string;
+  input?: unknown;
+  output?: unknown;
+  streamOutputs?: unknown[];
+  error?: unknown;
+  requestHeaders?: { [key: string]: string };
+  responseHeaders?: { [key: string]: string };
+  upstreamRequestHeaders?: { [key: string]: string };
+  upstreamResponseHeaders?: { [key: string]: string };
+  url?: string;
+  timestamp: number;
+  durationMs?: number;
+}
+
+interface StoredItem {
+  id: string;
+  timestamp: number;
+  call?: StoredCall;
+  logs?: Log[];
+}
+
+export interface StoredRun {
+  run: Run;
+  items: StoredItem[];
+  storedAt: number;
+}
+
+export type RunArchive = { [sourceId: string]: StoredRun };
+
+export interface LoadedRun {
+  run: Run;
+  items: ConsoleItem[];
+}
+
+function toStoredCall(call: MethodCall): StoredCall {
+  return {
+    appName: call.appName,
+    service: call.service.name,
+    method: call.method.name,
+    input: call.input,
+    output: call.output === undefined ? undefined : unwrapEnvelope(call.outputType, call.output),
+    streamOutputs: call.streamOutputs?.map((message) => unwrapEnvelope(call.outputType, message)),
+    error: call.error === undefined ? undefined : serializableError(call.error),
+    requestHeaders: call.requestHeaders,
+    responseHeaders: call.responseHeaders,
+    upstreamRequestHeaders: call.upstreamRequestHeaders,
+    upstreamResponseHeaders: call.upstreamResponseHeaders,
+    url: call.url,
+    timestamp: call.timestamp,
+    durationMs: call.durationMs,
+  };
+}
+
+// Errors reach the console as plain objects already (serializeError in
+// client.ts), but a thrown Error can get here too and would store as `{}`.
+function serializableError(error: any): unknown {
+  if (error instanceof Error) return { message: error.message, code: error.name };
+  return error;
+}
+
+function fromStoredCall(stored: StoredCall): MethodCall {
+  return {
+    id: `${stored.service}.${stored.method}:${stored.timestamp}`,
+    appName: stored.appName,
+    // Only the names survive; nothing that renders a stored run reaches past
+    // them, and the response is already unwrapped so no message type is needed.
+    service: { name: stored.service } as Service,
+    method: { name: stored.method } as Method,
+    input: stored.input,
+    output: stored.output,
+    streamOutputs: stored.streamOutputs,
+    streamComplete: stored.streamOutputs === undefined ? undefined : true,
+    error: stored.error,
+    requestHeaders: stored.requestHeaders,
+    responseHeaders: stored.responseHeaders,
+    upstreamRequestHeaders: stored.upstreamRequestHeaders,
+    upstreamResponseHeaders: stored.upstreamResponseHeaders,
+    url: stored.url,
+    timestamp: stored.timestamp,
+    durationMs: stored.durationMs,
+  };
+}
+
+export function serializeRun(run: Run, items: ConsoleItem[], now: number): StoredRun {
+  const stored: StoredRun = {
+    run: { ...run, stale: true, payloadsExpired: false },
+    items: items.map((item) => ({
+      id: item.id,
+      timestamp: item.timestamp,
+      call: item.call ? toStoredCall(item.call) : undefined,
+      logs: item.logs,
+    })),
+    storedAt: now,
+  };
+
+  if (payloadBytes(stored.items) > MAX_PAYLOAD_BYTES) {
+    return { ...stored, run: { ...stored.run, payloadsExpired: true }, items: [] };
+  }
+  return stored;
+}
+
+function payloadBytes(items: StoredItem[]): number {
+  try {
+    return JSON.stringify(items).length;
+  } catch {
+    return MAX_PAYLOAD_BYTES + 1;
+  }
+}
+
+export function deserializeRun(stored: StoredRun): LoadedRun {
+  return {
+    run: stored.run,
+    items: stored.items.map((item) => ({
+      id: item.id,
+      runId: stored.run.id,
+      timestamp: item.timestamp,
+      call: item.call ? fromStoredCall(item.call) : undefined,
+      logs: item.logs,
+    })),
+  };
+}
+
+/**
+ * Retention, applied on every read and write: a run older than a week keeps its
+ * header and loses its payloads, and only the fifty most recently run files are
+ * kept at all.
+ */
+export function pruneArchive(archive: RunArchive, now: number): RunArchive {
+  const cutoff = now - PAYLOAD_DAYS * 24 * 60 * 60 * 1000;
+  const entries = Object.entries(archive)
+    .filter(([, stored]) => stored?.run !== undefined)
+    .sort((a, b) => (b[1].run.startedAt ?? 0) - (a[1].run.startedAt ?? 0))
+    .slice(0, MAX_STORED_RUNS);
+
+  const pruned: RunArchive = {};
+  for (const [sourceId, stored] of entries) {
+    const expired = stored.storedAt < cutoff;
+    pruned[sourceId] = expired ? { ...stored, run: { ...stored.run, payloadsExpired: true }, items: [] } : stored;
+  }
+  return pruned;
+}
+
+function readArchive(): RunArchive {
+  return getPersistedValue<RunArchive>(STORAGE_KEY) ?? {};
+}
+
+function writeArchive(archive: RunArchive): void {
+  setPersistedValue(STORAGE_KEY, archive);
+}
+
+// Only a run that finished is worth keeping: one still in flight would come back
+// as a permanently pending header.
+export function saveLastRun(sourceId: string, run: Run, items: ConsoleItem[], now = Date.now()): void {
+  writeArchive(pruneArchive({ ...readArchive(), [sourceId]: serializeRun(run, items, now) }, now));
+}
+
+export function loadLastRun(sourceId: string, now = Date.now()): LoadedRun | undefined {
+  const archive = pruneArchive(readArchive(), now);
+  const stored = archive[sourceId];
+  return stored ? deserializeRun(stored) : undefined;
+}
+
+export function clearArchive(): void {
+  writeArchive({});
+}

--- a/ui/src/runs.test.ts
+++ b/ui/src/runs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { MethodCall } from "./kaja";
-import { callCount, ConsoleItem, groupRuns, isSingleItemRun, Run, worstStatus } from "./runs";
+import { callCount, ConsoleItem, followSelection, groupRuns, isSingleItemRun, Run, worstStatus } from "./runs";
 import { LogLevel } from "./server/api";
 
 const NOW = 1_700_000_000_000;
@@ -91,5 +91,37 @@ describe("callCount", () => {
   it("treats a run of one as a single row, so the common case gains no chrome", () => {
     const [group] = groupRuns([run("r1")], [call("a", "r1")]);
     expect(isSingleItemRun(group)).toBe(true);
+  });
+});
+
+describe("followSelection", () => {
+  const history = groupRuns([run("r1", { startedAt: NOW }), run("r2", { startedAt: NOW + 1 })], [call("a", "r1"), call("b", "r2"), call("c", "r2")]);
+
+  it("opens a run that has just arrived, whichever run was being read", () => {
+    expect(followSelection({ runId: "r1", itemId: "a" }, history, true)).toEqual({ runId: "r2", itemId: "c" });
+  });
+
+  it("opens the first run there is", () => {
+    expect(followSelection(null, groupRuns([run("r1")], [call("a", "r1")]), true)).toEqual({ runId: "r1", itemId: "a" });
+  });
+
+  it("follows the newest call inside the run being watched, so one in flight is selected as it is issued", () => {
+    expect(followSelection({ runId: "r2", itemId: "b" }, history, false)).toEqual({ runId: "r2", itemId: "c" });
+  });
+
+  it("leaves a run stepped back to alone when a call lands in a later one", () => {
+    expect(followSelection({ runId: "r1", itemId: "a" }, history, false)).toEqual({ runId: "r1", itemId: "a" });
+  });
+
+  it("follows the newest run when the selected one has gone", () => {
+    expect(followSelection({ runId: "gone", itemId: "x" }, history, false)).toEqual({ runId: "r2", itemId: "c" });
+  });
+
+  it("selects the header of a run that has produced nothing yet", () => {
+    expect(followSelection(null, groupRuns([run("r3")], []), true)).toEqual({ runId: "r3", itemId: undefined });
+  });
+
+  it("has nothing to select once the history is cleared", () => {
+    expect(followSelection({ runId: "r1", itemId: "a" }, [], true)).toBeNull();
   });
 });

--- a/ui/src/runs.test.ts
+++ b/ui/src/runs.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { MethodCall } from "./kaja";
+import { callCount, ConsoleItem, groupRuns, isSingleItemRun, Run, worstStatus } from "./runs";
+import { LogLevel } from "./server/api";
+
+const NOW = 1_700_000_000_000;
+
+function run(id: string, changes: Partial<Run> = {}): Run {
+  return { id, title: id, startedAt: NOW, ...changes };
+}
+
+function call(id: string, runId: string, changes: Partial<MethodCall> = {}): ConsoleItem {
+  const methodCall = {
+    id,
+    appName: "app",
+    service: { name: "Shows" },
+    method: { name: "ListShows" },
+    input: {},
+    output: {},
+    timestamp: NOW,
+    ...changes,
+  } as MethodCall;
+  return { id, runId, timestamp: methodCall.timestamp, call: methodCall };
+}
+
+function logs(id: string, runId: string, level: LogLevel): ConsoleItem {
+  return { id, runId, timestamp: NOW, logs: [{ level, message: "hello" }] };
+}
+
+describe("worstStatus", () => {
+  it("is pending when the run has produced nothing yet", () => {
+    expect(worstStatus([])).toBe("pending");
+  });
+
+  it("is success only when everything in it passed", () => {
+    expect(worstStatus([call("a", "r"), call("b", "r")])).toBe("success");
+  });
+
+  it("takes the worst status it contains", () => {
+    expect(worstStatus([call("a", "r"), call("b", "r", { error: { code: "UNAUTHENTICATED" } })])).toBe("error");
+  });
+
+  it("counts a script error as a failure of the run", () => {
+    expect(worstStatus([call("a", "r"), logs("b", "r", LogLevel.LEVEL_ERROR)])).toBe("error");
+  });
+
+  it("is pending while a call is still in flight", () => {
+    expect(worstStatus([call("a", "r"), call("b", "r", { output: undefined })])).toBe("pending");
+  });
+});
+
+describe("groupRuns", () => {
+  it("nests calls under the run that made them, oldest run first", () => {
+    const groups = groupRuns(
+      [run("r2", { startedAt: NOW + 100 }), run("r1")],
+      [call("a", "r1"), call("b", "r2"), call("c", "r1", { error: { code: "NOT_FOUND" } })],
+    );
+
+    expect(groups.map((group) => group.run.id)).toEqual(["r1", "r2"]);
+    expect(groups[0].items.map((item) => item.id)).toEqual(["a", "c"]);
+    expect(groups[0].status).toBe("error");
+    expect(groups[0].failures).toBe(1);
+    expect(groups[1].status).toBe("success");
+  });
+
+  it("keeps a run whose calls are gone, because the header is what says it happened", () => {
+    const groups = groupRuns([run("r1", { stale: true, payloadsExpired: true })], []);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items).toEqual([]);
+    expect(groups[0].inFlight).toBe(false);
+  });
+
+  it("never reports a stale run as in flight", () => {
+    const groups = groupRuns([run("r1", { stale: true })], [call("a", "r1", { output: undefined })]);
+    expect(groups[0].inFlight).toBe(false);
+  });
+
+  it("reports a live run with a call still in flight", () => {
+    const groups = groupRuns([run("r1")], [call("a", "r1", { output: undefined })]);
+    expect(groups[0].inFlight).toBe(true);
+  });
+});
+
+describe("callCount", () => {
+  it("counts calls, not the log lines the script printed", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1"), logs("b", "r1", LogLevel.LEVEL_INFO)]);
+    expect(callCount(group)).toBe(1);
+    expect(isSingleItemRun(group)).toBe(false);
+  });
+
+  it("treats a run of one as a single row, so the common case gains no chrome", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1")]);
+    expect(isSingleItemRun(group)).toBe(true);
+  });
+});

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -1,0 +1,135 @@
+import { isCallInFlight, MethodCall } from "./kaja";
+import { Log, LogLevel } from "./server/api";
+
+/**
+ * A run is the unit the console reports: one press of Run, one header, one
+ * duration, one verdict. The calls a script makes nest under it, because nothing
+ * else ties three calls to the same press.
+ */
+export interface Run {
+  id: string;
+  // The script's derived name at the time it was run, so the console and the
+  // sidebar speak the same language.
+  title: string;
+  // The file it came from — a scratch id or a script path — which is how
+  // reopening a script finds its last run.
+  sourceId?: string;
+  startedAt: number;
+  // Wall time for the whole script. It differs from the sum of the calls when
+  // they run concurrently, which is the number worth stating.
+  durationMs?: number;
+  // A run read back from the store: it happened in an earlier session and must
+  // not look live.
+  stale?: boolean;
+  // Set on a stale run whose payloads have aged out. The header still knows what
+  // happened, which is a more honest thing to show than nothing.
+  payloadsExpired?: boolean;
+}
+
+// One line in the console: a call the run made, or the log messages it printed.
+export interface ConsoleItem {
+  id: string;
+  runId: string;
+  timestamp: number;
+  call?: MethodCall;
+  logs?: Log[];
+}
+
+export type RunStatus = "pending" | "streaming" | "success" | "error";
+
+export interface RunGroup {
+  run: Run;
+  items: ConsoleItem[];
+  // The worst status the run contains: a green run means every call passed.
+  status: RunStatus;
+  // Whether anything it started is still in flight.
+  inFlight: boolean;
+  // How many of its calls failed, which is what the header says instead of
+  // repeating the duration of each one.
+  failures: number;
+}
+
+let sequence = 0;
+
+export function newRunId(): string {
+  sequence++;
+  return `run-${Date.now().toString(36)}-${sequence}`;
+}
+
+export function newItemId(): string {
+  sequence++;
+  return `item-${Date.now().toString(36)}-${sequence}`;
+}
+
+export function callStatus(call: MethodCall): RunStatus {
+  if (call.error) return "error";
+  const isStreaming = call.streamOutputs !== undefined;
+  if (isStreaming && !call.streamComplete) return "streaming";
+  return call.output !== undefined ? "success" : "pending";
+}
+
+export function logsStatus(logs: Log[]): RunStatus {
+  return logs.some((log) => log.level === LogLevel.LEVEL_ERROR) ? "error" : "success";
+}
+
+export function itemStatus(item: ConsoleItem): RunStatus {
+  return item.call ? callStatus(item.call) : item.logs ? logsStatus(item.logs) : "success";
+}
+
+export function itemName(item: ConsoleItem): string {
+  if (item.call) return `${item.call.service.name}.${item.call.method.name}`;
+  const logs = item.logs ?? [];
+  return logs.length === 1 ? logs[0].message.trim() : `${logs.length} log messages`;
+}
+
+// A run's status is the worst status it contains — there is no "partially
+// succeeded", and the header dot is the only thing anyone needs to read after a
+// press. A run that has produced nothing at all is still pending.
+export function worstStatus(items: ConsoleItem[]): RunStatus {
+  if (items.length === 0) return "pending";
+  const statuses = items.map(itemStatus);
+  if (statuses.includes("error")) return "error";
+  if (statuses.includes("pending")) return "pending";
+  if (statuses.includes("streaming")) return "streaming";
+  return "success";
+}
+
+/**
+ * Calls nest under the run that made them, ordered by start and never
+ * re-sorted. Runs come back oldest first, which is the order the history reads
+ * in; a run with no items left (its calls aged out) still gets a group, because
+ * the header is what says it happened.
+ */
+export function groupRuns(runs: Run[], items: ConsoleItem[]): RunGroup[] {
+  const byRun = new Map<string, ConsoleItem[]>();
+  for (const item of items) {
+    const list = byRun.get(item.runId);
+    if (list) list.push(item);
+    else byRun.set(item.runId, [item]);
+  }
+
+  return [...runs]
+    .sort((a, b) => a.startedAt - b.startedAt)
+    .map((run) => {
+      const runItems = byRun.get(run.id) ?? [];
+      return {
+        run,
+        items: runItems,
+        status: worstStatus(runItems),
+        inFlight: !run.stale && runItems.some((item) => item.call !== undefined && isCallInFlight(item.call)),
+        failures: runItems.filter((item) => itemStatus(item) === "error").length,
+      };
+    });
+}
+
+// How many calls the header reports. Log lines are the script talking, not calls
+// it made, so they don't count towards it.
+export function callCount(group: RunGroup): number {
+  return group.items.filter((item) => item.call !== undefined).length;
+}
+
+// A single-item run renders as one row, header and call merged, so the common
+// case gains no chrome over what the console shows today.
+export function isSingleItemRun(group: RunGroup): boolean {
+  return group.items.length <= 1;
+}

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -133,3 +133,27 @@ export function callCount(group: RunGroup): number {
 export function isSingleItemRun(group: RunGroup): boolean {
   return group.items.length <= 1;
 }
+
+// Which run is being looked at, and which of its calls. No call means the run
+// header itself is selected, which shows the run's own summary.
+export interface RunSelection {
+  runId: string;
+  itemId?: string;
+}
+
+/**
+ * Where the console points after the run list changes. Pressing Run is a request
+ * to see what it did, so a run arriving (`isNewRun`) always takes the selection —
+ * including from an older run that was deliberately stepped back to. Anything
+ * else only moves the cursor within the run being watched: a call landing in a
+ * later run leaves a stepped-back one alone, while inside the watched run it
+ * follows the newest call, which is what selects one in flight the moment it is
+ * issued. A selection whose run has gone has nothing left to point at and
+ * follows the newest too.
+ */
+export function followSelection(current: RunSelection | null, groups: RunGroup[], isNewRun: boolean): RunSelection | null {
+  const newest = groups[groups.length - 1];
+  if (!newest) return null;
+  if (!isNewRun && current && current.runId !== newest.run.id && groups.some((group) => group.run.id === current.runId)) return current;
+  return { runId: newest.run.id, itemId: newest.items[newest.items.length - 1]?.id };
+}

--- a/ui/src/scratchTitle.test.ts
+++ b/ui/src/scratchTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { deriveScratchTitle, readCalls } from "./scratchTitle";
+import { deriveScratchTitle, readCalls, titleParts } from "./scratchTitle";
 
 const generated = (body: string, names = "TheKajaTheatre") => `import { ${names} } from "theatre/service";\n\n${body}\n`;
 
@@ -75,7 +75,29 @@ describe("deriveScratchTitle", () => {
     expect(deriveScratchTitle(code)).toBe("GetShow · a");
   });
 
+  it('ignores a 64-bit zero, which is generated as the string "0"', () => {
+    const code = generated(`Add.Sum({ a: "0", b: "0" });`, "Add");
+    expect(deriveScratchTitle(code)).toBe("Sum");
+  });
+
+  it("still reads a filled 64-bit value", () => {
+    const code = generated(`Add.Sum({ a: "5", b: "3" });`, "Add");
+    expect(deriveScratchTitle(code)).toBe("Sum · 5, 3");
+  });
+
   it("has nothing to say about code that calls nothing", () => {
     expect(deriveScratchTitle(`const x = 1;`)).toBeUndefined();
+  });
+});
+
+describe("titleParts", () => {
+  it("splits the qualifier off, so a row can dim it", () => {
+    expect(titleParts("GetShow · vera-lune")).toEqual({ name: "GetShow", qualifier: "· vera-lune" });
+    expect(titleParts("Sum · 5, 3")).toEqual({ name: "Sum", qualifier: "· 5, 3" });
+  });
+
+  it("leaves a bare name alone", () => {
+    expect(titleParts("ListShows")).toEqual({ name: "ListShows" });
+    expect(titleParts("ListShows → GetShow")).toEqual({ name: "ListShows → GetShow" });
   });
 });

--- a/ui/src/scratchTitle.ts
+++ b/ui/src/scratchTitle.ts
@@ -76,7 +76,7 @@ function filledValues(object: ts.ObjectLiteralExpression): string[] | undefined 
     if (!ts.isPropertyAssignment(property)) return undefined;
     const value = property.initializer;
     if (ts.isStringLiteral(value)) {
-      if (value.text.trim() !== "") values.push(value.text);
+      if (!isZeroText(value.text)) values.push(value.text);
     } else if (ts.isNumericLiteral(value)) {
       if (Number(value.text) !== 0) values.push(value.text);
     } else if (value.kind === ts.SyntaxKind.TrueKeyword) {
@@ -96,7 +96,7 @@ function findLiteral(object: ts.ObjectLiteralExpression, pattern: RegExp, depth:
     const value = property.initializer;
 
     if (name && pattern.test(name)) {
-      if (ts.isStringLiteral(value) && value.text.trim() !== "") return truncate(value.text);
+      if (ts.isStringLiteral(value) && !isZeroText(value.text)) return truncate(value.text);
       if (ts.isNumericLiteral(value) && Number(value.text) !== 0) return value.text;
     }
     if (depth < 2 && ts.isObjectLiteralExpression(value)) {
@@ -105,6 +105,14 @@ function findLiteral(object: ts.ObjectLiteralExpression, pattern: RegExp, depth:
     }
   }
   return undefined;
+}
+
+// A 64-bit field is generated as a string, so its zero value is the text "0"
+// rather than the number — without this a request nobody has filled in gets
+// titled `Sum · 0, 0`.
+function isZeroText(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed === "" || /^-?0+$/.test(trimmed);
 }
 
 function truncate(value: string): string {
@@ -120,6 +128,16 @@ function truncate(value: string): string {
  * formatting job rather than a summarization one, and it comes out the same
  * every time.
  */
+/**
+ * The title is one string wherever it is stored, but a row can dim the part that
+ * only qualifies it. That is what tells an unsaved script apart from the method
+ * of the same name a few rows below it in the tree.
+ */
+export function titleParts(title: string): { name: string; qualifier?: string } {
+  const at = title.indexOf(" · ");
+  return at === -1 ? { name: title } : { name: title.slice(0, at), qualifier: title.slice(at + 1) };
+}
+
 export function deriveScratchTitle(code: string): string | undefined {
   const calls = readCalls(code);
   if (calls.length === 0) return undefined;

--- a/ui/src/views.ts
+++ b/ui/src/views.ts
@@ -2,7 +2,7 @@ import { Braces, FileCode, PenLine, ScrollText, Settings, type LucideIcon } from
 import * as monaco from "monaco-editor";
 import { appType, appTypeLabel, getAppType } from "./appTypes";
 import { Script } from "./apps";
-import { Scratch } from "./scratches";
+import { isUntouched, Scratch } from "./scratches";
 import { ConfigurationApp } from "./server/api";
 
 // How many views the pane keeps mounted. There is no "open files" set: this is
@@ -190,6 +190,10 @@ export interface ViewIdentity {
   // already the whole answer.
   origin: string;
   icon: LucideIcon;
+  // A browsing buffer: still exactly its generated code and never run, so the
+  // next call you pick takes it over. Wherever it is named it is dimmed, which
+  // is the only tell that rule has.
+  provisional?: boolean;
 }
 
 export function viewIdentity(view: View, scratches: Scratch[] = []): ViewIdentity {
@@ -199,7 +203,13 @@ export function viewIdentity(view: View, scratches: Scratch[] = []): ViewIdentit
       // can't have its own copy without the two drifting apart. Same vocabulary
       // as a saved script: only the icon says it isn't on disk.
       const scratch = scratches.find((candidate) => candidate.id === view.scratchId);
-      return { name: scratch?.title ?? "Scratch", path: "Scripts", origin: scratch?.origin?.appName ?? "", icon: PenLine };
+      return {
+        name: scratch?.title ?? "Scratch",
+        path: "Scripts",
+        origin: scratch?.origin?.appName ?? "",
+        icon: PenLine,
+        provisional: scratch !== undefined && isUntouched(scratch),
+      };
     }
     case "script":
       return { name: view.script.name, path: "Scripts", origin: "", icon: FileCode };


### PR DESCRIPTION
Built the two recommended options from the design review — the console's run grouping (3a) and empty state A (3b) — plus the seven polish items in 3c.

A run is now the console's unit: one press, one header, one wall duration, one verdict, calls nested under it and the worst status winning. Reopening a script shows its last run, labelled and dimmed. The empty state says the thing said nowhere else, an unsaved script dims while it's still a browsing buffer, delete and discard became different words, and split panes are cut.

---
_Generated by [Claude Code](https://claude.ai/code/session_018hQ5N5RnpeGwakKpBFuKpo)_