### PR TITLE
Tightened the sidebar and put the script verbs on the row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,10 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   and unsaved together under a single `Scripts` heading, in one vocabulary — two
   headings would teach a taxonomy the model doesn't have. **A dot is the whole
   difference**: amber for a script that isn't on disk, hollow grey for one that
-  is. It replaced the file icon, which spent 13px of a 22px row saying what five
-  make clear; the finder, which has the room, keeps `FileCode` / `PenLine`.
+  is. It replaced the file icon because a 5px mark is quieter than a drawing in
+  a 22px row that already spends a glyph on the app above it — not to save
+  width, since `ScriptGlyph` holds the slot open at the run spinner's 12px
+  either way. The finder, which has the room, keeps `FileCode` / `PenLine`.
   Saved sit above, then the six most recent unsaved; the rest are `⌘P` away,
   which is what makes an unlimited history usable. So saving is a change of
   state, not a move between places — the row's dot goes hollow and it rises, it
@@ -121,7 +123,9 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   buttons widens that slot instead, and **keeps its leading dot** — trading the
   dot for 11px was tried and it makes the label jump exactly as you reach for it.
   A label truncating a little sooner is the cheaper cost, and it is what
-  truncation is for.
+  truncation is for. The **leading** slot is fixed the same way (`ScriptGlyph`,
+  12px): a run spinner, the pin, the dot and — on the web — nothing at all all
+  occupy it, and a run starting under the cursor must not move the name either.
 - **The pile has a size and two verbs.** The `Scripts` header states how many
   scripts there are, and how many of them are unsaved, in amber. Under the cursor
   that count becomes **save them all** and **discard the unsaved**, each confirmed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,12 +75,14 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   re-bind.)
 - **There is one list, not two.** The sidebar and the finder both show saved
   and unsaved together under a single `Scripts` heading, in one vocabulary — two
-  headings would teach a taxonomy the model doesn't have. **The icon is the whole
-  difference**: `FileCode` for a script on disk, `PenLine` for one that isn't.
+  headings would teach a taxonomy the model doesn't have. **A dot is the whole
+  difference**: amber for a script that isn't on disk, hollow grey for one that
+  is. It replaced the file icon, which spent 13px of a 22px row saying what five
+  make clear; the finder, which has the room, keeps `FileCode` / `PenLine`.
   Saved sit above, then the six most recent unsaved; the rest are `⌘P` away,
   which is what makes an unlimited history usable. So saving is a change of
-  state, not a move between places — the row gains an icon and rises, it doesn't
-  vanish from one section and reappear in another. The word "scratch" survives in
+  state, not a move between places — the row's dot goes hollow and it rises, it
+  doesn't vanish from one section and reappear in another. The word "scratch" survives in
   the code, where it names the storage tier precisely, and nowhere in the UI.
   `origin` on a scratch is only the app name the trigger shows beside the title,
   to tell two same-named calls in different apps apart. **Nothing in the method
@@ -92,7 +94,7 @@ method in the sidebar is a *template*, not a document — clicking it fills a
 - **The browsing buffer says so.** "An untouched one gets taken over, a
   worked-in one doesn't" is a good rule you could otherwise only learn by being
   surprised by it, so it has a tell: a scratch that is still `isUntouched` is
-  **dimmed** — label and icon, in the sidebar row and in the finder's trigger and
+  **dimmed** — label and dot, in the sidebar row and in the finder's trigger and
   rows (`provisional` on `ViewIdentity` and on a finder `Destination`) — and
   resolves to full weight the moment it is edited or run. Not italics, and not a
   word; the dim is the reading. Beside it, `titleParts` splits the qualifier the
@@ -103,14 +105,59 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   it takes a file off disk. An unsaved row's is `Save…` / **`Discard`**, neutral
   and **undoable** — the row goes and a bar offers it back for eight seconds
   (`UNDO_DISCARD_MS`) — because nothing was anywhere to remove. Saving proposes
-  the filename from the derived name, so the section converges on one naming
-  convention instead of splitting into files and not-files by casing.
+  the filename from the derived name (`proposeFileName`), so the section
+  converges on one naming convention instead of splitting into files and
+  not-files by casing.
+- **The frequent verbs are on the row, not behind the menu.** A script is made by
+  clicking a method, run twice and thrown away — a several-times-a-minute loop
+  that shouldn't cost hover → ⋯ → click → click. So an unsaved row's hover
+  carries **✓ save · ✕ discard · ⋯**, and `⌫` on the focused row does the same as
+  the ✕. The menu survives for the rarer items. A **saved** row keeps only the
+  kebab: taking a file off disk is not the loop this is for, and it still asks
+  first.
 - **Rows reserve their trailing slot.** `TreeView.TrailingVisual` is a fixed 24px
   whether or not it holds anything, so a label's truncation point doesn't move
-  under the cursor when the row grows a kebab on hover.
+  under the cursor when the row grows a kebab on hover. Three buttons don't fit
+  in that slot beside a leading glyph in a 22px row, so the one row that carries
+  three — an unsaved script — widens the slot and **spends its dot** to seat
+  them, and only for as long as the cursor is on it.
+- **The pile has a size and two verbs.** The `Scripts` header states how many
+  scripts there are, and how many of them are unsaved, in amber. Under the cursor
+  that count becomes **save them all** and **discard the unsaved**, each confirmed
+  against the list it is about to touch — a bulk save names every file from its
+  own title (`proposeFileNames`, disambiguated against disk and against each
+  other), and the discard says which saved scripts it is keeping. Neither verb
+  can reach a file, which is what makes "dump everything I'm not keeping" a
+  one-click action rather than a destructive one.
+- **The one you are editing has the pair beside its name**, in the command row:
+  a dot, `Save ⌘S`, and a discard that closes the file with it. All three are
+  absent — not disabled — once there is nothing unsaved, so a saved file's row is
+  just its name and Run. Same two verbs as the sidebar row, so the model stays
+  single; they answer different moments (mid-edit, versus tidying up after).
 - **The web is the same app minus one verb.** Scratches are IndexedDB on both
   platforms, so the list, the titles and the history are identical; only Save is
   missing, because only the desktop has a disk to write to.
+
+## The tree is an index, so it reads as a list of names
+
+Rows are **22px** at `text-xs`, chevrons 12px — a dense desktop client's sizing,
+not a web page's. The three levers are row height, indent, and how many icons
+repeat per row, and the last one is what buys the horizontal room:
+
+- **Depth is a hairline, not an icon column.** `TreeView.SubTree` nests inside a
+  guide (14px indent, a 1px rule at its left edge). A package and a service
+  repeated the same glyph on every row, saying what the indent already said, so
+  those icons are gone. The **app keeps its** `AppTypeIcon` — that one says gRPC
+  or OpenAPI or Markdown, which nothing else does.
+- **A list of leaves takes the indent without the guide** (`leaf` on `TreeView`
+  and on `SubTree`): a line nothing hangs off is noise, and its rows drop the
+  chevron slot they would never fill, so methods start where the eye already is
+  rather than 20px right of it.
+- **Rows are full-bleed** — no radius, no inset — so the panel edge is the row
+  edge and hover reads as a band. The one hairline that remains is the one
+  between your scripts and the API's catalog.
+- The sidebar **header stays 40px** regardless, because it lines up with the
+  command row across the seam.
 
 ## The console reports runs
 
@@ -201,10 +248,13 @@ illustration, and it degrades correctly: on a first run the recent list is
 **There is no tab strip, and no open files either.** The pane shows one thing —
 whatever you last selected — and the window's right side opens with one 40px
 **command row** (`CommandRow.tsx`) that replaced the old top bar and tab strip:
-sidebar toggle · finder · spacer · action · hairline · search · layout. There are
+sidebar toggle · finder · the file's own save/discard · spacer · action ·
+hairline · search · layout. There are
 no recent chips — with one pane and a finder, they were the last echo of a tab
 strip. Nothing else may be added to it; new controls go in the sidebar header or
-the console header. The sidebar header is 40px too, so the two line up
+the console header. The save/discard pair is the one exception, and it earned it
+by belonging to the file the trigger just named rather than to the window — it is
+absent whenever there is nothing unsaved, which is most of the time. The sidebar header is 40px too, so the two line up
 across the seam, and the macOS traffic lights stay in it (the row takes over the
 inset only when the sidebar is collapsed).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,12 +115,13 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   the ✕. The menu survives for the rarer items. A **saved** row keeps only the
   kebab: taking a file off disk is not the loop this is for, and it still asks
   first.
-- **Rows reserve their trailing slot.** `TreeView.TrailingVisual` is a fixed 24px
-  whether or not it holds anything, so a label's truncation point doesn't move
-  under the cursor when the row grows a kebab on hover. Three buttons don't fit
-  in that slot beside a leading glyph in a 22px row, so the one row that carries
-  three — an unsaved script — widens the slot and **spends its dot** to seat
-  them, and only for as long as the cursor is on it.
+- **Nothing in a row moves under the cursor.** `TreeView.TrailingVisual` is a
+  fixed 24px whether or not it holds anything, so a label's truncation point
+  doesn't shift when the row grows a kebab on hover; the row that carries three
+  buttons widens that slot instead, and **keeps its leading dot** — trading the
+  dot for 11px was tried and it makes the label jump exactly as you reach for it.
+  A label truncating a little sooner is the cheaper cost, and it is what
+  truncation is for.
 - **The pile has a size and two verbs.** The `Scripts` header states how many
   scripts there are, and how many of them are unsaved, in amber. Under the cursor
   that count becomes **save them all** and **discard the unsaved**, each confirmed
@@ -134,9 +135,14 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   absent — not disabled — once there is nothing unsaved, so a saved file's row is
   just its name and Run. Same two verbs as the sidebar row, so the model stays
   single; they answer different moments (mid-edit, versus tidying up after).
-- **The web is the same app minus one verb.** Scratches are IndexedDB on both
-  platforms, so the list, the titles and the history are identical; only Save is
-  missing, because only the desktop has a disk to write to.
+- **The web is the same app minus one verb, and minus the state that verb
+  produces.** Scratches are IndexedDB on both platforms, so the list, the titles
+  and the history are identical; only Save is missing, because only the desktop
+  has a disk to write to. So the **dot, the amber count and the word "unsaved"
+  are desktop-only** — on the web every row is in the same state, and a mark
+  every row carries marks nothing. The command row's save/discard pair goes with
+  them: it is defined by collapsing away when there is nothing unsaved, and on
+  the web it never could.
 
 ## The tree is an index, so it reads as a list of names
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,7 +5,7 @@ import { Dialog } from "./components/dialog";
 import { FormControl } from "./components/form-control";
 import { IconButton } from "./components/icon-button";
 import { Input } from "./components/input";
-import { Braces, Code, FileCode, PenLine, ScrollText } from "lucide-react";
+import { Braces, Code, FileCode, PenLine, Save as SaveIcon, ScrollText, X } from "lucide-react";
 import * as monaco from "monaco-editor";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "./cn";
@@ -41,7 +41,7 @@ import { AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
 import { appendCall, createScratch, isUntouched, markRun, pruneScratches, Scratch, takeOver, withCode } from "./scratches";
-import { deriveScratchTitle } from "./scratchTitle";
+import { deriveScratchTitle, proposeFileName, proposeFileNames } from "./scratchTitle";
 import { generateMethodEditorCode } from "./appLoader";
 import { RunButton, useSyntaxErrors } from "./RunButton";
 import { Sidebar, TRAFFIC_LIGHTS_INSET } from "./Sidebar";
@@ -121,11 +121,6 @@ const MAX_EDITOR_HEIGHT_RATIO = 0.55;
 // gives it the full width instead.
 const SIDE_BY_SIDE_MIN_WIDTH = 1600;
 
-// Lowercase the first letter (e.g. method name "GetUser" -> "getUser").
-function lowerFirst(s: string): string {
-  return s ? s.charAt(0).toLowerCase() + s.slice(1) : s;
-}
-
 // Compare the parts of an app's configuration that require recompilation when
 // changed: its type and parameters. Headers are excluded.
 function appNeedsRecompile(a: ConfigurationApp, b: ConfigurationApp): boolean {
@@ -185,7 +180,8 @@ export function App() {
   const [views, setViews] = useState<View[]>(() =>
     restoreViews(getPersistedValue<PersistedViewState>("views"), getPersistedValue<Scratch[]>("scratches") ?? []),
   );
-  const [sidebarWidth, setSidebarWidth] = usePersistedState("sidebarWidth", 300);
+  // A tree of names at 22px a row needs less width than one of icons at 34px.
+  const [sidebarWidth, setSidebarWidth] = usePersistedState("sidebarWidth", 240);
   const [sidebarCollapsed, setSidebarCollapsed] = usePersistedState("sidebarCollapsed", false);
   const sidebarCollapsedRef = useRef(sidebarCollapsed);
   sidebarCollapsedRef.current = sidebarCollapsed;
@@ -224,6 +220,8 @@ export function App() {
   const hasViewMemory = useRef(getPersistedValue<PersistedViewState>("views") !== undefined);
   const viewsRestoredRef = useRef(views.some((tab) => tab.type === "scratch"));
   const [scripts, setScripts] = useState<Script[]>();
+  const scriptsRef = useRef(scripts);
+  scriptsRef.current = scripts;
   // "Preview Apps" toggle: reveals the experimental built-in app types in the New
   // dialog (openapi/openai/markdown). gRPC/Twirp are always available.
   const [previewApps, setPreviewApps] = usePersistedState("featurePreview:previewApps", false);
@@ -269,6 +267,9 @@ export function App() {
   const [renameScript, setRenameScript] = useState<{ script: Script; name: string } | null>(null);
   const [renameError, setRenameError] = useState<string>();
   const [deleteScript, setDeleteScript] = useState<Script | null>(null);
+  // The Scripts header's bulk verbs, each confirmed against the list it is about
+  // to act on. Nothing here can reach a saved script.
+  const [bulkScratches, setBulkScratches] = useState<{ verb: "save" | "discard"; scratches: Scratch[] } | null>(null);
   // Path of the script pinned to the macOS "Run Kaja Script" text service.
   const [pinnedScriptPath, setPinnedScriptPath] = useState<string | undefined>(() => getPersistedValue<string>("contextMenuScriptPath"));
   // The run in flight, if any: which tab issued it, when it started, and the
@@ -1124,32 +1125,65 @@ export function App() {
     if (!isWailsEnvironment()) return;
     const tab = viewsRef.current[0];
     if (!tab || (tab.type !== "scratch" && tab.type !== "script")) return;
-    const defaultName =
-      tab.type === "scratch"
-        ? lowerFirst(
-            viewIdentity(tab, scratchesRef.current)
-              .name.replace(/[^A-Za-z0-9]+/g, " ")
-              .trim()
-              .split(" ")[0] || "scratch",
-          )
-        : tab.script.name.replace(/\.ts$/, "");
+    const defaultName = tab.type === "scratch" ? proposeFileName(viewIdentity(tab, scratchesRef.current).name) : tab.script.name.replace(/\.ts$/, "");
     setSaveAsError(undefined);
     setSaveAs({ name: defaultName, content: tab.model.getValue(), fromScratchId: tab.type === "scratch" ? tab.scratchId : undefined });
   }, []);
 
   const onSaveScratch = useCallback((scratch: Scratch) => {
     setSaveAsError(undefined);
-    setSaveAs({
-      name: lowerFirst(
-        scratch.title
-          .replace(/[^A-Za-z0-9]+/g, " ")
-          .trim()
-          .split(" ")[0] || "scratch",
-      ),
-      content: scratch.code,
-      fromScratchId: scratch.id,
-    });
+    setSaveAs({ name: proposeFileName(scratch.title), content: scratch.code, fromScratchId: scratch.id });
   }, []);
+
+  // "How do I dump everything I'm not keeping" — one click, and the confirm says
+  // exactly what goes and what stays. Saved scripts are out of scope by
+  // construction, so the destructive half can't reach a file.
+  const onDiscardAllScratches = useCallback(() => {
+    if (scratchesRef.current.length > 0) setBulkScratches({ verb: "discard", scratches: scratchesRef.current });
+  }, []);
+
+  const onSaveAllScratches = useCallback(() => {
+    if (scratchesRef.current.length > 0) setBulkScratches({ verb: "save", scratches: scratchesRef.current });
+  }, []);
+
+  const onConfirmBulkScratches = useCallback(
+    async (verb: "save" | "discard", list: Scratch[]) => {
+      const ids = new Set(list.map((scratch) => scratch.id));
+      if (verb === "discard") {
+        applyViews((views) => views.filter((view) => !(view.type === "scratch" && ids.has(view.scratchId))));
+        applyScratches((current) => current.filter((scratch) => !ids.has(scratch.id)));
+        return;
+      }
+      // Bulk save names each file from its own title, disambiguating against
+      // what is already on disk and against the ones written a moment ago.
+      const names = proposeFileNames(
+        list.map((scratch) => scratch.title),
+        (scriptsRef.current ?? []).map((script) => script.name),
+      );
+      const written: Script[] = [];
+      const saved = new Set<string>();
+      for (const [index, scratch] of list.entries()) {
+        try {
+          const file = await CreateScript(names[index], scratch.code);
+          if (!file) continue;
+          written.push({ path: file.path, name: file.name });
+          saved.add(scratch.id);
+        } catch (err) {
+          showFileError(`Save failed: ${err}`);
+          break;
+        }
+      }
+      if (written.length > 0) {
+        setScripts((prev) => [...(prev ?? []), ...written].sort((a, b) => a.name.localeCompare(b.name)));
+      }
+      if (saved.size > 0) {
+        // Each scratch became its file, so it doesn't linger as a copy.
+        applyViews((views) => views.filter((view) => !(view.type === "scratch" && saved.has(view.scratchId))));
+        applyScratches((current) => current.filter((scratch) => !saved.has(scratch.id)));
+      }
+    },
+    [applyScratches, applyViews, showFileError],
+  );
 
   const onRequestSaveAsScriptRef = useRef(onRequestSaveAsScript);
   onRequestSaveAsScriptRef.current = onRequestSaveAsScript;
@@ -1819,6 +1853,48 @@ export function App() {
     return files;
   }, [scratches, scripts, onScratchSelect, onScriptSelect]);
 
+  // The pair you reach for mid-edit, beside the name of what it acts on: a dot
+  // that says this isn't on disk, Save, and a discard that closes the file with
+  // it. All three collapse away once there is nothing unsaved, so the row is
+  // just name + Run for a file that has one.
+  const unsavedView = currentView?.type === "scratch" ? scratches.find((scratch) => scratch.id === currentView.scratchId) : undefined;
+  const fileActions = unsavedView ? (
+    <div className="flex shrink-0 items-center gap-1">
+      <span aria-hidden title="Not saved" className="size-[5px] shrink-0 rounded-full bg-amber-500" />
+      {isWailsEnvironment() && (
+        <button
+          type="button"
+          onClick={onRequestSaveAsScript}
+          className="flex h-6 items-center gap-1.5 rounded-md bg-muted px-2 text-xs text-foreground hover:bg-accent"
+        >
+          <SaveIcon size={12} />
+          Save
+          <span className="font-mono text-muted-foreground">{navigator.platform.startsWith("Mac") ? "⌘S" : "Ctrl+S"}</span>
+        </button>
+      )}
+      <IconButton
+        icon={X}
+        aria-label={`Discard ${unsavedView.title}`}
+        variant="ghost"
+        size="sm"
+        className="size-6 [&_svg]:size-[13px]"
+        onClick={() => onDiscardScratch(unsavedView)}
+      />
+    </div>
+  ) : undefined;
+
+  // The filenames a bulk save would write, so the confirm lists what it does.
+  const bulkNames = useMemo(
+    () =>
+      bulkScratches?.verb === "save"
+        ? proposeFileNames(
+            bulkScratches.scratches.map((scratch) => scratch.title),
+            (scripts ?? []).map((script) => script.name),
+          )
+        : [],
+    [bulkScratches, scripts],
+  );
+
   // Stop aborts what the button is showing, so it tracks the active run rather
   // than the file's in-flight state — a run started elsewhere says so in the
   // sidebar instead.
@@ -1886,6 +1962,8 @@ export function App() {
                 onScratchSelect={onScratchSelect}
                 onDeleteScratch={onDiscardScratch}
                 onSaveScratch={isWailsEnvironment() ? onSaveScratch : undefined}
+                onSaveAllScratches={isWailsEnvironment() ? onSaveAllScratches : undefined}
+                onDiscardAllScratches={onDiscardAllScratches}
                 onShowAllScratches={() => setFinder("first")}
                 currentScriptPath={currentView?.type === "script" ? currentView.script.path : undefined}
                 onShowCompileLog={onShowCompileLog}
@@ -1915,6 +1993,7 @@ export function App() {
                   highlightPrevious={finder === "previous"}
                 />
               }
+              fileActions={fileActions}
               action={action}
               onSearch={() => setFinder("first")}
               layout={editorLayout}
@@ -2162,6 +2241,43 @@ export function App() {
           }}
         >
           Permanently delete <strong>{deleteScript.name}</strong>?
+        </ConfirmationDialog>
+      )}
+      {/* The bulk verbs name every script they are about to touch, and say that
+          the saved ones are kept — which is the whole reason clearing the pile
+          is safe to offer in one click. */}
+      {bulkScratches && (
+        <ConfirmationDialog
+          title={
+            bulkScratches.verb === "discard"
+              ? `Discard ${bulkScratches.scratches.length} unsaved ${bulkScratches.scratches.length === 1 ? "script" : "scripts"}?`
+              : `Save ${bulkScratches.scratches.length} unsaved ${bulkScratches.scratches.length === 1 ? "script" : "scripts"}?`
+          }
+          confirmButtonContent={bulkScratches.verb === "discard" ? "Discard" : "Save"}
+          confirmButtonType={bulkScratches.verb === "discard" ? "danger" : "primary"}
+          onClose={(gesture) => {
+            const pending = bulkScratches;
+            setBulkScratches(null);
+            if (gesture === "confirm" && pending) void onConfirmBulkScratches(pending.verb, pending.scratches);
+          }}
+        >
+          <span className="flex flex-col gap-1">
+            {/* The history is unlimited, so the list scrolls rather than growing
+                the dialog past the buttons. */}
+            <span className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+              {bulkScratches.scratches.map((scratch, index) => (
+                <span key={scratch.id} className="flex items-center gap-2">
+                  <span aria-hidden className="size-[5px] shrink-0 rounded-full bg-amber-500" />
+                  <span className="truncate font-mono text-xs">{bulkScratches.verb === "save" ? `${bulkNames[index]}.ts` : scratch.title}</span>
+                </span>
+              ))}
+            </span>
+            {(scripts?.length ?? 0) > 0 && bulkScratches.verb === "discard" && (
+              <span className="mt-1 text-xs">
+                {scripts!.length === 1 ? `${scripts![0].name} is saved and will be kept.` : `${scripts!.length} saved scripts will be kept.`}
+              </span>
+            )}
+          </span>
         </ConfirmationDialog>
       )}
       {fileError && (

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1856,12 +1856,13 @@ export function App() {
   // The pair you reach for mid-edit, beside the name of what it acts on: a dot
   // that says this isn't on disk, Save, and a discard that closes the file with
   // it. All three collapse away once there is nothing unsaved, so the row is
-  // just name + Run for a file that has one.
+  // just name + Run for a file that has one — which is also why the whole group
+  // is absent on the web, where there is no Save and it could never collapse.
   const unsavedView = currentView?.type === "scratch" ? scratches.find((scratch) => scratch.id === currentView.scratchId) : undefined;
-  const fileActions = unsavedView ? (
-    <div className="flex shrink-0 items-center gap-1">
-      <span aria-hidden title="Not saved" className="size-[5px] shrink-0 rounded-full bg-amber-500" />
-      {isWailsEnvironment() && (
+  const fileActions =
+    unsavedView && isWailsEnvironment() ? (
+      <div className="flex shrink-0 items-center gap-1">
+        <span aria-hidden title="Not on disk" className="size-[5px] shrink-0 rounded-full bg-amber-500" />
         <button
           type="button"
           onClick={onRequestSaveAsScript}
@@ -1871,17 +1872,16 @@ export function App() {
           Save
           <span className="font-mono text-muted-foreground">{navigator.platform.startsWith("Mac") ? "⌘S" : "Ctrl+S"}</span>
         </button>
-      )}
-      <IconButton
-        icon={X}
-        aria-label={`Discard ${unsavedView.title}`}
-        variant="ghost"
-        size="sm"
-        className="size-6 [&_svg]:size-[13px]"
-        onClick={() => onDiscardScratch(unsavedView)}
-      />
-    </div>
-  ) : undefined;
+        <IconButton
+          icon={X}
+          aria-label={`Discard ${unsavedView.title}`}
+          variant="ghost"
+          size="sm"
+          className="size-6 [&_svg]:size-[13px]"
+          onClick={() => onDiscardScratch(unsavedView)}
+        />
+      </div>
+    ) : undefined;
 
   // The filenames a bulk save would write, so the confirm lists what it does.
   const bulkNames = useMemo(
@@ -2249,9 +2249,13 @@ export function App() {
       {bulkScratches && (
         <ConfirmationDialog
           title={
-            bulkScratches.verb === "discard"
-              ? `Discard ${bulkScratches.scratches.length} unsaved ${bulkScratches.scratches.length === 1 ? "script" : "scripts"}?`
-              : `Save ${bulkScratches.scratches.length} unsaved ${bulkScratches.scratches.length === 1 ? "script" : "scripts"}?`
+            bulkScratches.verb === "save"
+              ? `Save ${bulkScratches.scratches.length} unsaved ${bulkScratches.scratches.length === 1 ? "script" : "scripts"}?`
+              : // Nothing is on disk on the web, so there is no "unsaved" subset
+                // to name — it is simply all of them.
+                `Discard ${bulkScratches.scratches.length} ${isWailsEnvironment() ? "unsaved " : ""}${
+                  bulkScratches.scratches.length === 1 ? "script" : "scripts"
+                }?`
           }
           confirmButtonContent={bulkScratches.verb === "discard" ? "Discard" : "Save"}
           confirmButtonType={bulkScratches.verb === "discard" ? "danger" : "primary"}
@@ -2267,7 +2271,7 @@ export function App() {
             <span className="flex max-h-48 flex-col gap-1 overflow-y-auto">
               {bulkScratches.scratches.map((scratch, index) => (
                 <span key={scratch.id} className="flex items-center gap-2">
-                  <span aria-hidden className="size-[5px] shrink-0 rounded-full bg-amber-500" />
+                  {isWailsEnvironment() && <span aria-hidden className="size-[5px] shrink-0 rounded-full bg-amber-500" />}
                   <span className="truncate font-mono text-xs">{bulkScratches.verb === "save" ? `${bulkNames[index]}.ts` : scratch.title}</span>
                 </span>
               ))}

--- a/ui/src/CommandRow.tsx
+++ b/ui/src/CommandRow.tsx
@@ -11,6 +11,10 @@ interface CommandRowProps {
   onToggleSidebar: () => void;
   // The finder's trigger; it owns its own popover.
   finder: React.ReactNode;
+  // Save and discard for the file being edited, next to its name. Absent
+  // entirely once there is nothing to save — this is the pair you reach for
+  // mid-edit, not a permanent fixture.
+  fileActions?: React.ReactNode;
   // What you do with the current file: Run for a script, the JSON toggle for a
   // form. A file is never both, so they share the slot and the row keeps its
   // shape.
@@ -21,9 +25,10 @@ interface CommandRowProps {
 }
 
 // One 40px row instead of a top bar and a tab strip: sidebar toggle · finder ·
-// spacer · action · hairline · search · layout. Nothing else may be added to it
-// — new controls go in the sidebar header or the console header.
-export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finder, action, onSearch, layout, onToggleLayout }: CommandRowProps) {
+// the file's own save/discard · spacer · action · hairline · search · layout.
+// Nothing else may be added to it — new controls go in the sidebar header or the
+// console header.
+export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finder, fileActions, action, onSearch, layout, onToggleLayout }: CommandRowProps) {
   const modifier = navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+";
 
   return (
@@ -44,6 +49,7 @@ export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finde
           />
         </SimpleTooltip>
         {finder}
+        {fileActions}
       </div>
       <div className="flex-1" />
       <div className="flex shrink-0 items-center gap-2" style={{ "--wails-draggable": "no-drag" } as React.CSSProperties}>

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "./components/spinner";
 import { TreeView } from "./components/tree-view";
 import {
   Braces,
+  Check,
   CircleX,
   FileCode,
   FoldVertical,
@@ -13,16 +14,16 @@ import {
   Pin,
   Plus,
   RotateCw,
+  Save,
   Settings,
   Trash2,
   TriangleAlert,
   UnfoldVertical,
   ChevronRight,
-  Package,
   Ellipsis,
-  PenLine,
   Plus as PlusIcon,
   X,
+  type LucideIcon,
 } from "lucide-react";
 import { appType, getAppType } from "./appTypes";
 import { SimpleTooltip } from "./components/tooltip";
@@ -57,6 +58,46 @@ function groupServicesByPackage(services: Service[]): [string, Service[]][] {
 const RECENT_SCRATCHES = 6;
 
 const pillClass = "ml-1.5 rounded bg-accent px-[5px] py-px text-[9px] font-bold text-accent-foreground";
+
+// A section header is a row of the same height as the rows under it — the tree
+// is an index, and an index reads as a list of names.
+const SECTION_ROW = "flex h-[22px] cursor-pointer select-none items-center gap-1.5 px-2 text-xs font-medium text-foreground";
+
+// Small enough to sit inside a 22px row, which is what lets the frequent verbs
+// live on the row instead of behind a menu.
+const ROW_ACTION = "size-[18px] min-h-0 min-w-0 [&_svg]:size-3";
+
+/**
+ * Whether a script is on disk, in five pixels. It replaces the file icon the row
+ * used to carry: the icon spent 13px saying what a dot says, and the row needs
+ * the width more than the drawing.
+ */
+function ScriptDot({ saved, dim }: { saved?: boolean; dim?: boolean }) {
+  return (
+    <span
+      aria-hidden
+      title={saved ? "Saved" : "Not saved"}
+      className={cn("size-[5px] shrink-0 rounded-full", saved ? "bg-muted-foreground opacity-50" : "bg-amber-500", dim && "opacity-40")}
+    />
+  );
+}
+
+function RowAction({ icon, label, onClick }: { icon: LucideIcon; label: string; onClick: (event: React.MouseEvent) => void }) {
+  return (
+    <IconButton
+      size="xs"
+      variant="ghost"
+      tooltip={false}
+      aria-label={label}
+      icon={icon}
+      className={ROW_ACTION}
+      onClick={(event: React.MouseEvent) => {
+        event.stopPropagation();
+        onClick(event);
+      }}
+    />
+  );
+}
 
 // An app's type is its icon, the same one its New entry and its settings tab
 // carry. The word is a hover away for whoever needs it.
@@ -97,6 +138,10 @@ interface SidebarProps {
   onScratchSelect?: (scratch: Scratch) => void;
   onDeleteScratch?: (scratch: Scratch) => void;
   onSaveScratch?: (scratch: Scratch) => void;
+  // The bulk verbs on the Scripts header. They only ever touch the unsaved ones,
+  // so clearing the pile is safe by construction.
+  onSaveAllScratches?: () => void;
+  onDiscardAllScratches?: () => void;
   // Opens the finder on the full list.
   onShowAllScratches?: () => void;
   onScriptSelect?: (script: Script) => void;
@@ -132,6 +177,8 @@ export function Sidebar({
   onScratchSelect,
   onDeleteScratch,
   onSaveScratch,
+  onSaveAllScratches,
+  onDiscardAllScratches,
   onShowAllScratches,
   onScriptSelect,
   onRenameScript,
@@ -148,7 +195,11 @@ export function Sidebar({
 }: SidebarProps) {
   const hasScripts = (scripts?.length ?? 0) > 0;
   const hasScratches = (scratches?.length ?? 0) > 0;
+  const unsavedCount = scratches?.length ?? 0;
+  const scriptCount = (scripts?.length ?? 0) + unsavedCount;
   const [scriptsExpanded, setScriptsExpanded] = useState<boolean>(() => getPersistedValue<boolean>("scriptsExpanded") ?? true);
+  // The Scripts header trades its count for the bulk verbs while it is hovered.
+  const [scriptsHeaderHovered, setScriptsHeaderHovered] = useState(false);
   // Right-click context menu for a script, anchored at the cursor.
   const [scriptMenu, setScriptMenu] = useState<{ script: Script; top: number; left: number } | null>(null);
   const scriptMenuAnchorRef = useRef<HTMLDivElement>(null);
@@ -421,125 +472,166 @@ export function Sidebar({
           <IconButton icon={UnfoldVertical} size="sm" variant="ghost" aria-label="Unfold All" onClick={unfoldAll} />
         </div>
       </div>
-      <div style={{ flex: 1, overflowY: "auto", padding: "8px 12px", minHeight: 0 }}>
+      <div style={{ flex: 1, overflowY: "auto", padding: "4px 0", minHeight: 0 }}>
         {/* One list, not two. A script that has been saved and one that hasn't
             are the same kind of thing — the only difference is whether it is on
-            disk, which is what the icon says. Saved ones sit on top because they
+            disk, which is what the dot says. Saved ones sit on top because they
             are a library; the rest are recent work, and the whole history is a
             ⌘P away. */}
         {(hasScripts || hasScratches) && (
           <nav aria-label="Scripts">
             <div
-              className="-ml-3 flex h-7 cursor-pointer select-none items-center gap-0.5 pl-1 text-xs font-bold text-muted-foreground"
+              className={cn(SECTION_ROW, "hover:bg-accent/50")}
               onClick={() => setScriptsExpanded((v) => !v)}
+              onMouseEnter={() => setScriptsHeaderHovered(true)}
+              onMouseLeave={() => setScriptsHeaderHovered(false)}
             >
-              <span className={cn("inline-flex text-muted-foreground transition-transform duration-[120ms]", scriptsExpanded && "rotate-90")}>
-                <ChevronRight size={16} />
+              <ChevronRight size={12} className={cn("shrink-0 text-muted-foreground transition-transform duration-[120ms]", scriptsExpanded && "rotate-90")} />
+              <span className="truncate">Scripts</span>
+              {/* The pile of drafts is a number you can act on, so the header
+                  says how big it is and, under the cursor, offers the two verbs
+                  that only ever touch it. Saved scripts are never in scope. */}
+              {unsavedCount > 0 && <span className="shrink-0 text-amber-600 dark:text-amber-400">{unsavedCount} unsaved</span>}
+              <span className="ml-auto flex shrink-0 items-center gap-0.5">
+                {scriptsHeaderHovered && unsavedCount > 0 ? (
+                  <>
+                    {onSaveAllScratches && (
+                      <RowAction icon={Save} label={`Save ${unsavedCount} unsaved ${unsavedCount === 1 ? "script" : "scripts"}`} onClick={onSaveAllScratches} />
+                    )}
+                    {onDiscardAllScratches && (
+                      <RowAction
+                        icon={Trash2}
+                        label={`Discard ${unsavedCount} unsaved ${unsavedCount === 1 ? "script" : "scripts"}`}
+                        onClick={onDiscardAllScratches}
+                      />
+                    )}
+                  </>
+                ) : (
+                  scriptCount > 0 && <span className="pr-1 font-mono text-muted-foreground">{scriptCount}</span>
+                )}
               </span>
-              <FileCode size={16} />
-              <span className="ml-1">Scripts</span>
             </div>
             {scriptsExpanded && (
-              <TreeView aria-label="Scripts">
-                {(scripts ?? []).map((script) => (
-                  <TreeView.Item
-                    id={`script-${script.path}`}
-                    key={script.path}
-                    ref={(el: HTMLElement | null) => {
-                      // TreeView.Item doesn't forward these handlers, so attach them to the DOM node.
-                      if (el) {
-                        el.oncontextmenu = (e) => {
-                          e.preventDefault();
-                          setScriptMenu({ script, top: e.clientY, left: e.clientX });
-                        };
-                        el.onmouseenter = () => setHoveredScript(script.path);
-                        el.onmouseleave = () => setHoveredScript((prev) => (prev === script.path ? null : prev));
-                      }
-                    }}
-                    onSelect={() => onScriptSelect?.(script)}
-                    current={currentScriptPath === script.path}
-                  >
-                    {/* Pin lives in the leading slot so it never shifts when the kebab appears on
-                        hover, and it lines a pinned script up with the package/expand icons above. */}
-                    <TreeView.LeadingVisual>
-                      {runningFileIds?.has(script.path) ? (
-                        <Spinner className="size-3" />
-                      ) : pinnedScriptPath === script.path ? (
-                        <Pin size={12} />
-                      ) : (
-                        <FileCode size={13} />
-                      )}
-                    </TreeView.LeadingVisual>
-                    {script.name}
-                    <TreeView.TrailingVisual>
-                      {(hoveredScript === script.path || scriptMenu?.script.path === script.path) && (
-                        <IconButton
-                          size="xs"
-                          variant="ghost"
-                          tooltip={false}
-                          aria-label={`Actions for ${script.name}`}
-                          icon={Ellipsis}
-                          style={{ minHeight: 0, minWidth: 0 }}
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
+              <TreeView leaf aria-label="Scripts">
+                {(scripts ?? []).map((script) => {
+                  const active = hoveredScript === script.path || scriptMenu?.script.path === script.path;
+                  return (
+                    <TreeView.Item
+                      id={`script-${script.path}`}
+                      key={script.path}
+                      ref={(el: HTMLElement | null) => {
+                        // TreeView.Item doesn't forward these handlers, so attach them to the DOM node.
+                        if (el) {
+                          el.oncontextmenu = (e) => {
+                            e.preventDefault();
                             setScriptMenu({ script, top: e.clientY, left: e.clientX });
-                          }}
-                        />
-                      )}
-                    </TreeView.TrailingVisual>
-                  </TreeView.Item>
-                ))}
-                {(scratches ?? []).slice(0, RECENT_SCRATCHES).map((scratch) => (
-                  <TreeView.Item
-                    id={`scratch-${scratch.id}`}
-                    key={scratch.id}
-                    ref={(el: HTMLElement | null) => {
-                      if (el) {
-                        el.oncontextmenu = (e) => {
-                          e.preventDefault();
-                          setScratchMenu({ scratch, top: e.clientY, left: e.clientX });
-                        };
-                        el.onmouseenter = () => setHoveredScratch(scratch.id);
-                        el.onmouseleave = () => setHoveredScratch((prev) => (prev === scratch.id ? null : prev));
-                      }
-                    }}
-                    onSelect={() => onScratchSelect?.(scratch)}
-                    current={currentScratchId === scratch.id}
-                  >
-                    {/* Not saved: the pen is the whole difference. */}
-                    <TreeView.LeadingVisual>
-                      {runningFileIds?.has(scratch.id) ? (
-                        <Spinner className="size-3" />
-                      ) : (
-                        <PenLine size={13} className={cn(isUntouched(scratch) && "opacity-60")} />
-                      )}
-                    </TreeView.LeadingVisual>
-                    <ScratchLabel scratch={scratch} />
-                    <TreeView.TrailingVisual>
-                      {(hoveredScratch === scratch.id || scratchMenu?.scratch.id === scratch.id) && (
-                        <IconButton
-                          size="xs"
-                          variant="ghost"
-                          tooltip={false}
-                          aria-label={`Actions for ${scratch.title}`}
-                          icon={Ellipsis}
-                          style={{ minHeight: 0, minWidth: 0 }}
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
+                          };
+                          el.onmouseenter = () => setHoveredScript(script.path);
+                          el.onmouseleave = () => setHoveredScript((prev) => (prev === script.path ? null : prev));
+                        }
+                      }}
+                      onSelect={() => onScriptSelect?.(script)}
+                      // Scripts are the one part of the tree where the keyboard
+                      // may remove something: a file still asks first.
+                      onKeyDown={(event: React.KeyboardEvent) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          onScriptSelect?.(script);
+                        } else if ((event.key === "Backspace" || event.key === "Delete") && onDeleteScript) {
+                          event.preventDefault();
+                          onDeleteScript(script);
+                        }
+                      }}
+                      current={currentScriptPath === script.path}
+                    >
+                      {/* One button fits the reserved slot, so a saved row keeps
+                          its dot under the cursor. Pin takes the same place, and
+                          says the file answers the macOS service. */}
+                      <TreeView.LeadingVisual>
+                        {runningFileIds?.has(script.path) ? (
+                          <Spinner className="size-3" />
+                        ) : pinnedScriptPath === script.path ? (
+                          <Pin size={12} />
+                        ) : (
+                          <ScriptDot saved />
+                        )}
+                      </TreeView.LeadingVisual>
+                      {script.name}
+                      <TreeView.TrailingVisual>
+                        {active && (
+                          <RowAction
+                            icon={Ellipsis}
+                            label={`Actions for ${script.name}`}
+                            onClick={(e) => setScriptMenu({ script, top: e.clientY, left: e.clientX })}
+                          />
+                        )}
+                      </TreeView.TrailingVisual>
+                    </TreeView.Item>
+                  );
+                })}
+                {(scratches ?? []).slice(0, RECENT_SCRATCHES).map((scratch) => {
+                  const active = hoveredScratch === scratch.id || scratchMenu?.scratch.id === scratch.id;
+                  return (
+                    <TreeView.Item
+                      id={`scratch-${scratch.id}`}
+                      key={scratch.id}
+                      ref={(el: HTMLElement | null) => {
+                        if (el) {
+                          el.oncontextmenu = (e) => {
+                            e.preventDefault();
                             setScratchMenu({ scratch, top: e.clientY, left: e.clientX });
-                          }}
-                        />
+                          };
+                          el.onmouseenter = () => setHoveredScratch(scratch.id);
+                          el.onmouseleave = () => setHoveredScratch((prev) => (prev === scratch.id ? null : prev));
+                        }
+                      }}
+                      onSelect={() => onScratchSelect?.(scratch)}
+                      // Discarding one costs nothing and is taken back for eight
+                      // seconds, so the key can do it without asking.
+                      onKeyDown={(event: React.KeyboardEvent) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          onScratchSelect?.(scratch);
+                        } else if (event.key === "Backspace" || event.key === "Delete") {
+                          event.preventDefault();
+                          onDeleteScratch?.(scratch);
+                        }
+                      }}
+                      current={currentScratchId === scratch.id}
+                    >
+                      {/* Three buttons don't fit beside the dot in 22px, so the
+                          row spends the dot to seat them — it is only ever gone
+                          while the cursor is on the row, which is when the state
+                          it reports is the least of what the row is saying. */}
+                      {!active && (
+                        <TreeView.LeadingVisual>
+                          {runningFileIds?.has(scratch.id) ? <Spinner className="size-3" /> : <ScriptDot dim={isUntouched(scratch)} />}
+                        </TreeView.LeadingVisual>
                       )}
-                    </TreeView.TrailingVisual>
-                  </TreeView.Item>
-                ))}
+                      <ScratchLabel scratch={scratch} />
+                      <TreeView.TrailingVisual className={active ? "w-auto gap-0.5" : undefined}>
+                        {active && (
+                          <>
+                            {onSaveScratch && <RowAction icon={Check} label={`Save ${scratch.title}`} onClick={() => onSaveScratch(scratch)} />}
+                            <RowAction icon={X} label={`Discard ${scratch.title}`} onClick={() => onDeleteScratch?.(scratch)} />
+                            <RowAction
+                              icon={Ellipsis}
+                              label={`Actions for ${scratch.title}`}
+                              onClick={(e) => setScratchMenu({ scratch, top: e.clientY, left: e.clientX })}
+                            />
+                          </>
+                        )}
+                      </TreeView.TrailingVisual>
+                    </TreeView.Item>
+                  );
+                })}
                 {(scratches?.length ?? 0) > RECENT_SCRATCHES && (
                   <li role="treeitem">
                     <div
                       onClick={onShowAllScratches}
-                      className="flex h-7 cursor-pointer items-center rounded-md pl-2 text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                      className="flex h-[22px] cursor-pointer items-center pl-2 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
                     >
-                      Show all {(scripts?.length ?? 0) + (scratches?.length ?? 0)}…
+                      Show all {scriptCount}…
                     </div>
                   </li>
                 )}
@@ -550,12 +642,11 @@ export function Sidebar({
         {/* Your scripts and the API's catalog are two different lists, and two
             rows can carry the same name across the seam. A rule keeps nobody
             reading them as one. */}
-        {(hasScripts || hasScratches) && apps.length > 0 && <div className="mx-[-4px] mt-3 h-px bg-border" />}
-        {apps.map((app, appIndex) => {
+        {(hasScripts || hasScratches) && apps.length > 0 && <div className="my-1 h-px bg-border" />}
+        {apps.map((app) => {
           const appName = app.configuration.name;
           const isExpanded = expandedApps.has(appName);
-          const showAppHeader = true;
-          const showTopMargin = appIndex > 0 || hasScripts || hasScratches;
+          const active = hoveredApp === appName || appMenu?.appName === appName;
 
           return (
             <nav
@@ -565,48 +656,32 @@ export function Sidebar({
                 else elementRefs.current.delete(appName);
               }}
               aria-label="Services and methods"
-              style={{ marginTop: showTopMargin ? 12 : 0 }}
             >
-              {showAppHeader && (
-                <div
-                  className={cn(
-                    "-ml-3 flex h-7 cursor-pointer select-none items-center justify-between rounded-md px-1 text-xs font-bold text-muted-foreground",
-                    (hoveredApp === appName || appMenu?.appName === appName) && "bg-accent",
+              {/* The app keeps its icon: it is the one place in the tree where
+                  the glyph says something the indent can't — gRPC or OpenAPI or
+                  Markdown. Everything below repeats itself, so it goes. */}
+              <div
+                className={cn(SECTION_ROW, active ? "bg-accent" : "hover:bg-accent/50")}
+                onMouseEnter={() => setHoveredApp(appName)}
+                onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
+                onClick={() => toggleAppExpanded(appName)}
+                onContextMenu={(e: React.MouseEvent) => {
+                  e.preventDefault();
+                  setAppMenu({ appName, top: e.clientY, left: e.clientX });
+                }}
+              >
+                <ChevronRight size={12} className={cn("shrink-0 text-muted-foreground transition-transform duration-[120ms]", isExpanded && "rotate-90")} />
+                <AppTypeIcon type={appType(app.configuration)} size={13} />
+                <span className="truncate">{appName}</span>
+                <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
+                <span className="ml-auto flex w-6 shrink-0 items-center justify-center">
+                  {active && (
+                    <RowAction icon={Ellipsis} label={`Actions for ${appName}`} onClick={(e) => setAppMenu({ appName, top: e.clientY, left: e.clientX })} />
                   )}
-                  onMouseEnter={() => setHoveredApp(appName)}
-                  onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
-                  onClick={() => toggleAppExpanded(appName)}
-                  onContextMenu={(e: React.MouseEvent) => {
-                    e.preventDefault();
-                    setAppMenu({ appName, top: e.clientY, left: e.clientX });
-                  }}
-                >
-                  <span className="flex items-center gap-0.5">
-                    <span className={cn("inline-flex text-muted-foreground transition-transform duration-[120ms]", isExpanded && "rotate-90")}>
-                      <ChevronRight size={16} />
-                    </span>
-                    <AppTypeIcon type={appType(app.configuration)} />
-                    <span className="ml-1">{appName}</span>
-                    <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
-                  </span>
-                  {(hoveredApp === appName || appMenu?.appName === appName) && (
-                    <IconButton
-                      size="xs"
-                      variant="ghost"
-                      tooltip={false}
-                      aria-label={`Actions for ${appName}`}
-                      icon={Ellipsis}
-                      style={{ minHeight: 0, minWidth: 0 }}
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        setAppMenu({ appName, top: e.clientY, left: e.clientX });
-                      }}
-                    />
-                  )}
-                </div>
-              )}
-              {(isExpanded || !showAppHeader) && (
-                <TreeView aria-label="Services and methods">
+                </span>
+              </div>
+              {isExpanded && (
+                <TreeView guide aria-label="Services and methods">
                   {app.compilation.status === "running" || app.compilation.status === "pending" ? (
                     <LoadingTreeViewItem />
                   ) : (
@@ -640,7 +715,7 @@ export function Sidebar({
                             }}
                           >
                             {service.name}
-                            <TreeView.SubTree>
+                            <TreeView.SubTree leaf>
                               {service.methods.map((method) => {
                                 const mId = methodId(service, method);
                                 return (
@@ -663,16 +738,10 @@ export function Sidebar({
                                           deliberate, so it gets its own target rather than
                                           happening because you clicked in the wrong mood. */}
                                       {hoveredMethod === mId && (
-                                        <IconButton
-                                          size="xs"
-                                          variant="ghost"
-                                          aria-label={`Add ${method.name} to the open scratch`}
+                                        <RowAction
                                           icon={PlusIcon}
-                                          style={{ minHeight: 0, minWidth: 0 }}
-                                          onClick={(e: React.MouseEvent) => {
-                                            e.stopPropagation();
-                                            onSelect(method, service, app, "append");
-                                          }}
+                                          label={`Add ${method.name} to the open scratch`}
+                                          onClick={() => onSelect(method, service, app, "append")}
                                         />
                                       )}
                                     </TreeView.TrailingVisual>
@@ -713,10 +782,10 @@ export function Sidebar({
                               if (expanded) scrollIntoView(packageId);
                             }}
                           >
-                            <TreeView.LeadingVisual>
-                              <Package size={16} />
-                            </TreeView.LeadingVisual>
-                            <span className="font-normal text-muted-foreground">{packageName}</span>
+                            {/* No icon: every package row carried the same one,
+                                which is 20px per row spent saying what the guide
+                                already says. */}
+                            <span className="text-muted-foreground">{packageName}</span>
                             <TreeView.SubTree>{services.map(renderServiceItem)}</TreeView.SubTree>
                           </TreeView.Item>
                         );
@@ -879,13 +948,13 @@ function AppCompileMarker({ app, onShowCompileLog }: { app: App; onShowCompileLo
       type="button"
       title={label}
       aria-label={`${app.configuration.name}: ${label}. Show compile log`}
-      className={cn("ml-1.5 inline-flex items-center", failed ? "text-destructive" : "text-amber-600 dark:text-amber-400")}
+      className={cn("ml-1 inline-flex shrink-0 items-center", failed ? "text-destructive" : "text-amber-600 dark:text-amber-400")}
       onClick={(e: React.MouseEvent) => {
         e.stopPropagation();
         onShowCompileLog(app.configuration.name);
       }}
     >
-      {failed ? <CircleX size={13} /> : <TriangleAlert size={13} />}
+      {failed ? <CircleX size={12} /> : <TriangleAlert size={12} />}
     </button>
   );
 }
@@ -894,7 +963,7 @@ function LoadingTreeViewItem() {
   return (
     <TreeView.Item id="loading-tree-view-item" expanded={true}>
       Loading...
-      <TreeView.SubTree state="loading" count={3} />
+      <TreeView.SubTree state="loading" count={3} leaf />
     </TreeView.Item>
   );
 }

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -197,6 +197,10 @@ export function Sidebar({
   const hasScratches = (scratches?.length ?? 0) > 0;
   const unsavedCount = scratches?.length ?? 0;
   const scriptCount = (scripts?.length ?? 0) + unsavedCount;
+  // On disk versus not is only a distinction where there is a disk. The web has
+  // no Save, so every row is in the same state and the dot, the amber count and
+  // the word "unsaved" would all be marking a difference that can't exist.
+  const canSave = onSaveScratch !== undefined;
   const [scriptsExpanded, setScriptsExpanded] = useState<boolean>(() => getPersistedValue<boolean>("scriptsExpanded") ?? true);
   // The Scripts header trades its count for the bulk verbs while it is hovered.
   const [scriptsHeaderHovered, setScriptsHeaderHovered] = useState(false);
@@ -491,7 +495,7 @@ export function Sidebar({
               {/* The pile of drafts is a number you can act on, so the header
                   says how big it is and, under the cursor, offers the two verbs
                   that only ever touch it. Saved scripts are never in scope. */}
-              {unsavedCount > 0 && <span className="shrink-0 text-amber-600 dark:text-amber-400">{unsavedCount} unsaved</span>}
+              {canSave && unsavedCount > 0 && <span className="shrink-0 text-amber-600 dark:text-amber-400">{unsavedCount} unsaved</span>}
               <span className="ml-auto flex shrink-0 items-center gap-0.5">
                 {scriptsHeaderHovered && unsavedCount > 0 ? (
                   <>
@@ -501,7 +505,11 @@ export function Sidebar({
                     {onDiscardAllScratches && (
                       <RowAction
                         icon={Trash2}
-                        label={`Discard ${unsavedCount} unsaved ${unsavedCount === 1 ? "script" : "scripts"}`}
+                        label={
+                          canSave
+                            ? `Discard ${unsavedCount} unsaved ${unsavedCount === 1 ? "script" : "scripts"}`
+                            : `Discard all ${unsavedCount} ${unsavedCount === 1 ? "script" : "scripts"}`
+                        }
                         onClick={onDiscardAllScratches}
                       />
                     )}
@@ -599,11 +607,10 @@ export function Sidebar({
                       }}
                       current={currentScratchId === scratch.id}
                     >
-                      {/* Three buttons don't fit beside the dot in 22px, so the
-                          row spends the dot to seat them — it is only ever gone
-                          while the cursor is on the row, which is when the state
-                          it reports is the least of what the row is saying. */}
-                      {!active && (
+                      {/* The dot stays put under the cursor. Dropping it to seat
+                          the three buttons buys 11px the row doesn't need, and
+                          costs a label that moves as you reach for it. */}
+                      {canSave && (
                         <TreeView.LeadingVisual>
                           {runningFileIds?.has(scratch.id) ? <Spinner className="size-3" /> : <ScriptDot dim={isUntouched(scratch)} />}
                         </TreeView.LeadingVisual>

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -68,17 +68,32 @@ const SECTION_ROW = "flex h-[22px] cursor-pointer select-none items-center gap-1
 const ROW_ACTION = "size-[18px] min-h-0 min-w-0 [&_svg]:size-3";
 
 /**
- * Whether a script is on disk, in five pixels. It replaces the file icon the row
- * used to carry: the icon spent 13px saying what a dot says, and the row needs
- * the width more than the drawing.
+ * A script row's leading slot. It is the width of the run spinner whatever it
+ * currently holds, because all four things that can appear here — a run in the
+ * air, the pin, the on-disk dot, and nothing at all on the web — would otherwise
+ * move the label out from under the cursor as they swap.
+ *
+ * The dot itself replaced the file icon: a 5px mark is quieter than a drawing in
+ * a 22px row, which already spends a glyph on the app above it.
+ *
+ * It goes inside a `TreeView.LeadingVisual` and never wraps one — `TreeView.Item`
+ * picks its slots out by child type, so a wrapper lands the glyph in the label.
  */
-function ScriptDot({ saved, dim }: { saved?: boolean; dim?: boolean }) {
+function ScriptGlyph({ running, pinned, saved, dim, dot = true }: { running?: boolean; pinned?: boolean; saved?: boolean; dim?: boolean; dot?: boolean }) {
   return (
-    <span
-      aria-hidden
-      title={saved ? "Saved" : "Not saved"}
-      className={cn("size-[5px] shrink-0 rounded-full", saved ? "bg-muted-foreground opacity-50" : "bg-amber-500", dim && "opacity-40")}
-    />
+    <span className="flex size-3 items-center justify-center">
+      {running ? (
+        <Spinner className="size-3" />
+      ) : pinned ? (
+        <Pin size={12} />
+      ) : dot ? (
+        <span
+          aria-hidden
+          title={saved ? "On disk" : "Not on disk"}
+          className={cn("size-[5px] rounded-full", saved ? "bg-muted-foreground opacity-50" : "bg-amber-500", dim && "opacity-40")}
+        />
+      ) : null}
+    </span>
   );
 }
 
@@ -552,17 +567,8 @@ export function Sidebar({
                       }}
                       current={currentScriptPath === script.path}
                     >
-                      {/* One button fits the reserved slot, so a saved row keeps
-                          its dot under the cursor. Pin takes the same place, and
-                          says the file answers the macOS service. */}
                       <TreeView.LeadingVisual>
-                        {runningFileIds?.has(script.path) ? (
-                          <Spinner className="size-3" />
-                        ) : pinnedScriptPath === script.path ? (
-                          <Pin size={12} />
-                        ) : (
-                          <ScriptDot saved />
-                        )}
+                        <ScriptGlyph running={runningFileIds?.has(script.path)} pinned={pinnedScriptPath === script.path} saved dot={canSave} />
                       </TreeView.LeadingVisual>
                       {script.name}
                       <TreeView.TrailingVisual>
@@ -607,14 +613,12 @@ export function Sidebar({
                       }}
                       current={currentScratchId === scratch.id}
                     >
-                      {/* The dot stays put under the cursor. Dropping it to seat
-                          the three buttons buys 11px the row doesn't need, and
-                          costs a label that moves as you reach for it. */}
-                      {canSave && (
-                        <TreeView.LeadingVisual>
-                          {runningFileIds?.has(scratch.id) ? <Spinner className="size-3" /> : <ScriptDot dim={isUntouched(scratch)} />}
-                        </TreeView.LeadingVisual>
-                      )}
+                      {/* The slot stays whatever is in it. Dropping the dot to
+                          seat the three buttons buys 11px the row doesn't need,
+                          and costs a label that moves as you reach for it. */}
+                      <TreeView.LeadingVisual>
+                        <ScriptGlyph running={runningFileIds?.has(scratch.id)} dim={isUntouched(scratch)} dot={canSave} />
+                      </TreeView.LeadingVisual>
                       <ScratchLabel scratch={scratch} />
                       <TreeView.TrailingVisual className={active ? "w-auto gap-0.5" : undefined}>
                         {active && (

--- a/ui/src/components/tree-view.tsx
+++ b/ui/src/components/tree-view.tsx
@@ -4,17 +4,36 @@ import * as React from "react";
 import { cn } from "../cn";
 
 // Covers what the sidebar uses: controlled expand/collapse, a current
-// (selected) leaf, leading/trailing visuals, depth-based indentation, and a
-// loading SubTree. Rows toggle when they have a SubTree, otherwise they call
-// onSelect.
-const DepthContext = React.createContext(0);
-const INDENT = 16;
-const BASE_PADDING = 8;
+// (selected) leaf, leading/trailing visuals, and a loading SubTree. Rows toggle
+// when they have a SubTree, otherwise they call onSelect.
+//
+// Depth is drawn as a hairline rather than paid for in icons: a package and a
+// service repeat the same glyph on every row, so the column costs width to say
+// what the indent already says. Levels that branch nest inside a guide; a list
+// of leaves takes the indent without one, because a line nothing hangs off is
+// noise, and its rows drop the chevron slot they would never fill.
+const LeafContext = React.createContext(false);
 
-function TreeView({ children, ...props }: { children: React.ReactNode; "aria-label"?: string }) {
+const GUIDE = "relative pl-3.5 before:absolute before:inset-y-0 before:left-3.5 before:w-px before:bg-border before:content-['']";
+const LEAF = "pl-5";
+
+function TreeView({
+  children,
+  guide,
+  leaf,
+  ...props
+}: {
+  children: React.ReactNode;
+  // Nest the whole list under a hairline, for a tree hung off a header that is
+  // not itself an Item (an app in the sidebar).
+  guide?: boolean;
+  // A list that never branches, indented but unguided.
+  leaf?: boolean;
+  "aria-label"?: string;
+}) {
   return (
-    <ul role="tree" className="select-none" {...props}>
-      {children}
+    <ul role="tree" className={cn("select-none", guide && GUIDE, leaf && LEAF)} {...props}>
+      <LeafContext.Provider value={!!leaf}>{children}</LeafContext.Provider>
     </ul>
   );
 }
@@ -29,11 +48,13 @@ interface ItemProps {
   // Double click, the editor gesture for "I mean it": a single click opens a
   // preview, this opens for good.
   onActivate?: () => void;
+  // Makes the row focusable, for the rows that answer to a key of their own.
+  onKeyDown?: (event: React.KeyboardEvent) => void;
   children: React.ReactNode;
 }
 
-const Item = React.forwardRef<HTMLDivElement, ItemProps>(({ id, current, expanded, onExpandedChange, onSelect, onActivate, children }, ref) => {
-  const depth = React.useContext(DepthContext);
+const Item = React.forwardRef<HTMLDivElement, ItemProps>(({ id, current, expanded, onExpandedChange, onSelect, onActivate, onKeyDown, children }, ref) => {
+  const leaf = React.useContext(LeafContext);
 
   let leading: React.ReactNode = null;
   let trailing: React.ReactNode = null;
@@ -57,17 +78,21 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>(({ id, current, expande
       <div
         ref={ref}
         id={id}
+        tabIndex={onKeyDown ? 0 : undefined}
+        onKeyDown={onKeyDown}
         onClick={(event) => (hasSubtree ? onExpandedChange?.(!expanded) : onSelect?.(event))}
         onDoubleClick={hasSubtree ? undefined : onActivate}
         className={cn(
-          "group flex h-7 items-center gap-1.5 rounded-md pr-1.5 text-sm",
+          "group flex h-[22px] cursor-pointer items-center gap-1.5 pl-2 pr-1 text-xs outline-none",
           current ? "bg-accent text-accent-foreground" : "text-foreground hover:bg-accent/50",
+          "focus-visible:bg-accent/50",
         )}
-        style={{ paddingLeft: BASE_PADDING + depth * INDENT, cursor: "pointer" }}
       >
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-          {hasSubtree && <ChevronRight size={16} className={cn("transition-transform", expanded && "rotate-90")} />}
-        </span>
+        {!leaf && (
+          <span className="flex size-3 shrink-0 items-center justify-center text-muted-foreground">
+            {hasSubtree && <ChevronRight size={12} className={cn("transition-transform", expanded && "rotate-90")} />}
+          </span>
+        )}
         {leading}
         <span className="flex-1 truncate">
           {labels.map((label, index) => (
@@ -76,7 +101,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>(({ id, current, expande
         </span>
         {trailing}
       </div>
-      {hasSubtree && expanded && <DepthContext.Provider value={depth + 1}>{subtree}</DepthContext.Provider>}
+      {hasSubtree && expanded && subtree}
     </li>
   );
 });
@@ -85,26 +110,31 @@ Item.displayName = "TreeView.Item";
 interface SubTreeProps {
   state?: "initial" | "loading" | "done";
   count?: number;
+  leaf?: boolean;
   children?: React.ReactNode;
 }
 
-function SubTree({ state, count = 3, children }: SubTreeProps) {
-  const depth = React.useContext(DepthContext);
+function SubTree({ state, count = 3, leaf, children }: SubTreeProps) {
+  const className = cn("select-none", leaf ? LEAF : GUIDE);
   if (state === "loading") {
     return (
-      <ul role="group">
+      <ul role="group" className={className}>
         {Array.from({ length: count }).map((_, index) => (
           <li key={index} role="treeitem">
-            <div className="flex h-7 items-center gap-1.5 pr-1.5" style={{ paddingLeft: BASE_PADDING + depth * INDENT }}>
-              <span className="h-4 w-4 shrink-0" />
-              <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <div className="flex h-[22px] items-center gap-1.5 pl-2 pr-1">
+              <span className="size-3 shrink-0" />
+              <div className="h-2.5 w-24 animate-pulse rounded bg-muted" />
             </div>
           </li>
         ))}
       </ul>
     );
   }
-  return <ul role="group">{children}</ul>;
+  return (
+    <ul role="group" className={className}>
+      <LeafContext.Provider value={!!leaf}>{children}</LeafContext.Provider>
+    </ul>
+  );
 }
 
 function LeadingVisual({ children }: { children: React.ReactNode }) {
@@ -113,8 +143,10 @@ function LeadingVisual({ children }: { children: React.ReactNode }) {
 
 // The slot keeps its width whether or not it holds anything, so a row that grows
 // a kebab on hover doesn't move the label's truncation point under the cursor.
-function TrailingVisual({ children }: { children: React.ReactNode }) {
-  return <span className="ml-auto flex w-6 shrink-0 items-center justify-center">{children}</span>;
+// A row whose hover actions are several buttons wide overrides the width, and
+// buys the room back by dropping its leading glyph for as long as it is hovered.
+function TrailingVisual({ className, children }: { className?: string; children: React.ReactNode }) {
+  return <span className={cn("ml-auto flex w-6 shrink-0 items-center justify-center", className)}>{children}</span>;
 }
 
 TreeView.Item = Item;

--- a/ui/src/scratchTitle.test.ts
+++ b/ui/src/scratchTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { deriveScratchTitle, readCalls, titleParts } from "./scratchTitle";
+import { deriveScratchTitle, proposeFileName, proposeFileNames, readCalls, titleParts } from "./scratchTitle";
 
 const generated = (body: string, names = "TheKajaTheatre") => `import { ${names} } from "theatre/service";\n\n${body}\n`;
 
@@ -99,5 +99,34 @@ describe("titleParts", () => {
   it("leaves a bare name alone", () => {
     expect(titleParts("ListShows")).toEqual({ name: "ListShows" });
     expect(titleParts("ListShows → GetShow")).toEqual({ name: "ListShows → GetShow" });
+  });
+});
+
+describe("proposeFileName", () => {
+  it("takes the name and drops the qualifier, so the section keeps one convention", () => {
+    expect(proposeFileName("GetShow · vera-lune")).toBe("getShow");
+    expect(proposeFileName("Sum · 5, 3")).toBe("sum");
+    expect(proposeFileName("ListShows → GetShow")).toBe("listShows");
+  });
+
+  it("has something to call a scratch that names nothing", () => {
+    expect(proposeFileName("")).toBe("scratch");
+    expect(proposeFileName("· · ·")).toBe("scratch");
+  });
+
+  it("steps past what is already on disk, extension or not", () => {
+    expect(proposeFileName("GetShow", ["getShow.ts"])).toBe("getShow2");
+    expect(proposeFileName("GetShow", ["getShow.ts", "getShow2.ts"])).toBe("getShow3");
+    expect(proposeFileName("GetShow", ["GETSHOW.ts"])).toBe("getShow2");
+  });
+});
+
+describe("proposeFileNames", () => {
+  it("names a whole pile without collisions, so the confirm lists what gets written", () => {
+    expect(proposeFileNames(["GetShow · a", "GetShow · b", "ListShows"])).toEqual(["getShow", "getShow2", "listShows"]);
+  });
+
+  it("counts what is already on disk too", () => {
+    expect(proposeFileNames(["GetShow", "GetShow"], ["getShow.ts"])).toEqual(["getShow2", "getShow3"]);
   });
 });

--- a/ui/src/scratchTitle.ts
+++ b/ui/src/scratchTitle.ts
@@ -138,6 +138,39 @@ export function titleParts(title: string): { name: string; qualifier?: string } 
   return at === -1 ? { name: title } : { name: title.slice(0, at), qualifier: title.slice(at + 1) };
 }
 
+/**
+ * The filename a script is proposed under. Naming a script and saving it are the
+ * same act, so the derived title decides it and the section converges on one
+ * convention. `taken` settles collisions, which saving the whole pile at once
+ * produces even where saving one at a time wouldn't.
+ */
+export function proposeFileName(title: string, taken: Iterable<string> = []): string {
+  const word =
+    title
+      .replace(/[^A-Za-z0-9]+/g, " ")
+      .trim()
+      .split(" ")[0] || "scratch";
+  const base = word.charAt(0).toLowerCase() + word.slice(1);
+  const used = new Set([...taken].map((name) => name.replace(/\.ts$/, "").toLowerCase()));
+  if (!used.has(base.toLowerCase())) return base;
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${base}${suffix}`;
+    if (!used.has(candidate.toLowerCase())) return candidate;
+  }
+}
+
+// Names a whole pile at once, each one disambiguated against what is on disk and
+// against the ones named before it — so the list the confirm shows is the list
+// that gets written.
+export function proposeFileNames(titles: string[], taken: Iterable<string> = []): string[] {
+  const used = [...taken];
+  return titles.map((title) => {
+    const name = proposeFileName(title, used);
+    used.push(name);
+    return name;
+  });
+}
+
 export function deriveScratchTitle(code: string): string | undefined {
   const calls = readCalls(code);
   if (calls.length === 0) return undefined;


### PR DESCRIPTION
Implements the sidebar spec: 22px rows with hairline indent guides in place of the repeated package/service icon column, and the frequent script verbs moved out of the ⋯ menu onto the row, the Scripts header, and the command row.

`C` (folding the package into the service line) is left out — the spec calls it a separate question to answer with real usage data.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBgDk5B29ZA2Kmg3WjsFic)_