### PR TITLE
Dropped the compile log from the finder when there is nothing compiled

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1799,7 +1799,11 @@ export function App() {
     if (!views.some((view) => view.type === "variables")) {
       destinations.push({ key: "variables", name: "Variables", path: "Workspace", origin: "", icon: Braces, go: onVariablesClick });
     }
-    if (!views.some((view) => view.type === "compiler")) {
+    // With no apps there is nothing to have compiled, so the log is absent
+    // rather than empty — going to it would land on the same blankslate you
+    // were already looking at. The status bar's compile item is gone for the
+    // same reason.
+    if (apps.length > 0 && !views.some((view) => view.type === "compiler")) {
       destinations.push({ key: "compiler", name: "Compile log", path: "Output", origin: "", icon: ScrollText, go: () => onShowCompileLog() });
     }
 


### PR DESCRIPTION
With no apps there is nothing to have compiled, so picking Compile log landed on the same "No apps configured" blankslate you were already on. The status bar's compile item is already absent in that state; the finder now matches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyLXpAD3Vxy81xgSt1Yi11)_