### PR TITLE
Named the source in the variable suggestion list

### DIFF
--- a/ui/src/VariableSuggestInput.tsx
+++ b/ui/src/VariableSuggestInput.tsx
@@ -4,11 +4,13 @@ import { cn } from "./cn";
 import { environmentReferences, variableKind } from "./variableExpansion";
 
 // variableSummary describes a variable in one line: its value when kaja.json
-// carries it, and where the value comes from when it doesn't.
+// carries it, and where the value comes from when it doesn't. There is no source
+// picker beside this list as there is on a Variables row, so the line has to name
+// the source itself.
 function variableSummary(value: string): string {
   switch (variableKind(value)) {
     case "stored":
-      return "Stored on this machine";
+      return "From the keychain";
     case "environment":
       return "From " + environmentReferences(value).join(", ");
     default:


### PR DESCRIPTION
A keychain-backed variable read "Stored on this machine" in the `${` suggestion list, which is true of everything in the app and never says the value is in the keychain. It now reads "From the keychain", parallel to the environment case's "From KAJA_X".

---
_Generated by [Claude Code](https://claude.ai/code/session_01URiz2H6p35t1RnuZFST3RU)_