### PR TITLE
Removed ⌘K as a second key onto the finder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,22 +289,27 @@ inset only when the sidebar is collapsed).
   (over that the qualifier drops — measured with a clipped probe — then the name
   truncates from the left so the call name survives). It is a **label first**:
   with the sidebar collapsed it is the only thing that says where you are. Its
-  popover is one list — `Recent`, then `All files` — and typing narrows both.
-  That is why `⌘K` lands here too: the finder is the only surface that can search
-  the calls, which the tree can't. `⌘P` opens it on the previous place so `⌘P⏎`
-  is "back" — the only way back, now that the chips are gone; `⌘K` and the
-  trigger open on the first row. Only the response is
-  120ms opacity — no slide, no scale, because movement makes fast repeated `⌘P`
-  feel unstable.
+  popover is one list — `Recent`, then `All files` — and typing narrows both,
+  which is what makes it the only surface that can search the calls, as the tree
+  can't. **`⌘P` is the only key that opens it**, on the previous place so `⌘P⏎`
+  is "back" — the only way back, now that the chips are gone; a click on the
+  trigger opens on the first row instead, since a click carries no "back"
+  intent. Only the response is 120ms opacity — no slide, no scale, because
+  movement makes fast repeated `⌘P` feel unstable.
+- **`⌘K` is deliberately unassigned.** It used to open this same finder on the
+  first row, which made it `⌘P` minus the one thing `⌘P` is for. `⌘K` is the
+  command-palette convention (Linear, Slack, GitHub) and a palette *does* things;
+  this list only navigates, so the first thing anyone types into it is a verb,
+  which filters the file names to nothing. It is left free rather than reassigned:
+  it is a chord prefix in Monaco, and it is the key a real palette would want.
 - **The action slot** — Run and the `</>` JSON toggle share one position, since a
   file is never both a script and a form. Run is absent (not disabled) on
   non-script surfaces. Its disabled state and the trigger's `N errors` state come
   from the same `useSyntaxErrors` (`RunButton.tsx`), so the row never disagrees
   with itself.
-- **Shortcuts** — `⌘P` finder on the previous place · `⌘K` same surface · `⌘N`
-  blank script · `⌘⏎`/F5 run · `⌘J` JSON view · `⌘B` sidebar · `⌘S` save.
-  `⌃Tab`, `⌘1–9` and `⌘W` are gone: there are no positions to number and nothing
-  to close.
+- **Shortcuts** — `⌘P` finder on the previous place · `⌘N` blank script ·
+  `⌘⏎`/F5 run · `⌘J` JSON view · `⌘B` sidebar · `⌘S` save. `⌃Tab`, `⌘1–9` and
+  `⌘W` are gone: there are no positions to number and nothing to close.
 - **Split panes are cut, not deferred.** The pane holds one thing by
   construction; splitting it reintroduces "which one is current", which is the
   exact question removing the strip answered — two panes, one trigger, one `⌘P`.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -209,8 +209,8 @@ export function App() {
   // stray call afterwards starts one of its own rather than joining a run that
   // is over.
   const currentRunRef = useRef<Run | null>(null);
-  // Whether the finder is open, and where it opened: ⌘P lands on the
-  // previous file so ⌘P⏎ goes back, everything else on the first row.
+  // Whether the finder is open, and where it opened: ⌘P lands on the previous
+  // file so ⌘P⏎ goes back, a click on the trigger on the first row.
   const [finder, setFinder] = useState<"first" | "previous">();
   const viewsRef = useRef(views);
   viewsRef.current = views;
@@ -776,11 +776,10 @@ export function App() {
         setSidebarCollapsed((collapsed) => !collapsed);
         return;
       }
-      // ⌘P opens the finder on the previous place, so ⌘P⏎ is "back". ⌘K is the
-      // same surface, opened on the first row.
-      if ((e.metaKey || e.ctrlKey) && (e.key === "p" || e.key === "k")) {
+      // ⌘P opens the finder on the previous place, so ⌘P⏎ is "back".
+      if ((e.metaKey || e.ctrlKey) && e.key === "p") {
         e.preventDefault();
-        setFinder(e.key === "p" ? "previous" : "first");
+        setFinder("previous");
         return;
       }
       // A blank script — the other half of "pick a call and Kaja writes one".
@@ -1760,8 +1759,8 @@ export function App() {
     go: () => onGoToView(view.id),
   }));
 
-  // Everywhere else you can go. Typing narrows across both, which is why ⌘K
-  // lands here too — the finder is the only surface that can search the calls.
+  // Everywhere else you can go. Typing narrows across both, which is what makes
+  // the finder the only surface that can search the calls.
   const elsewhere = useMemo<Destination[]>(() => {
     const shownScratches = new Set(views.filter((view) => view.type === "scratch").map((view) => view.scratchId));
     const shownScripts = new Set(views.filter((view) => view.type === "script").map((view) => view.script.path));

--- a/ui/src/Finder.tsx
+++ b/ui/src/Finder.tsx
@@ -40,8 +40,8 @@ interface FinderProps {
   errorCount: number;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  // ⌘P opens on the previous place so ⌘P⏎ is "back"; ⌘K and a click on the
-  // trigger open on the first row.
+  // ⌘P opens on the previous place so ⌘P⏎ is "back"; a click on the trigger
+  // opens on the first row, since a click carries no "back" intent.
   highlightPrevious: boolean;
 }
 


### PR DESCRIPTION
⌘K opened the same finder as ⌘P, differing only in which row started highlighted — and with one view in the cache, not even that. It's now unassigned: ⌘K is the command-palette convention and this list only navigates, so it's left free for a real palette rather than reassigned.

---
_Generated by [Claude Code](https://claude.ai/code/session_0161PmfCWA4F4gqofoNkkD5b)_