### PR TITLE
Nudged the sidebar type up to 13px

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,9 +150,11 @@ method in the sidebar is a *template*, not a document — clicking it fills a
 
 ## The tree is an index, so it reads as a list of names
 
-Rows are **22px** at `text-xs`, chevrons 12px — a dense desktop client's sizing,
-not a web page's. The three levers are row height, indent, and how many icons
-repeat per row, and the last one is what buys the horizontal room:
+Rows are **22px** at **13px**, chevrons 12px — a dense desktop client's sizing,
+not a web page's. The row is tight but the names in it are still names, so the
+type sits one step above the `text-xs` of the chrome around it. The three levers
+are row height, indent, and how many icons repeat per row, and the last one is
+what buys the horizontal room:
 
 - **Depth is a hairline, not an icon column.** `TreeView.SubTree` nests inside a
   guide (14px indent, a 1px rule at its left edge). A package and a service

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -61,7 +61,7 @@ const pillClass = "ml-1.5 rounded bg-accent px-[5px] py-px text-[9px] font-bold 
 
 // A section header is a row of the same height as the rows under it — the tree
 // is an index, and an index reads as a list of names.
-const SECTION_ROW = "flex h-[22px] cursor-pointer select-none items-center gap-1.5 px-2 text-xs font-medium text-foreground";
+const SECTION_ROW = "flex h-[22px] cursor-pointer select-none items-center gap-1.5 px-2 text-[13px] font-medium text-foreground";
 
 // Small enough to sit inside a 22px row, which is what lets the frequent verbs
 // live on the row instead of behind a menu.
@@ -640,7 +640,7 @@ export function Sidebar({
                   <li role="treeitem">
                     <div
                       onClick={onShowAllScratches}
-                      className="flex h-[22px] cursor-pointer items-center pl-2 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                      className="flex h-[22px] cursor-pointer items-center pl-2 text-[13px] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
                     >
                       Show all {scriptCount}…
                     </div>
@@ -939,7 +939,7 @@ function ScratchLabel({ scratch }: { scratch: Scratch }) {
   return (
     <span title={browsing ? "Browsing — the next call you pick takes this over" : undefined} className={cn(browsing && "text-muted-foreground")}>
       {name}
-      {qualifier && <span className="ml-1 font-mono text-xs text-muted-foreground opacity-70">{qualifier}</span>}
+      {qualifier && <span className="ml-1 font-mono text-muted-foreground opacity-70">{qualifier}</span>}
     </span>
   );
 }

--- a/ui/src/components/tree-view.tsx
+++ b/ui/src/components/tree-view.tsx
@@ -83,7 +83,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>(({ id, current, expande
         onClick={(event) => (hasSubtree ? onExpandedChange?.(!expanded) : onSelect?.(event))}
         onDoubleClick={hasSubtree ? undefined : onActivate}
         className={cn(
-          "group flex h-[22px] cursor-pointer items-center gap-1.5 pl-2 pr-1 text-xs outline-none",
+          "group flex h-[22px] cursor-pointer items-center gap-1.5 pl-2 pr-1 text-[13px] outline-none",
           current ? "bg-accent text-accent-foreground" : "text-foreground hover:bg-accent/50",
           "focus-visible:bg-accent/50",
         )}


### PR DESCRIPTION
The condensed sidebar shipped at `text-xs` and the rows read as too small in use, so tree rows, section headers and the "Show all" row go up one point to 13px. Row height, indent and glyph sizing are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RY334XHYeS2tyPHEQVpA3)_