### PR TITLE
Gave every script its own result console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,36 @@ method in the sidebar is a *template*, not a document — clicking it fills a
 one verdict, with the calls it made nested under it. One script can make three
 calls, and three unrelated rows say nothing about the thing you actually pressed.
 
+**And the console belongs to the file** (`runHistory.ts`). There is no shared
+console: a run lands in the console of the script it was pressed on and stays
+there, so switching files switches consoles and coming back finds the runs, the
+selection and the tab as they were left. With one pane showing one file, a
+console reporting some other file's run under the code on screen was the same
+"which one is current" problem the tab strip removal set out to answer.
+
+- **Keyed by file, not held on the view.** `RunHistory` is `{ [fileId]:
+  FileConsole }`, where a `fileId` is a scratch id or a script path and a
+  `FileConsole` is that file's runs, calls, selection and tab. Views are a
+  ten-slot cache, so a console living on one would be thrown away by ordinary
+  navigation. ("Source" was the old name for this and is taken: it means an
+  app's generated proto TypeScript.)
+- **The scope is what makes the history worth stepping through.** `⌃↑`/`⌃↓` walk
+  *this call's* runs, so one go at it is comparable against the last — which is
+  what the run history was for. Caps are per file (25 runs, 300 calls), so a
+  chatty script can no longer evict another's history; fifty files hold a console
+  at once and the least recently run is let go.
+- **A run that has nowhere to land is not kept.** An agent running code that was
+  never saved has no file, so no console; it still gets its results back. A call
+  arriving with no run open gets one under the file the last run came from, which
+  is where a late call almost certainly belongs.
+- **A run keeps going when you navigate away from it**, and its console is no
+  longer on screen to say so — so the sidebar row does, with a spinner in place
+  of its icon (`runningFileIds`). Run/Stop in the command row still tracks the
+  *active* run, because Stop has to abort what it is showing.
+- **Renaming or saving moves the console; deleting takes it with the file.**
+  Saving a scratch to disk changes what the file is called, not what it is, so
+  its runs follow it from the scratch id to the path (`renameFile`). Discarding a
+  scratch is undoable, so its console is held alongside it and comes back.
 - **Three rules make the grouping hold.** ① A run's status is the **worst status
   it contains** (`worstStatus`) — there is no "partially succeeded", and the
   header dot is the only thing anyone needs to read after a press. ② A

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,17 +11,36 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "./cn";
 import { CommandRow } from "./CommandRow";
 import { Console } from "./Console";
-import { ConsoleItem, newItemId, newRunId, Run } from "./runs";
-import { loadLastRun, clearArchive, saveLastRun, LoadedRun } from "./runStore";
+import { ConsoleTab, newRunId, Run, RunSelection } from "./runs";
+import {
+  adoptStoredRuns,
+  clearFile,
+  dropFile,
+  fileConsole,
+  hasCallsInFlight,
+  putFile,
+  recordCall,
+  recordLogs,
+  renameFile,
+  RunHistory,
+  runningFileIds,
+  setSelection,
+  setTab,
+  settleRun,
+  startRun,
+  takeFile,
+  FileConsole,
+} from "./runHistory";
+import { dropStoredFile, loadRuns, renameStoredFile, saveRuns } from "./runStore";
 import { NoFileBlankslate, RecentFile } from "./NoFileBlankslate";
 import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
 import { Gutter } from "./Gutter";
-import { AskCancelledError, isCallInFlight, Kaja, MethodCall } from "./kaja";
+import { AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
-import { appendCall, createScratch, isUntouched, markRun, pruneScratches, Scratch, ScratchOrigin, takeOver, withCode } from "./scratches";
+import { appendCall, createScratch, isUntouched, markRun, pruneScratches, Scratch, takeOver, withCode } from "./scratches";
 import { deriveScratchTitle } from "./scratchTitle";
 import { generateMethodEditorCode } from "./appLoader";
 import { RunButton, useSyntaxErrors } from "./RunButton";
@@ -78,10 +97,6 @@ import {
 import { main } from "./wailsjs/go/models";
 import { runTask, runTaskCaptured } from "./taskRunner";
 
-// Maximum number of console items kept in memory; older calls are dropped.
-const MAX_CONSOLE_ITEMS = 500;
-// Runs are the unit the console reports, so the history is capped in runs too.
-const MAX_RUNS = 100;
 // How long a discarded scratch is held before it is really gone. Nothing was on
 // disk, so this is undo rather than a confirmation.
 const UNDO_DISCARD_MS = 8000;
@@ -188,23 +203,19 @@ export function App() {
     window.innerWidth >= SIDE_BY_SIDE_MIN_WIDTH ? "horizontal" : "vertical",
   );
   const [colorMode, setColorMode] = usePersistedState<ColorMode>("colorMode", "night");
-  // What the console reports: one run per press of Run, and the calls and log
-  // lines that ran under it.
-  const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([]);
-  const [runs, setRuns] = useState<Run[]>([]);
-  const runsRef = useRef(runs);
-  runsRef.current = runs;
+  // Every file's console: its runs, the calls under them, and where it was left
+  // pointing. The console belongs to the file, so this is keyed by file and not
+  // held on the view — views are a cache and get evicted.
+  const [history, setHistory] = useState<RunHistory>({});
+  const historyRef = useRef(history);
+  historyRef.current = history;
   // The run calls are being attributed to. Cleared once the run settles, so a
   // stray call afterwards starts one of its own rather than joining a run that
   // is over.
   const currentRunRef = useRef<Run | null>(null);
-  // The last run of the file on screen, read back from the store. It happened in
-  // an earlier session and is shown as such — never as something live.
-  const [staleRun, setStaleRun] = useState<LoadedRun | undefined>();
   // Whether the finder is open, and where it opened: ⌘P lands on the
   // previous file so ⌘P⏎ goes back, everything else on the first row.
   const [finder, setFinder] = useState<"first" | "previous">();
-  const [scrollToMethod, setScrollToMethod] = useState<{ method: Method; service: Service; app: AppModel }>();
   const viewsRef = useRef(views);
   viewsRef.current = views;
   const scratchesRef = useRef(scratches);
@@ -263,12 +274,12 @@ export function App() {
   // The run in flight, if any: which tab issued it, when it started, and the
   // controller its Stop button aborts. `settled` marks the script itself as
   // finished — the run is only over once its calls have landed too.
-  const [activeRun, setActiveRun] = useState<{ runId: string; viewId?: string; startedAt: number; controller?: AbortController; settled: boolean } | null>(
+  const [activeRun, setActiveRun] = useState<{ runId: string; fileId?: string; startedAt: number; controller?: AbortController; settled: boolean } | null>(
     null,
   );
   // A discarded scratch, held long enough to take it back. Nothing was on disk,
   // so discarding is undoable rather than confirmed.
-  const [discarded, setDiscarded] = useState<Scratch | null>(null);
+  const [discarded, setDiscarded] = useState<{ scratch: Scratch; runs?: FileConsole } | null>(null);
   const discardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Pending debounced disk writes for open script views, keyed by tab id.
   const scriptSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
@@ -364,30 +375,35 @@ export function App() {
     [disposeView, persistViews],
   );
 
-  // One press of Run opens a run; everything the script does lands under it.
-  // Nothing else creates one, except a call that arrives with no run open —
-  // which gets a run of its own rather than joining one that is over.
-  const beginRun = useCallback((title: string, sourceId?: string, viewId?: string, controller?: AbortController): Run => {
-    const run: Run = { id: newRunId(), title, sourceId, startedAt: Date.now() };
+  // One press of Run opens a run; everything the script does lands under it, in
+  // the console of the file it was pressed on. Nothing else creates one, except
+  // a call that arrives with no run open — which gets a run of its own rather
+  // than joining one that is over, under the file the last run came from.
+  const lastRunFileIdRef = useRef<string | undefined>(undefined);
+  const beginRun = useCallback((title: string, fileId?: string, controller?: AbortController): Run => {
+    const run: Run = { id: newRunId(), title, fileId, startedAt: Date.now() };
     currentRunRef.current = run;
-    setRuns((list) => {
-      const next = [...list, run];
-      return next.length > MAX_RUNS ? next.slice(next.length - MAX_RUNS) : next;
-    });
-    setActiveRun({ runId: run.id, viewId, startedAt: run.startedAt, controller, settled: false });
+    if (fileId) lastRunFileIdRef.current = fileId;
+    setHistory((current) => startRun(current, run, run.startedAt));
+    setActiveRun({ runId: run.id, fileId, startedAt: run.startedAt, controller, settled: false });
     return run;
   }, []);
 
   const beginRunRef = useRef(beginRun);
   beginRunRef.current = beginRun;
 
-  const appendConsoleItem = useCallback((item: ConsoleItem) => {
-    setConsoleItems((items) => {
-      const next = [...items, item];
-      // Cap history so a long session can't grow the console unbounded.
-      return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
-    });
-  }, []);
+  // A call arriving with no run open gets one, under the file the last run came
+  // from — that is where a late call almost certainly belongs. A run with no
+  // file at all (an agent running code that was never saved) has no console to
+  // land in and is not kept; the agent still gets its results.
+  const openRun = useCallback(
+    (title: string): Run => {
+      const current = currentRunRef.current;
+      if (current) return current;
+      return beginRun(title, lastRunFileIdRef.current);
+    },
+    [beginRun],
+  );
 
   const onMethodCallUpdate = useCallback(
     (methodCall: MethodCall) => {
@@ -397,17 +413,10 @@ export function App() {
         if (i > -1) collector[i] = methodCall;
         else collector.push(methodCall);
       }
-      const run = currentRunRef.current ?? beginRun(methodCall.method.name);
-      setConsoleItems((items) => {
-        const index = items.findIndex((item) => item.call?.id === methodCall.id);
-        if (index > -1) {
-          return items.map((item, i) => (i === index ? { ...item, call: { ...methodCall } } : item));
-        }
-        const next = [...items, { id: newItemId(), runId: run.id, timestamp: methodCall.timestamp, call: { ...methodCall } }];
-        return next.length > MAX_CONSOLE_ITEMS ? next.slice(next.length - MAX_CONSOLE_ITEMS) : next;
-      });
+      const run = openRun(methodCall.method.name);
+      setHistory((current) => recordCall(current, run.fileId, run.id, methodCall, Date.now()));
     },
-    [beginRun],
+    [openRun],
   );
 
   // Show a failed script run in the console; a script that dies silently looks
@@ -416,10 +425,10 @@ export function App() {
     (error: unknown) => {
       console.error("Script error:", error);
       const message = error instanceof Error ? (error.name === "Error" ? error.message : `${error.name}: ${error.message}`) : String(error);
-      const run = currentRunRef.current ?? beginRun("Script error");
-      appendConsoleItem({ id: newItemId(), runId: run.id, timestamp: Date.now(), logs: [{ level: LogLevel.LEVEL_ERROR, message }] });
+      const run = openRun("Script error");
+      setHistory((current) => recordLogs(current, run.fileId, run.id, [{ level: LogLevel.LEVEL_ERROR, message }], Date.now()));
     },
-    [appendConsoleItem, beginRun],
+    [openRun],
   );
 
   // Open the input dialog for a `kaja.ask(...)` call, resolving once the user
@@ -435,14 +444,11 @@ export function App() {
     kajaRef.current = new Kaja(onMethodCallUpdate, onAsk);
   }
 
-  // Clearing the history clears what is being held for next time too; leaving
-  // yesterday's run behind would make "cleared" a half-truth.
-  const onClearConsole = useCallback(() => {
-    setConsoleItems([]);
-    setRuns([]);
-    setStaleRun(undefined);
-    currentRunRef.current = null;
-    clearArchive();
+  // Clearing a file's history clears what is being held of it for next time too;
+  // leaving yesterday's run behind would make "cleared" a half-truth.
+  const onClearConsole = useCallback((fileId: string) => {
+    setHistory((current) => clearFile(current, fileId, Date.now()));
+    dropStoredFile(fileId);
   }, []);
 
   // Kept in sync during render so the first drag can pick up wherever the gutter
@@ -915,7 +921,7 @@ export function App() {
       // thing — the editor's own format-on-open can't help a buffer that is
       // written into a model it already has.
       const code = await formatTypeScript(generateMethodEditorCode(app, service, method));
-      const origin: ScratchOrigin = { appName: app.configuration.name, serviceName: service.name, methodName: method.name };
+      const originAppName = app.configuration.name;
       const now = Date.now();
       const current = viewsRef.current[0];
       const currentScratch = current?.type === "scratch" ? scratchesRef.current.find((s) => s.id === current.scratchId) : undefined;
@@ -929,11 +935,11 @@ export function App() {
 
       if (currentScratch && isUntouched(currentScratch)) {
         current.type === "scratch" && current.model.setValue(code);
-        updateScratch(currentScratch.id, (scratch) => takeOver(scratch, code, origin, now));
+        updateScratch(currentScratch.id, (scratch) => takeOver(scratch, code, originAppName, now));
         return;
       }
 
-      const scratch = createScratch(code, origin, now);
+      const scratch = createScratch(code, originAppName, now);
       applyScratches((list) => [scratch, ...list]);
       applyViews((views) => showScratch(views, scratch));
     },
@@ -954,8 +960,13 @@ export function App() {
       const shown = viewsRef.current.find((view) => view.type === "scratch" && view.scratchId === scratch.id);
       if (shown) applyViews((views) => dropView(views, shown.id));
       applyScratches((list) => list.filter((candidate) => candidate.id !== scratch.id));
+      // The console goes with the script, and is held alongside it so taking the
+      // discard back brings the runs back too.
+      const [remaining, taken] = takeFile(historyRef.current, scratch.id);
+      setHistory(remaining);
+      dropStoredFile(scratch.id);
       if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
-      setDiscarded(scratch);
+      setDiscarded({ scratch, runs: taken });
       discardTimerRef.current = setTimeout(() => setDiscarded(null), UNDO_DISCARD_MS);
     },
     [applyScratches, applyViews],
@@ -963,8 +974,14 @@ export function App() {
 
   const onUndoDiscard = useCallback(() => {
     if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
-    setDiscarded((scratch) => {
-      if (scratch) applyScratches((list) => [scratch, ...list]);
+    setDiscarded((held) => {
+      if (held) {
+        applyScratches((list) => [held.scratch, ...list]);
+        if (held.runs) {
+          setHistory((current) => putFile(current, held.scratch.id, held.runs!));
+          saveRuns(held.scratch.id, held.runs.runs, held.runs.items);
+        }
+      }
       return null;
     });
   }, [applyScratches]);
@@ -1211,6 +1228,10 @@ export function App() {
       if (saveAs.fromScratchId) {
         const id = saveAs.fromScratchId;
         applyScratches((list) => list.filter((candidate) => candidate.id !== id));
+        // Saving changes what the file is called, not what it is, so its runs
+        // come along to the path it now lives at.
+        setHistory((current) => renameFile(current, id, script.path));
+        renameStoredFile(id, script.path);
       }
       setSaveAs(null);
       setSaveAsError(undefined);
@@ -1232,6 +1253,9 @@ export function App() {
       setScripts((prev) => (prev ?? []).map((s) => (s.path === oldPath ? renamed : s)).sort((a, b) => a.name.localeCompare(b.name)));
       applyViews((views) => views.map((tab) => (tab.type === "script" && tab.script.path === oldPath ? { ...tab, script: renamed } : tab)));
       setPinnedScriptPath((current) => (current === oldPath ? renamed.path : current));
+      // The file is the console's key, so a rename moves it rather than losing it.
+      setHistory((current) => renameFile(current, oldPath, renamed.path));
+      renameStoredFile(oldPath, renamed.path);
     },
     [applyViews],
   );
@@ -1271,6 +1295,9 @@ export function App() {
     (path: string) => {
       setScripts((prev) => (prev ?? []).filter((s) => s.path !== path));
       setPinnedScriptPath((current) => (current === path ? undefined : current));
+      // The file is gone, so its console goes with it.
+      setHistory((current) => dropFile(current, path));
+      dropStoredFile(path);
       applyViews((views) => {
         const shown = views.find((candidate) => candidate.type === "script" && candidate.script.path === path);
         if (!shown) return views;
@@ -1341,16 +1368,6 @@ export function App() {
     });
     return () => unsub();
   }, [applyScriptRename, removeScriptFromUI, persistViews]);
-
-  // Going to a call from the finder also reveals it in the sidebar, so the tree
-  // stays in step with what is on screen.
-  const onFinderMethodSelect = useCallback(
-    (method: Method, service: Service, app: AppModel) => {
-      onMethodSelect(method, service, app);
-      setScrollToMethod({ method, service, app });
-    },
-    [onMethodSelect],
-  );
 
   const onGoToDefinition = (model: monaco.editor.ITextModel, startLineNumber: number, startColumn: number) => {
     applyViews((views) => showDefinition(views, model, startLineNumber, startColumn));
@@ -1463,8 +1480,7 @@ export function App() {
     // Run names reuse the derived script names, so the console and the sidebar
     // speak the same language.
     const title = tab.type === "script" ? tab.script.name : (deriveScratchTitle(code) ?? viewIdentity(tab, scratchesRef.current).name);
-    const sourceId = tab.type === "script" ? tab.script.path : tab.scratchId;
-    beginRun(title, sourceId, tab.id, controller);
+    beginRun(title, tab.type === "script" ? tab.script.path : tab.scratchId, controller);
     runTask(code, kajaRef.current!, apps, onScriptError, controller.signal).finally(() =>
       setActiveRun((run) => (run?.controller === controller ? { ...run, settled: true } : run)),
     );
@@ -1482,32 +1498,33 @@ export function App() {
   // time the file is opened.
   useEffect(() => {
     if (!activeRun?.settled) return;
-    const items = consoleItems.filter((item) => item.runId === activeRun.runId);
-    if (items.some((item) => item.call !== undefined && isCallInFlight(item.call))) return;
+    const file = fileConsole(historyRef.current, activeRun.fileId);
+    if (hasCallsInFlight(file, activeRun.runId)) return;
 
-    const finished = runsRef.current.find((run) => run.id === activeRun.runId);
-    if (finished) {
-      const settled: Run = { ...finished, durationMs: Date.now() - activeRun.startedAt };
-      setRuns((list) => list.map((run) => (run.id === settled.id ? settled : run)));
-      if (settled.sourceId) saveLastRun(settled.sourceId, settled, items);
+    if (activeRun.fileId) {
+      const now = Date.now();
+      const next = settleRun(historyRef.current, activeRun.fileId, activeRun.runId, now - activeRun.startedAt, now);
+      setHistory(next);
+      const settled = fileConsole(next, activeRun.fileId);
+      saveRuns(activeRun.fileId, settled.runs, settled.items, now);
     }
     if (currentRunRef.current?.id === activeRun.runId) currentRunRef.current = null;
     setActiveRun(null);
-  }, [consoleItems, activeRun]);
+  }, [history, activeRun]);
 
-  // Which file the console is reporting on, so its last run can be found again.
-  const currentSourceId = currentView?.type === "script" ? currentView.script.path : currentView?.type === "scratch" ? currentView.scratchId : undefined;
+  // Which file the console is reporting on. Everything below the editor is that
+  // file's: its runs, where it was left pointing, and what it was showing.
+  const currentFileId = currentView?.type === "script" ? currentView.script.path : currentView?.type === "scratch" ? currentView.scratchId : undefined;
+  const currentConsole = fileConsole(history, currentFileId);
 
-  // Reopening a script gives you its code and, if we still hold it, its last
-  // run. A run made in this session already says what happened, so the stored
-  // one only appears when there isn't one.
+  // Reopening a script gives you its code and, if we still hold them, the runs
+  // it last made. They are read once and sit underneath anything run since.
   useEffect(() => {
-    if (!currentSourceId || runs.some((run) => run.sourceId === currentSourceId)) {
-      setStaleRun(undefined);
-      return;
-    }
-    setStaleRun(loadLastRun(currentSourceId));
-  }, [currentSourceId, runs]);
+    if (!currentFileId || fileConsole(historyRef.current, currentFileId).loaded) return;
+    const fileId = currentFileId;
+    const stored = loadRuns(fileId);
+    setHistory((current) => adoptStoredRuns(current, fileId, stored, Date.now()));
+  }, [currentFileId]);
 
   // Stop aborts the calls the run has in flight; the script itself stops at the
   // call it was awaiting.
@@ -1736,7 +1753,7 @@ export function App() {
         key: `scratch:${scratch.id}`,
         name: scratch.title,
         path: "Scripts",
-        origin: scratch.origin?.appName ?? "",
+        origin: scratch.originAppName ?? "",
         icon: PenLine,
         provisional: isUntouched(scratch),
         go: () => onScratchSelect(scratch),
@@ -1761,25 +1778,28 @@ export function App() {
             path: `${app.configuration.name} / ${service.name}`,
             origin: app.configuration.name,
             icon: FileCode,
-            go: () => onFinderMethodSelect(method, service, app),
+            go: () => void onMethodSelect(method, service, app),
           });
         }
       }
     }
 
     return destinations;
-  }, [apps, scratches, scripts, views, onScratchSelect, onScriptSelect, onFinderMethodSelect, onVariablesClick, onShowCompileLog]);
+  }, [apps, scratches, scripts, views, onScratchSelect, onScriptSelect, onMethodSelect, onVariablesClick, onShowCompileLog]);
 
-  // The console reports runs. A run whose calls have all aged out of the item
-  // cap would be a header with nothing under it, so it goes with them; the one
-  // in flight is kept even before it has produced anything.
-  const consoleRuns = useMemo(() => {
-    const withItems = new Set(consoleItems.map((item) => item.runId));
-    const live = runs.filter((run) => withItems.has(run.id) || run.id === activeRun?.runId);
-    return staleRun ? [staleRun.run, ...live] : live;
-  }, [runs, consoleItems, activeRun?.runId, staleRun]);
+  // Which files have something in the air, so a run started on one script says
+  // so while you are looking at another.
+  const runningFiles = useMemo(() => runningFileIds(history), [history]);
 
-  const consoleEntries = useMemo(() => (staleRun ? [...staleRun.items, ...consoleItems] : consoleItems), [staleRun, consoleItems]);
+  const onConsoleSelect = useCallback(
+    (selection: RunSelection | null) => setHistory((current) => setSelection(current, currentFileId, selection, Date.now())),
+    [currentFileId],
+  );
+
+  const onConsoleTabChange = useCallback(
+    (tab: ConsoleTab) => setHistory((current) => setTab(current, currentFileId, tab, Date.now())),
+    [currentFileId],
+  );
 
   // What the empty state offers instead of an illustration: the last few things
   // you were in. On a first run there are none and the list is simply absent.
@@ -1799,7 +1819,10 @@ export function App() {
     return files;
   }, [scratches, scripts, onScratchSelect, onScriptSelect]);
 
-  const running = currentView !== undefined && activeRun?.viewId === currentView.id;
+  // Stop aborts what the button is showing, so it tracks the active run rather
+  // than the file's in-flight state — a run started elsewhere says so in the
+  // sidebar instead.
+  const running = currentFileId !== undefined && activeRun?.fileId === currentFileId;
   const action = currentIsEditor ? (
     <RunButton
       onRun={onRunCurrentTab}
@@ -1857,6 +1880,7 @@ export function App() {
                 onDeleteScript={isWailsEnvironment() ? (script) => setDeleteScript(script) : undefined}
                 onPinScript={isDesktopMac ? onPinScript : undefined}
                 pinnedScriptPath={pinnedScriptPath}
+                runningFileIds={runningFiles}
                 scratches={scratches}
                 currentScratchId={currentView?.type === "scratch" ? currentView.scratchId : undefined}
                 onScratchSelect={onScratchSelect}
@@ -1864,7 +1888,6 @@ export function App() {
                 onSaveScratch={isWailsEnvironment() ? onSaveScratch : undefined}
                 onShowAllScratches={() => setFinder("first")}
                 currentScriptPath={currentView?.type === "script" ? currentView.script.path : undefined}
-                scrollToMethod={scrollToMethod}
                 onShowCompileLog={onShowCompileLog}
                 onRecompileApp={onRecompile}
                 onNewAppClick={onNewAppClick}
@@ -1979,7 +2002,16 @@ export function App() {
                         flexDirection: "column",
                       }}
                     >
-                      <Console runs={consoleRuns} items={consoleEntries} onClear={onClearConsole} />
+                      <Console
+                        fileId={currentFileId}
+                        runs={currentConsole.runs}
+                        items={currentConsole.items}
+                        selection={currentConsole.selection}
+                        tab={currentConsole.tab}
+                        onSelect={onConsoleSelect}
+                        onTabChange={onConsoleTabChange}
+                        onClear={currentFileId ? () => onClearConsole(currentFileId) : undefined}
+                      />
                     </div>
                   </>
                 )}
@@ -2142,7 +2174,7 @@ export function App() {
       {discarded && (
         <div className="fixed bottom-10 left-1/2 z-[1000] flex h-9 -translate-x-1/2 items-center gap-3 rounded-md border border-border bg-popover px-3 shadow-lg">
           <span className="text-sm text-muted-foreground">
-            Discarded <span className="text-foreground">{discarded.title}</span>
+            Discarded <span className="text-foreground">{discarded.scratch.title}</span>
           </span>
           <button type="button" className="text-sm font-medium text-foreground hover:underline" onClick={onUndoDiscard}>
             Undo

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "./components/spinner";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
 import { MethodCall } from "./kaja";
-import { callCount, ConsoleItem, followSelection, groupRuns, itemName, itemStatus, Run, RunGroup, RunSelection, RunStatus } from "./runs";
+import { callCount, ConsoleItem, ConsoleTab, followSelection, groupRuns, itemName, itemStatus, Run, RunGroup, RunSelection, RunStatus } from "./runs";
 import { runShortcutLabel } from "./RunButton";
 import { Log, LogLevel } from "./server/api";
 
@@ -33,14 +33,21 @@ const consoleTabActiveClass = "font-medium text-foreground";
 const utilityButtonClass = "h-6 w-6 rounded-md hover:bg-accent hover:text-foreground";
 
 interface ConsoleProps {
+  // Which file's console this is. It is the whole scope: the runs are that
+  // file's runs, and changing it swaps consoles rather than reporting a new run.
+  fileId?: string;
   runs: Run[];
   items: ConsoleItem[];
+  // Where the console is pointing and what it is showing of the selected call.
+  // Both are kept per file by the caller, so coming back finds it as it was.
+  selection: RunSelection | null;
+  tab: ConsoleTab;
+  onSelect: (selection: RunSelection | null) => void;
+  onTabChange: (tab: ConsoleTab) => void;
   onClear?: () => void;
 }
 
-export function Console({ runs, items, onClear }: ConsoleProps) {
-  const [selection, setSelection] = useState<RunSelection | null>(null);
-  const [activeTab, setActiveTab] = useState<ConsoleTab>("response");
+export function Console({ fileId, runs, items, selection, tab: activeTab, onSelect, onTabChange, onClear }: ConsoleProps) {
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState(false);
 
@@ -60,55 +67,51 @@ export function Console({ runs, items, onClear }: ConsoleProps) {
     return () => clearInterval(interval);
   }, [hasInFlight]);
 
-  // The newest run the console has followed, which is what tells a run arriving
-  // apart from a call arriving inside the one already on screen.
-  const followedRunRef = useRef<string | undefined>(undefined);
+  // The file and run the console has followed, which is what tells a run
+  // arriving apart from a call arriving inside the one already on screen — and
+  // both apart from the console being handed a different file altogether.
+  const followedRef = useRef<{ fileId?: string; runId?: string }>({});
 
   useEffect(() => {
-    const isNewRun = followedRunRef.current !== newest?.run.id;
-    followedRunRef.current = newest?.run.id;
-    setSelection((current) => followSelection(current, groups, isNewRun));
+    const sameFile = followedRef.current.fileId === fileId;
+    const isNewRun = sameFile && followedRef.current.runId !== newest?.run.id;
+    followedRef.current = { fileId, runId: newest?.run.id };
+    // Arriving at another file is not a run arriving: its own selection has just
+    // been restored, and only a selection with nothing left to point at is
+    // moved on to the newest run.
+    const next = followSelection(selection, groups, isNewRun);
+    if (next?.runId !== selection?.runId || next?.itemId !== selection?.itemId) onSelect(next);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [newest?.run.id, newest?.items.length, groups.length]);
-
-  // Opening a file whose last run we still hold is a reason to show that run:
-  // it is what happened here, even though it isn't live.
-  const staleRunId = groups.find((group) => group.run.stale)?.run.id;
-
-  useEffect(() => {
-    if (!staleRunId) return;
-    const group = groups.find((candidate) => candidate.run.id === staleRunId);
-    if (group) setSelection({ runId: staleRunId, itemId: group.items[group.items.length - 1]?.id });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [staleRunId]);
+  }, [fileId, newest?.run.id, newest?.items.length, groups.length]);
 
   const selectedGroup = groups.find((group) => group.run.id === selection?.runId);
   const selectedItem = selectedGroup?.items.find((item) => item.id === selection?.itemId);
   const selectedCall = selectedItem?.call;
   const selectedLogs = selectedItem?.logs;
 
-  const selectRun = useCallback((group: RunGroup) => {
-    const last = group.items[group.items.length - 1];
-    setSelection({ runId: group.run.id, itemId: last?.id });
-  }, []);
+  const selectRun = useCallback(
+    (group: RunGroup) => {
+      const last = group.items[group.items.length - 1];
+      onSelect({ runId: group.run.id, itemId: last?.id });
+    },
+    [onSelect],
+  );
 
-  // ⌃↑ / ⌃↓ step through the runs without opening the dropdown.
+  // ⌃↑ / ⌃↓ step through this file's runs without opening the dropdown, which is
+  // what makes one go at a call comparable against the last.
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!event.ctrlKey || event.metaKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
       if (groups.length === 0) return;
       event.preventDefault();
-      setSelection((current) => {
-        const index = groups.findIndex((group) => group.run.id === current?.runId);
-        const from = index === -1 ? groups.length - 1 : index;
-        const next = Math.max(0, Math.min(groups.length - 1, from + (event.key === "ArrowUp" ? -1 : 1)));
-        const group = groups[next];
-        return { runId: group.run.id, itemId: group.items[group.items.length - 1]?.id };
-      });
+      const index = groups.findIndex((group) => group.run.id === selection?.runId);
+      const from = index === -1 ? groups.length - 1 : index;
+      const next = Math.max(0, Math.min(groups.length - 1, from + (event.key === "ArrowUp" ? -1 : 1)));
+      selectRun(groups[next]);
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [groups]);
+  }, [groups, selection?.runId, selectRun]);
 
   const handleCopy = useCallback(() => {
     jsonViewerRef.current?.copyToClipboard();
@@ -173,7 +176,7 @@ export function Console({ runs, items, onClear }: ConsoleProps) {
         {selectedCall && (
           <>
             <div className="h-4 w-px shrink-0 bg-border" />
-            <Console.DetailTabs methodCall={selectedCall} activeTab={activeTab} onTabChange={setActiveTab} />
+            <Console.DetailTabs methodCall={selectedCall} activeTab={activeTab} onTabChange={onTabChange} />
           </>
         )}
         {showUtilities && (
@@ -209,7 +212,7 @@ export function Console({ runs, items, onClear }: ConsoleProps) {
             group={selectedGroup}
             selected={selection?.itemId === undefined}
             expanded={showRunChildren}
-            onSelect={() => setSelection({ runId: selectedGroup.run.id })}
+            onSelect={() => onSelect({ runId: selectedGroup.run.id })}
             now={now}
           />
         )}
@@ -220,7 +223,7 @@ export function Console({ runs, items, onClear }: ConsoleProps) {
               key={item.id}
               item={item}
               selected={item.id === selection?.itemId}
-              onSelect={() => setSelection({ runId: selectedGroup.run.id, itemId: item.id })}
+              onSelect={() => onSelect({ runId: selectedGroup.run.id, itemId: item.id })}
               now={now}
             />
           ))}
@@ -231,7 +234,7 @@ export function Console({ runs, items, onClear }: ConsoleProps) {
               <span className="font-mono text-xs text-muted-foreground">{runShortcutLabel}</span>
             </div>
           ) : selectedCall ? (
-            <Console.DetailContent methodCall={selectedCall} activeTab={activeTab} onTabChange={setActiveTab} jsonViewerRef={jsonViewerRef} />
+            <Console.DetailContent methodCall={selectedCall} activeTab={activeTab} onTabChange={onTabChange} jsonViewerRef={jsonViewerRef} />
           ) : selectedLogs ? (
             <Console.LogContent logs={selectedLogs} />
           ) : selectedGroup ? (
@@ -438,7 +441,6 @@ Console.RunSummary = function ({ group }: { group: RunGroup }) {
   );
 };
 
-type ConsoleTab = "request" | "response" | "headers";
 
 interface DetailTabsProps {
   methodCall: MethodCall;

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { cn } from "./cn";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { IconButton } from "./components/icon-button";
+import { Spinner } from "./components/spinner";
 import { TreeView } from "./components/tree-view";
 import {
   Braces,
@@ -76,12 +77,6 @@ export function PreviewPill() {
   return <span className={pillClass}>Preview</span>;
 }
 
-interface ScrollToMethod {
-  method: Method;
-  service: Service;
-  app: App;
-}
-
 interface SidebarProps {
   apps: App[];
   scripts?: Script[];
@@ -92,7 +87,9 @@ interface SidebarProps {
   currentScriptPath?: string;
   // Path of the script pinned to the macOS "Run Kaja Script" text service.
   pinnedScriptPath?: string;
-  scrollToMethod?: ScrollToMethod;
+  // Files with a run still in the air. A run keeps going when you navigate away
+  // from it, and its console is no longer on screen to say so — the row is.
+  runningFileIds?: Set<string>;
   canDeleteApps?: boolean;
   // Clicking goes to the call; ⌥click (or the + on the row) adds it to the
   // script already on screen.
@@ -129,7 +126,7 @@ export function Sidebar({
   currentScratchId,
   currentScriptPath,
   pinnedScriptPath,
-  scrollToMethod,
+  runningFileIds,
   canDeleteApps = true,
   onSelect,
   onScratchSelect,
@@ -344,55 +341,6 @@ export function Sidebar({
     }
   }, [expandedApps, expandedServices]);
 
-  // Handle scrollToMethod: expand app/service and scroll to method
-  useEffect(() => {
-    if (!scrollToMethod) return;
-
-    const { method, service, app } = scrollToMethod;
-    const appName = app.configuration.name;
-    const serviceElementId = getServiceElementId(appName, service);
-    const methodElementId = methodId(service, method);
-
-    // Expand app if not already expanded
-    setExpandedApps((prev) => {
-      if (!prev.has(appName)) {
-        const next = new Set(prev);
-        next.add(appName);
-        return next;
-      }
-      return prev;
-    });
-
-    // Expand package if multiple packages and not already expanded
-    if (hasMultiplePackages(app.services)) {
-      const packageElementId = getPackageElementId(appName, service.packageName);
-      setExpandedServices((prev) => {
-        if (!prev.has(packageElementId)) {
-          const next = new Set(prev);
-          next.add(packageElementId);
-          return next;
-        }
-        return prev;
-      });
-    }
-
-    // Expand service if not already expanded
-    setExpandedServices((prev) => {
-      if (!prev.has(serviceElementId)) {
-        const next = new Set(prev);
-        next.add(serviceElementId);
-        return next;
-      }
-      return prev;
-    });
-
-    // Schedule scroll after React renders any expansions
-    // Use setTimeout to ensure state updates have been processed
-    setTimeout(() => {
-      scrollIntoView(methodElementId);
-    }, 0);
-  }, [scrollToMethod]);
-
   const toggleAppExpanded = (appName: string) => {
     setExpandedApps((prev) => {
       const next = new Set(prev);
@@ -513,7 +461,15 @@ export function Sidebar({
                   >
                     {/* Pin lives in the leading slot so it never shifts when the kebab appears on
                         hover, and it lines a pinned script up with the package/expand icons above. */}
-                    <TreeView.LeadingVisual>{pinnedScriptPath === script.path ? <Pin size={12} /> : <FileCode size={13} />}</TreeView.LeadingVisual>
+                    <TreeView.LeadingVisual>
+                      {runningFileIds?.has(script.path) ? (
+                        <Spinner className="size-3" />
+                      ) : pinnedScriptPath === script.path ? (
+                        <Pin size={12} />
+                      ) : (
+                        <FileCode size={13} />
+                      )}
+                    </TreeView.LeadingVisual>
                     {script.name}
                     <TreeView.TrailingVisual>
                       {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
@@ -552,7 +508,11 @@ export function Sidebar({
                   >
                     {/* Not saved: the pen is the whole difference. */}
                     <TreeView.LeadingVisual>
-                      <PenLine size={13} className={cn(isUntouched(scratch) && "opacity-60")} />
+                      {runningFileIds?.has(scratch.id) ? (
+                        <Spinner className="size-3" />
+                      ) : (
+                        <PenLine size={13} className={cn(isUntouched(scratch) && "opacity-60")} />
+                      )}
                     </TreeView.LeadingVisual>
                     <ScratchLabel scratch={scratch} />
                     <TreeView.TrailingVisual>

--- a/ui/src/runHistory.test.ts
+++ b/ui/src/runHistory.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "bun:test";
+import { MethodCall } from "./kaja";
+import {
+  adoptStoredRuns,
+  clearFile,
+  dropFile,
+  fileConsole,
+  hasCallsInFlight,
+  putFile,
+  recordCall,
+  recordLogs,
+  renameFile,
+  RunHistory,
+  runningFileIds,
+  setSelection,
+  setTab,
+  settleRun,
+  startRun,
+  takeFile,
+} from "./runHistory";
+import { Run } from "./runs";
+import { LogLevel } from "./server/api";
+
+const NOW = 1_700_000_000_000;
+
+function run(id: string, fileId?: string, startedAt = NOW): Run {
+  return { id, title: id, fileId, startedAt };
+}
+
+function call(id: string, output?: unknown): MethodCall {
+  return { id, appName: "theatre", service: { name: "Shows" }, method: { name: "ListShows" }, output, timestamp: NOW } as MethodCall;
+}
+
+describe("startRun", () => {
+  it("lands a run in the console of the file it was pressed on", () => {
+    const history = startRun({}, run("r1", "a"), NOW);
+    expect(fileConsole(history, "a").runs.map((r) => r.id)).toEqual(["r1"]);
+    expect(fileConsole(history, "b").runs).toEqual([]);
+  });
+
+  it("keeps one file's runs out of another's", () => {
+    let history: RunHistory = {};
+    history = startRun(history, run("r1", "a"), NOW);
+    history = startRun(history, run("r2", "b"), NOW);
+    history = startRun(history, run("r3", "a"), NOW);
+    expect(fileConsole(history, "a").runs.map((r) => r.id)).toEqual(["r1", "r3"]);
+    expect(fileConsole(history, "b").runs.map((r) => r.id)).toEqual(["r2"]);
+  });
+
+  it("does not keep a run with no file of its own", () => {
+    expect(startRun({}, run("r1"), NOW)).toEqual({});
+  });
+
+  it("drops the oldest runs of a file past the cap, and their calls with them", () => {
+    let history: RunHistory = {};
+    for (let index = 0; index < 30; index++) {
+      history = startRun(history, run(`r${index}`, "a"), NOW + index);
+      history = recordCall(history, "a", `r${index}`, call(`c${index}`), NOW + index);
+    }
+    const file = fileConsole(history, "a");
+    expect(file.runs).toHaveLength(25);
+    expect(file.runs[0].id).toBe("r5");
+    expect(file.items.every((item) => item.runId !== "r0")).toBe(true);
+  });
+
+  it("holds fifty files and lets go of the least recently run", () => {
+    let history: RunHistory = {};
+    for (let index = 0; index < 60; index++) {
+      history = startRun(history, run(`r${index}`, `f${index}`, NOW + index), NOW + index);
+    }
+    expect(Object.keys(history)).toHaveLength(50);
+    expect(history.f0).toBeUndefined();
+    expect(history.f59).toBeDefined();
+  });
+});
+
+describe("recordCall", () => {
+  it("replaces a call already in the run rather than appending it again", () => {
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = recordCall(history, "a", "r1", call("c1"), NOW);
+    history = recordCall(history, "a", "r1", call("c1", { shows: [] }), NOW);
+    const file = fileConsole(history, "a");
+    expect(file.items).toHaveLength(1);
+    expect(file.items[0].call?.output).toEqual({ shows: [] });
+  });
+
+  it("keeps calls in the order they started", () => {
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = recordCall(history, "a", "r1", call("c1"), NOW);
+    history = recordCall(history, "a", "r1", call("c2"), NOW);
+    history = recordCall(history, "a", "r1", call("c1", { done: true }), NOW);
+    expect(fileConsole(history, "a").items.map((item) => item.call?.id)).toEqual(["c1", "c2"]);
+  });
+});
+
+describe("settleRun", () => {
+  it("gives the run its wall duration", () => {
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = settleRun(history, "a", "r1", 212, NOW);
+    expect(fileConsole(history, "a").runs[0].durationMs).toBe(212);
+  });
+
+  it("leaves a file alone when the run has already gone", () => {
+    const history = startRun({}, run("r1", "a"), NOW);
+    expect(settleRun(history, "a", "gone", 1, NOW)).toBe(history);
+  });
+});
+
+describe("adoptStoredRuns", () => {
+  it("puts stored runs underneath what has been run since", () => {
+    let history = startRun({}, run("live", "a"), NOW + 100);
+    history = adoptStoredRuns(history, "a", { runs: [{ ...run("old", "a"), stale: true }], items: [] }, NOW);
+    expect(fileConsole(history, "a").runs.map((r) => r.id)).toEqual(["old", "live"]);
+  });
+
+  it("reads the store once, so a second visit does not put back what was cleared", () => {
+    const stored = { runs: [{ ...run("old", "a"), stale: true }], items: [] };
+    let history = adoptStoredRuns({}, "a", stored, NOW);
+    history = clearFile(history, "a", NOW);
+    history = adoptStoredRuns(history, "a", stored, NOW);
+    expect(fileConsole(history, "a").runs).toEqual([]);
+  });
+
+  it("marks a file with nothing stored as read", () => {
+    const history = adoptStoredRuns({}, "a", undefined, NOW);
+    expect(fileConsole(history, "a").loaded).toBe(true);
+  });
+});
+
+describe("selection and tab", () => {
+  it("are kept per file, so coming back finds the console as it was left", () => {
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = startRun(history, run("r2", "b"), NOW);
+    history = setSelection(history, "a", { runId: "r1", itemId: "i1" }, NOW);
+    history = setTab(history, "a", "headers", NOW);
+    history = setTab(history, "b", "request", NOW);
+
+    expect(fileConsole(history, "a").selection).toEqual({ runId: "r1", itemId: "i1" });
+    expect(fileConsole(history, "a").tab).toBe("headers");
+    expect(fileConsole(history, "b").selection).toBeNull();
+    expect(fileConsole(history, "b").tab).toBe("request");
+  });
+
+  it("start on the response tab with nothing selected", () => {
+    const file = fileConsole({}, "never-run");
+    expect(file.selection).toBeNull();
+    expect(file.tab).toBe("response");
+  });
+});
+
+describe("renameFile", () => {
+  it("moves a console to the name the file now has", () => {
+    let history = startRun({}, run("r1", "scratch-1"), NOW);
+    history = renameFile(history, "scratch-1", "/scripts/shows.ts");
+    expect(history["scratch-1"]).toBeUndefined();
+    expect(fileConsole(history, "/scripts/shows.ts").runs[0].fileId).toBe("/scripts/shows.ts");
+  });
+
+  it("leaves a history with nothing under that name alone", () => {
+    const history = startRun({}, run("r1", "a"), NOW);
+    expect(renameFile(history, "b", "c")).toBe(history);
+  });
+});
+
+describe("taking a console out and putting it back", () => {
+  it("hands the console back so a discard can be undone", () => {
+    const history = recordLogs(startRun({}, run("r1", "a"), NOW), "a", "r1", [{ level: LogLevel.LEVEL_ERROR, message: "boom" }], NOW);
+    const [without, taken] = takeFile(history, "a");
+    expect(without.a).toBeUndefined();
+    expect(taken?.items).toHaveLength(1);
+    expect(fileConsole(putFile(without, "a", taken!), "a").items).toHaveLength(1);
+  });
+
+  it("drops a file outright", () => {
+    expect(dropFile(startRun({}, run("r1", "a"), NOW), "a").a).toBeUndefined();
+  });
+});
+
+describe("running files", () => {
+  it("names the files with a run that has not settled", () => {
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = startRun(history, run("r2", "b"), NOW);
+    history = settleRun(history, "b", "r2", 10, NOW);
+    expect(runningFileIds(history)).toEqual(new Set(["a"]));
+  });
+
+  it("never counts a run read back from the store", () => {
+    const history = adoptStoredRuns({}, "a", { runs: [{ ...run("old", "a"), stale: true }], items: [] }, NOW);
+    expect(runningFileIds(history)).toEqual(new Set());
+  });
+});
+
+describe("hasCallsInFlight", () => {
+  it("is what the settle check waits on", () => {
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = recordCall(history, "a", "r1", call("c1"), NOW);
+    expect(hasCallsInFlight(fileConsole(history, "a"), "r1")).toBe(true);
+    history = recordCall(history, "a", "r1", call("c1", { shows: [] }), NOW);
+    expect(hasCallsInFlight(fileConsole(history, "a"), "r1")).toBe(false);
+  });
+});

--- a/ui/src/runHistory.ts
+++ b/ui/src/runHistory.ts
@@ -1,0 +1,212 @@
+import { isCallInFlight, MethodCall } from "./kaja";
+import { ConsoleItem, ConsoleTab, newItemId, Run, RunSelection } from "./runs";
+import { Log } from "./server/api";
+
+/**
+ * The console belongs to the file. A run is made by pressing Run on something,
+ * so it lands in that file's console and stays there: switching files switches
+ * consoles, and coming back finds the runs, the selection and the tab as they
+ * were left.
+ *
+ * This is keyed by file rather than kept on the view because views are a
+ * ten-slot cache — a console that lived on one would be thrown away by ordinary
+ * navigation.
+ */
+export interface FileConsole {
+  // Oldest first, the order the history reads in.
+  runs: Run[];
+  items: ConsoleItem[];
+  // Which run and call is being looked at. Null means "whatever is newest",
+  // which is what a file that has never been looked at wants.
+  selection: RunSelection | null;
+  tab: ConsoleTab;
+  // Whether the store has been consulted for this file yet, so it is read once
+  // rather than on every visit.
+  loaded: boolean;
+  touchedAt: number;
+}
+
+export type RunHistory = { [fileId: string]: FileConsole };
+
+// How much of one file's console is kept in memory. The two caps are
+// independent: one run can make a thousand calls, and one file can be run a
+// thousand times.
+const MAX_RUNS_PER_FILE = 25;
+const MAX_ITEMS_PER_FILE = 300;
+// How many files hold a console at once. Past this the least recently run one is
+// let go — its last runs are in the store, which is what reopening it reads.
+const MAX_FILES = 50;
+
+const EMPTY: FileConsole = { runs: [], items: [], selection: null, tab: "response", loaded: false, touchedAt: 0 };
+
+export function fileConsole(history: RunHistory, fileId: string | undefined): FileConsole {
+  return (fileId !== undefined ? history[fileId] : undefined) ?? EMPTY;
+}
+
+/**
+ * Runs leave oldest first, taking their calls with them. If the calls alone
+ * overflow, the oldest go and any run left holding none goes with them — except
+ * one whose payloads expired in the store, which never had calls in memory and
+ * whose header is the whole point of keeping it.
+ */
+function trim(file: FileConsole): FileConsole {
+  let runs = file.runs;
+  let items = file.items;
+
+  if (runs.length > MAX_RUNS_PER_FILE) {
+    runs = runs.slice(runs.length - MAX_RUNS_PER_FILE);
+    const kept = new Set(runs.map((run) => run.id));
+    items = items.filter((item) => kept.has(item.runId));
+  }
+
+  if (items.length > MAX_ITEMS_PER_FILE) {
+    items = items.slice(items.length - MAX_ITEMS_PER_FILE);
+    const withItems = new Set(items.map((item) => item.runId));
+    const newest = runs[runs.length - 1]?.id;
+    runs = runs.filter((run) => withItems.has(run.id) || run.payloadsExpired === true || run.id === newest);
+  }
+
+  return runs === file.runs && items === file.items ? file : { ...file, runs, items };
+}
+
+// Files are evicted by when they last ran something, so the ones being worked in
+// are the ones that stay.
+function evict(history: RunHistory): RunHistory {
+  const ids = Object.keys(history);
+  if (ids.length <= MAX_FILES) return history;
+
+  const kept = ids.sort((a, b) => history[b].touchedAt - history[a].touchedAt).slice(0, MAX_FILES);
+  const next: RunHistory = {};
+  for (const id of kept) next[id] = history[id];
+  return next;
+}
+
+function withFile(history: RunHistory, fileId: string, now: number, change: (file: FileConsole) => FileConsole): RunHistory {
+  const current = history[fileId] ?? EMPTY;
+  const changed = change(current);
+  if (changed === current) return history;
+  return evict({ ...history, [fileId]: trim({ ...changed, touchedAt: now }) });
+}
+
+/**
+ * One press of Run. A run with no file of its own — an agent running code that
+ * was never saved — is not kept: there is no console it belongs to, and the
+ * caller still gets its results.
+ */
+export function startRun(history: RunHistory, run: Run, now: number): RunHistory {
+  if (!run.fileId) return history;
+  return withFile(history, run.fileId, now, (file) => ({ ...file, runs: [...file.runs, run] }));
+}
+
+// Calls arrive more than once as they stream and settle, so a call already in
+// the run is replaced rather than appended.
+export function recordCall(history: RunHistory, fileId: string | undefined, runId: string, call: MethodCall, now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => {
+    const index = file.items.findIndex((item) => item.call?.id === call.id);
+    if (index > -1) {
+      return { ...file, items: file.items.map((item, i) => (i === index ? { ...item, call: { ...call } } : item)) };
+    }
+    return { ...file, items: [...file.items, { id: newItemId(), runId, timestamp: call.timestamp, call: { ...call } }] };
+  });
+}
+
+export function recordLogs(history: RunHistory, fileId: string | undefined, runId: string, logs: Log[], now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => ({ ...file, items: [...file.items, { id: newItemId(), runId, timestamp: now, logs }] }));
+}
+
+// The run's wall duration is known once the script has settled and everything it
+// started has landed.
+export function settleRun(history: RunHistory, fileId: string | undefined, runId: string, durationMs: number, now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => {
+    if (!file.runs.some((run) => run.id === runId)) return file;
+    return { ...file, runs: file.runs.map((run) => (run.id === runId ? { ...run, durationMs } : run)) };
+  });
+}
+
+/**
+ * What the store held for this file, read once and merged in underneath: runs
+ * made in this session always sit above ones read back from an earlier one.
+ */
+export function adoptStoredRuns(history: RunHistory, fileId: string, stored: { runs: Run[]; items: ConsoleItem[] } | undefined, now: number): RunHistory {
+  const file = history[fileId] ?? EMPTY;
+  if (file.loaded) return history;
+  if (!stored || stored.runs.length === 0) {
+    return { ...history, [fileId]: { ...file, loaded: true, touchedAt: file.touchedAt || now } };
+  }
+  const known = new Set(file.runs.map((run) => run.id));
+  const runs = stored.runs.filter((run) => !known.has(run.id));
+  const items = stored.items.filter((item) => !known.has(item.runId));
+  return evict({
+    ...history,
+    [fileId]: trim({ ...file, runs: [...runs, ...file.runs], items: [...items, ...file.items], loaded: true, touchedAt: file.touchedAt || now }),
+  });
+}
+
+export function setSelection(history: RunHistory, fileId: string | undefined, selection: RunSelection | null, now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => (file.selection === selection ? file : { ...file, selection }));
+}
+
+export function setTab(history: RunHistory, fileId: string | undefined, tab: ConsoleTab, now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => (file.tab === tab ? file : { ...file, tab }));
+}
+
+// Saving a scratch to disk changes what the file is called, not what it is, so
+// its console moves with it. Renaming a script is the same act.
+export function renameFile(history: RunHistory, oldId: string, newId: string): RunHistory {
+  const file = history[oldId];
+  if (!file) return history;
+  const { [oldId]: _dropped, ...rest } = history;
+  return {
+    ...rest,
+    [newId]: { ...file, runs: file.runs.map((run) => ({ ...run, fileId: newId })) },
+  };
+}
+
+// Taking a file's console out, and putting it back — discarding a scratch is
+// undoable, so its runs have to be able to come back with it.
+export function takeFile(history: RunHistory, fileId: string): [RunHistory, FileConsole | undefined] {
+  const file = history[fileId];
+  if (!file) return [history, undefined];
+  const { [fileId]: _dropped, ...rest } = history;
+  return [rest, file];
+}
+
+export function putFile(history: RunHistory, fileId: string, file: FileConsole): RunHistory {
+  return evict({ ...history, [fileId]: file });
+}
+
+export function dropFile(history: RunHistory, fileId: string): RunHistory {
+  return takeFile(history, fileId)[0];
+}
+
+// Clearing a file's history leaves the file with an empty console rather than no
+// console: the store has been read, and re-reading it would put back what was
+// just cleared.
+export function clearFile(history: RunHistory, fileId: string, now: number): RunHistory {
+  return { ...history, [fileId]: { ...EMPTY, loaded: true, touchedAt: now } };
+}
+
+// A run that has not settled is still going. This is what lets a file say so in
+// the sidebar while you are looking at another one.
+export function isRunning(file: FileConsole): boolean {
+  return file.runs.some((run) => !run.stale && run.durationMs === undefined);
+}
+
+export function runningFileIds(history: RunHistory): Set<string> {
+  const running = new Set<string>();
+  for (const [fileId, file] of Object.entries(history)) {
+    if (isRunning(file)) running.add(fileId);
+  }
+  return running;
+}
+
+// Whether anything the run started is still in the air, which is what the settle
+// check waits on.
+export function hasCallsInFlight(file: FileConsole, runId: string): boolean {
+  return file.items.some((item) => item.runId === runId && item.call !== undefined && isCallInFlight(item.call));
+}

--- a/ui/src/runStore.test.ts
+++ b/ui/src/runStore.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import { MethodCall } from "./kaja";
 import { ConsoleItem, Run } from "./runs";
-import { deserializeRun, pruneArchive, RunArchive, serializeRun, StoredRun } from "./runStore";
+import { deserializeFile, pruneArchive, RunArchive, serializeFile, StoredFile } from "./runStore";
 
 const NOW = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
 
-const run: Run = { id: "r1", title: "ListShows", sourceId: "scratch-1", startedAt: NOW, durationMs: 212 };
+const run: Run = { id: "r1", title: "ListShows", fileId: "scratch-1", startedAt: NOW, durationMs: 212 };
 
-function call(output: unknown): ConsoleItem {
+function call(output: unknown, runId = run.id, id = "item-1"): ConsoleItem {
   const methodCall = {
-    id: "call-1",
+    id: `call-${id}`,
     appName: "theatre",
     service: { name: "Shows" },
     method: { name: "ListShows" },
@@ -19,26 +19,46 @@ function call(output: unknown): ConsoleItem {
     timestamp: NOW,
     durationMs: 212,
   } as MethodCall;
-  return { id: "item-1", runId: run.id, timestamp: NOW, call: methodCall };
+  return { id, runId, timestamp: NOW, call: methodCall };
 }
 
-describe("serializeRun", () => {
+describe("serializeFile", () => {
   it("marks what it stores as stale, so it can never come back looking live", () => {
-    const stored = serializeRun(run, [call({ shows: [] })], NOW);
-    expect(stored.run.stale).toBe(true);
-    expect(stored.run.payloadsExpired).toBe(false);
+    const stored = serializeFile([run], [call({ shows: [] })], NOW);
+    expect(stored.runs[0].run.stale).toBe(true);
+    expect(stored.runs[0].run.payloadsExpired).toBe(false);
   });
 
   it("keeps the header and drops the payloads when they are too big to hold", () => {
-    const stored = serializeRun(run, [call({ blob: "x".repeat(600 * 1024) })], NOW);
-    expect(stored.items).toEqual([]);
-    expect(stored.run.payloadsExpired).toBe(true);
-    expect(stored.run.title).toBe("ListShows");
+    const stored = serializeFile([run], [call({ blob: "x".repeat(600 * 1024) })], NOW);
+    expect(stored.runs[0].items).toEqual([]);
+    expect(stored.runs[0].run.payloadsExpired).toBe(true);
+    expect(stored.runs[0].run.title).toBe("ListShows");
+  });
+
+  it("keeps only the newest few runs of a file", () => {
+    const runs = Array.from({ length: 5 }, (_, index) => ({ ...run, id: `r${index}`, startedAt: NOW + index }));
+    const stored = serializeFile(runs, [], NOW);
+    expect(stored.runs.map((entry) => entry.run.id)).toEqual(["r2", "r3", "r4"]);
+  });
+
+  it("spends the payload budget on the newest run first, so what is dropped is the oldest", () => {
+    const big = { blob: "x".repeat(400 * 1024) };
+    const runs = [
+      { ...run, id: "old", startedAt: NOW },
+      { ...run, id: "new", startedAt: NOW + 1 },
+    ];
+    const items = [call(big, "old", "item-old"), call(big, "new", "item-new")];
+    const stored = serializeFile(runs, items, NOW);
+    expect(stored.runs[0].run.id).toBe("old");
+    expect(stored.runs[0].run.payloadsExpired).toBe(true);
+    expect(stored.runs[1].run.payloadsExpired).toBe(false);
+    expect(stored.runs[1].items).toHaveLength(1);
   });
 
   it("round-trips a call back into something the console can render", () => {
-    const loaded = deserializeRun(serializeRun(run, [call({ shows: [1, 2] })], NOW));
-    expect(loaded.run.id).toBe("r1");
+    const loaded = deserializeFile(serializeFile([run], [call({ shows: [1, 2] })], NOW));
+    expect(loaded.runs[0].id).toBe("r1");
     expect(loaded.items).toHaveLength(1);
     expect(loaded.items[0].runId).toBe("r1");
     expect(loaded.items[0].call?.service.name).toBe("Shows");
@@ -48,12 +68,11 @@ describe("serializeRun", () => {
   });
 });
 
-function archiveEntry(sourceId: string, startedAt: number, storedAt: number): [string, StoredRun] {
+function archiveEntry(fileId: string, startedAt: number, storedAt: number): [string, StoredFile] {
   return [
-    sourceId,
+    fileId,
     {
-      run: { ...run, id: sourceId, sourceId, startedAt, stale: true },
-      items: [call({})].map((item) => ({ id: item.id, timestamp: item.timestamp })),
+      runs: [{ run: { ...run, id: fileId, fileId, startedAt, stale: true }, items: [{ id: "item-1", timestamp: startedAt }] }],
       storedAt,
     },
   ];
@@ -63,15 +82,15 @@ describe("pruneArchive", () => {
   it("keeps a run's header past the payload cut-off, because expiry has to be a stated state", () => {
     const archive: RunArchive = Object.fromEntries([archiveEntry("a", NOW - 10 * DAY, NOW - 10 * DAY)]);
     const pruned = pruneArchive(archive, NOW);
-    expect(pruned.a.run.payloadsExpired).toBe(true);
-    expect(pruned.a.items).toEqual([]);
-    expect(pruned.a.run.title).toBe("ListShows");
+    expect(pruned.a.runs[0].run.payloadsExpired).toBe(true);
+    expect(pruned.a.runs[0].items).toEqual([]);
+    expect(pruned.a.runs[0].run.title).toBe("ListShows");
   });
 
   it("leaves a recent run alone", () => {
     const archive: RunArchive = Object.fromEntries([archiveEntry("a", NOW - DAY, NOW - DAY)]);
-    expect(pruneArchive(archive, NOW).a.run.payloadsExpired).toBeUndefined();
-    expect(pruneArchive(archive, NOW).a.items).toHaveLength(1);
+    expect(pruneArchive(archive, NOW).a.runs[0].run.payloadsExpired).toBeUndefined();
+    expect(pruneArchive(archive, NOW).a.runs[0].items).toHaveLength(1);
   });
 
   it("holds the fifty most recently run files and no more", () => {
@@ -80,5 +99,10 @@ describe("pruneArchive", () => {
     expect(Object.keys(pruned)).toHaveLength(50);
     expect(pruned.s0).toBeDefined();
     expect(pruned.s59).toBeUndefined();
+  });
+
+  it("drops an entry written in a shape it can no longer read", () => {
+    const archive = { old: { run: { ...run }, items: [], storedAt: NOW } } as unknown as RunArchive;
+    expect(pruneArchive(archive, NOW)).toEqual({});
   });
 });

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -5,15 +5,16 @@ import { ConsoleItem, Run } from "./runs";
 import { Log } from "./server/api";
 import { getPersistedValue, setPersistedValue } from "./storage";
 
-// Storing code is free; storing responses is not. Headers are small and are kept
-// for the last fifty files you ran something in; the payloads under them are
-// dropped after a week, because expiry is only bearable when it is a stated
-// state rather than a silent hole.
-const MAX_STORED_RUNS = 50;
+// Storing code is free; storing responses is not. A file keeps its last few run
+// headers, the payloads under them are dropped after a week, and only the fifty
+// most recently run files are kept at all — because expiry is only bearable when
+// it is a stated state rather than a silent hole.
+const MAX_STORED_FILES = 50;
+const MAX_STORED_RUNS_PER_FILE = 3;
 const PAYLOAD_DAYS = 7;
-// A run whose payloads don't fit is stored without them rather than not at all:
-// the header is still worth having, and "no longer kept" is what the screen
-// already says.
+// The payload budget for one file, spent newest run first. A run whose payloads
+// don't fit is stored without them rather than not at all: the header is still
+// worth having, and "no longer kept" is what the screen already says.
 const MAX_PAYLOAD_BYTES = 512 * 1024;
 
 const STORAGE_KEY = "lastRuns";
@@ -45,16 +46,22 @@ interface StoredItem {
   logs?: Log[];
 }
 
-export interface StoredRun {
+interface StoredRun {
   run: Run;
   items: StoredItem[];
+}
+
+// One file's console as it is kept between sessions: its last few runs, oldest
+// first, exactly as the live list reads.
+export interface StoredFile {
+  runs: StoredRun[];
   storedAt: number;
 }
 
-export type RunArchive = { [sourceId: string]: StoredRun };
+export type RunArchive = { [fileId: string]: StoredFile };
 
-export interface LoadedRun {
-  run: Run;
+export interface LoadedRuns {
+  runs: Run[];
   items: ConsoleItem[];
 }
 
@@ -107,22 +114,34 @@ function fromStoredCall(stored: StoredCall): MethodCall {
   };
 }
 
-export function serializeRun(run: Run, items: ConsoleItem[], now: number): StoredRun {
-  const stored: StoredRun = {
-    run: { ...run, stale: true, payloadsExpired: false },
-    items: items.map((item) => ({
-      id: item.id,
-      timestamp: item.timestamp,
-      call: item.call ? toStoredCall(item.call) : undefined,
-      logs: item.logs,
-    })),
-    storedAt: now,
-  };
+/**
+ * A file's runs on their way into the store: the newest few, each marked as
+ * belonging to an earlier session, and the payload budget spent newest first so
+ * what is dropped is always the oldest thing.
+ */
+export function serializeFile(runs: Run[], items: ConsoleItem[], now: number): StoredFile {
+  const kept = runs.slice(Math.max(0, runs.length - MAX_STORED_RUNS_PER_FILE));
+  const stored: StoredRun[] = [];
+  let budget = MAX_PAYLOAD_BYTES;
 
-  if (payloadBytes(stored.items) > MAX_PAYLOAD_BYTES) {
-    return { ...stored, run: { ...stored.run, payloadsExpired: true }, items: [] };
+  // Newest first while spending, then flipped back to oldest first.
+  for (let index = kept.length - 1; index >= 0; index--) {
+    const run = kept[index];
+    const runItems = items.filter((item) => item.runId === run.id).map(toStoredItem);
+    const size = payloadBytes(runItems);
+    if (run.payloadsExpired || size > budget) {
+      stored.unshift({ run: { ...run, stale: true, payloadsExpired: true }, items: [] });
+      continue;
+    }
+    budget -= size;
+    stored.unshift({ run: { ...run, stale: true, payloadsExpired: false }, items: runItems });
   }
-  return stored;
+
+  return { runs: stored, storedAt: now };
+}
+
+function toStoredItem(item: ConsoleItem): StoredItem {
+  return { id: item.id, timestamp: item.timestamp, call: item.call ? toStoredCall(item.call) : undefined, logs: item.logs };
 }
 
 function payloadBytes(items: StoredItem[]): number {
@@ -133,37 +152,41 @@ function payloadBytes(items: StoredItem[]): number {
   }
 }
 
-export function deserializeRun(stored: StoredRun): LoadedRun {
-  return {
-    run: stored.run,
-    items: stored.items.map((item) => ({
-      id: item.id,
-      runId: stored.run.id,
-      timestamp: item.timestamp,
-      call: item.call ? fromStoredCall(item.call) : undefined,
-      logs: item.logs,
-    })),
-  };
+export function deserializeFile(stored: StoredFile): LoadedRuns {
+  const runs: Run[] = [];
+  const items: ConsoleItem[] = [];
+  for (const entry of stored.runs) {
+    runs.push(entry.run);
+    for (const item of entry.items) {
+      items.push({ id: item.id, runId: entry.run.id, timestamp: item.timestamp, call: item.call ? fromStoredCall(item.call) : undefined, logs: item.logs });
+    }
+  }
+  return { runs, items };
 }
 
 /**
- * Retention, applied on every read and write: a run older than a week keeps its
- * header and loses its payloads, and only the fifty most recently run files are
- * kept at all.
+ * Retention, applied on every read and write: a file's runs older than a week
+ * keep their headers and lose their payloads, and only the fifty most recently
+ * run files are kept at all. An entry written by an older build has a shape this
+ * can't read and is simply dropped.
  */
 export function pruneArchive(archive: RunArchive, now: number): RunArchive {
   const cutoff = now - PAYLOAD_DAYS * 24 * 60 * 60 * 1000;
   const entries = Object.entries(archive)
-    .filter(([, stored]) => stored?.run !== undefined)
-    .sort((a, b) => (b[1].run.startedAt ?? 0) - (a[1].run.startedAt ?? 0))
-    .slice(0, MAX_STORED_RUNS);
+    .filter(([, stored]) => Array.isArray(stored?.runs))
+    .sort((a, b) => lastRunAt(b[1]) - lastRunAt(a[1]))
+    .slice(0, MAX_STORED_FILES);
 
   const pruned: RunArchive = {};
-  for (const [sourceId, stored] of entries) {
-    const expired = stored.storedAt < cutoff;
-    pruned[sourceId] = expired ? { ...stored, run: { ...stored.run, payloadsExpired: true }, items: [] } : stored;
+  for (const [fileId, stored] of entries) {
+    pruned[fileId] =
+      stored.storedAt < cutoff ? { ...stored, runs: stored.runs.map((entry) => ({ run: { ...entry.run, payloadsExpired: true }, items: [] })) } : stored;
   }
   return pruned;
+}
+
+function lastRunAt(stored: StoredFile): number {
+  return stored.runs[stored.runs.length - 1]?.run.startedAt ?? 0;
 }
 
 function readArchive(): RunArchive {
@@ -174,18 +197,31 @@ function writeArchive(archive: RunArchive): void {
   setPersistedValue(STORAGE_KEY, archive);
 }
 
-// Only a run that finished is worth keeping: one still in flight would come back
-// as a permanently pending header.
-export function saveLastRun(sourceId: string, run: Run, items: ConsoleItem[], now = Date.now()): void {
-  writeArchive(pruneArchive({ ...readArchive(), [sourceId]: serializeRun(run, items, now) }, now));
+export function saveRuns(fileId: string, runs: Run[], items: ConsoleItem[], now = Date.now()): void {
+  if (runs.length === 0) {
+    dropStoredFile(fileId);
+    return;
+  }
+  writeArchive(pruneArchive({ ...readArchive(), [fileId]: serializeFile(runs, items, now) }, now));
 }
 
-export function loadLastRun(sourceId: string, now = Date.now()): LoadedRun | undefined {
-  const archive = pruneArchive(readArchive(), now);
-  const stored = archive[sourceId];
-  return stored ? deserializeRun(stored) : undefined;
+export function loadRuns(fileId: string, now = Date.now()): LoadedRuns | undefined {
+  const stored = pruneArchive(readArchive(), now)[fileId];
+  return stored ? deserializeFile(stored) : undefined;
 }
 
-export function clearArchive(): void {
-  writeArchive({});
+// A scratch saved to disk, or a script renamed: same console, new name.
+export function renameStoredFile(oldId: string, newId: string): void {
+  const archive = readArchive();
+  const stored = archive[oldId];
+  if (!stored) return;
+  const { [oldId]: _dropped, ...rest } = archive;
+  writeArchive({ ...rest, [newId]: { ...stored, runs: stored.runs.map((entry) => ({ ...entry, run: { ...entry.run, fileId: newId } })) } });
+}
+
+export function dropStoredFile(fileId: string): void {
+  const archive = readArchive();
+  if (!(fileId in archive)) return;
+  const { [fileId]: _dropped, ...rest } = archive;
+  writeArchive(rest);
 }

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -11,9 +11,10 @@ export interface Run {
   // The script's derived name at the time it was run, so the console and the
   // sidebar speak the same language.
   title: string;
-  // The file it came from — a scratch id or a script path — which is how
-  // reopening a script finds its last run.
-  sourceId?: string;
+  // The file it came from — a scratch id or a script path. The console belongs
+  // to the file, so this is what decides which console a run lands in. ("Source"
+  // is taken: it means an app's generated proto TypeScript.)
+  fileId?: string;
   startedAt: number;
   // Wall time for the whole script. It differs from the sum of the calls when
   // they run concurrently, which is the number worth stating.
@@ -36,6 +37,10 @@ export interface ConsoleItem {
 }
 
 export type RunStatus = "pending" | "streaming" | "success" | "error";
+
+// Which part of the selected call is showing. It is remembered per file along
+// with the selection, so going back to a script finds its console as it was.
+export type ConsoleTab = "request" | "response" | "headers";
 
 export interface RunGroup {
   run: Run;

--- a/ui/src/scratches.ts
+++ b/ui/src/scratches.ts
@@ -5,14 +5,6 @@ import { deriveScratchTitle } from "./scratchTitle";
 // not work. It is dropped once it is this old.
 const STALE_DAYS = 14;
 
-// Where a scratch came from, so the sidebar can show which method you are
-// looking at. Only a hint — the scratch is free to grow past it.
-export interface ScratchOrigin {
-  appName: string;
-  serviceName: string;
-  methodName: string;
-}
-
 /**
  * A scratch is the unit of exploration: unlimited, kept in the app, and named
  * from its own code. It is not a file — saving it as a script is what puts it
@@ -29,7 +21,11 @@ export interface Scratch {
   // starting another one.
   generatedCode: string;
   ran: boolean;
-  origin?: ScratchOrigin;
+  // The app the call it was generated from belongs to, and nothing more: it is
+  // the qualifier beside the title, which is what tells two same-named calls in
+  // different apps apart. A scratch is not bound to the method it came from and
+  // is free to grow past it.
+  originAppName?: string;
   createdAt: number;
   updatedAt: number;
 }
@@ -41,14 +37,14 @@ export function newScratchId(): string {
   return `scratch-${Date.now().toString(36)}-${sequence}`;
 }
 
-export function createScratch(code: string, origin: ScratchOrigin | undefined, now: number): Scratch {
+export function createScratch(code: string, originAppName: string | undefined, now: number): Scratch {
   return {
     id: newScratchId(),
     title: deriveScratchTitle(code) ?? "Scratch",
     code,
     generatedCode: code,
     ran: false,
-    origin,
+    originAppName,
     createdAt: now,
     updatedAt: now,
   };
@@ -60,13 +56,13 @@ export function isUntouched(scratch: Scratch): boolean {
   return !scratch.ran && scratch.code === scratch.generatedCode;
 }
 
-export function takeOver(scratch: Scratch, code: string, origin: ScratchOrigin | undefined, now: number): Scratch {
+export function takeOver(scratch: Scratch, code: string, originAppName: string | undefined, now: number): Scratch {
   return {
     ...scratch,
     title: deriveScratchTitle(code) ?? "Scratch",
     code,
     generatedCode: code,
-    origin,
+    originAppName,
     updatedAt: now,
   };
 }

--- a/ui/src/views.test.ts
+++ b/ui/src/views.test.ts
@@ -65,7 +65,7 @@ describe("the mounted cache", () => {
 
 describe("viewIdentity", () => {
   it("takes a scratch's name from the store, so the two can't drift apart", () => {
-    const scratch = { id: "s1", title: "GetShow · vera-lune", origin: { appName: "theatre", serviceName: "S", methodName: "GetShow" } } as any;
+    const scratch = { id: "s1", title: "GetShow · vera-lune", originAppName: "theatre" } as any;
     const identity = viewIdentity(scratchView("scratch-1", "s1"), [scratch]);
 
     expect(identity.name).toBe("GetShow · vera-lune");

--- a/ui/src/views.ts
+++ b/ui/src/views.ts
@@ -206,7 +206,7 @@ export function viewIdentity(view: View, scratches: Scratch[] = []): ViewIdentit
       return {
         name: scratch?.title ?? "Scratch",
         path: "Scripts",
-        origin: scratch?.origin?.appName ?? "",
+        origin: scratch?.originAppName ?? "",
         icon: PenLine,
         provisional: scratch !== undefined && isUntouched(scratch),
       };


### PR DESCRIPTION
The console now belongs to the file — a run lands in the console of the script it was pressed on, and coming back finds the runs, the selection and the tab as they were left. `runHistory.ts` keys it all by file id, `runStore` becomes its persistence layer (so `staleRun` stops being a run spliced in from the side), `Run.sourceId` is renamed `fileId`, and the finder's reveal-in-tree hop is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135zio3q3FphckJPzaGeDzy)_