### PR TITLE
Reopened an untouched scratch instead of duplicating it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,15 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   code, never run — `isUntouched`) is a browsing buffer and gets **taken over**;
   a worked-in one is left alone and the call starts a **new** scratch. So
   browsing the tree leaves one scratch behind, not a trail, and work is never
-  silently overwritten. Appending is the deliberate gesture — **⌥click, or the
+  silently overwritten. **A new one is never a copy of one that is already
+  there**: before either of those, `findUntouched` looks for an untouched
+  scratch holding exactly this call, from this app, and **reopens** it — two
+  browsing buffers of the same call are one buffer written twice, identical
+  down to the title and the dim. It is decided before the takeover, which is
+  what would otherwise make the duplicate. Reopening settles nothing (`reopen`
+  only bumps `updatedAt`, so the buffer sits at the top of the list and out of
+  the pruner's reach) — a run or an edit is still what turns a buffer into work.
+  Appending is the deliberate gesture — **⌥click, or the
   `+` on the row** — so a scratch never grows a second call by drifting.
   `appendCall` merges the import lines instead of stacking a second copy, and
   edits the text rather than reprinting it so the author's formatting survives.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -40,7 +40,7 @@ import { Gutter } from "./Gutter";
 import { AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
-import { appendCall, createScratch, isUntouched, markRun, pruneScratches, Scratch, takeOver, withCode } from "./scratches";
+import { appendCall, createScratch, findUntouched, isUntouched, markRun, pruneScratches, reopen, Scratch, takeOver, withCode } from "./scratches";
 import { deriveScratchTitle, proposeFileName, proposeFileNames } from "./scratchTitle";
 import { generateMethodEditorCode } from "./appLoader";
 import { RunButton, useSyntaxErrors } from "./RunButton";
@@ -909,9 +909,11 @@ export function App() {
   /**
    * Clicking a method never asks what to do with it. The current scratch
    * decides: an untouched one is a browsing buffer and gets taken over, a
-   * worked-in one is left alone and the call starts a new scratch. Appending to
-   * what you already have is the deliberate gesture (⌥click, or the + on the
-   * row), so it can't happen by drifting.
+   * worked-in one is left alone and the call starts a new scratch — unless an
+   * untouched scratch already holds exactly this call, which is reopened rather
+   * than made a second time. Appending to what you already have is the
+   * deliberate gesture (⌥click, or the + on the row), so it can't happen by
+   * drifting.
    */
   const onMethodSelect = useCallback(
     async (method: Method, service: Service, app: AppModel, mode: "go" | "append" = "go") => {
@@ -930,6 +932,16 @@ export function App() {
         const merged = await formatTypeScript(appendCall(current.model.getValue(), code));
         current.model.setValue(merged);
         updateScratch(currentScratch.id, (scratch) => withCode(scratch, merged, now));
+        return;
+      }
+
+      // An untouched scratch holding exactly this call is the buffer this click
+      // would produce, so it is reopened instead. This is decided before the
+      // takeover, which would otherwise be the thing that made the duplicate.
+      const held = findUntouched(scratchesRef.current, code, originAppName);
+      if (held) {
+        updateScratch(held.id, (scratch) => reopen(scratch, now));
+        applyViews((views) => showScratch(views, held));
         return;
       }
 

--- a/ui/src/scratches.test.ts
+++ b/ui/src/scratches.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { appendCall, createScratch, isUntouched, markRun, pruneScratches, Scratch, takeOver, withCode } from "./scratches";
+import { appendCall, createScratch, findUntouched, isUntouched, markRun, pruneScratches, reopen, Scratch, takeOver, withCode } from "./scratches";
 
 const NOW = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
@@ -24,6 +24,43 @@ describe("isUntouched", () => {
     expect(isUntouched(scratch)).toBe(true);
     expect(isUntouched({ ...scratch, code: listShows + "// mine" })).toBe(false);
     expect(isUntouched({ ...scratch, ran: true })).toBe(false);
+  });
+});
+
+describe("findUntouched", () => {
+  const buffer = (code: string, originAppName?: string, extra: Partial<Scratch> = {}) => ({
+    ...createScratch(code, originAppName, NOW),
+    ...extra,
+  });
+
+  it("finds the browsing buffer that already holds the call", () => {
+    const held = buffer(listShows, "theatre");
+    expect(findUntouched([buffer(getShow, "theatre"), held], listShows, "theatre")?.id).toBe(held.id);
+  });
+
+  it("takes the most recent of several", () => {
+    const [newest, oldest] = [buffer(listShows, "theatre"), buffer(listShows, "theatre")];
+    expect(findUntouched([newest, oldest], listShows, "theatre")?.id).toBe(newest.id);
+  });
+
+  it("never reaches a scratch that was worked in", () => {
+    expect(findUntouched([buffer(listShows, "theatre", { ran: true })], listShows, "theatre")).toBeUndefined();
+    expect(findUntouched([buffer(listShows, "theatre", { code: listShows + "// mine" })], listShows, "theatre")).toBeUndefined();
+  });
+
+  it("keeps two apps apart even when their code reads the same", () => {
+    expect(findUntouched([buffer(getSeatMap, "seating")], getSeatMap, "theatre")).toBeUndefined();
+  });
+});
+
+describe("reopen", () => {
+  it("says the buffer is the one being browsed and settles nothing else", () => {
+    const scratch = createScratch(listShows, undefined, NOW);
+    const held = reopen(scratch, NOW + 1);
+
+    expect(held.updatedAt).toBe(NOW + 1);
+    expect(isUntouched(held)).toBe(true);
+    expect(held.title).toBe(scratch.title);
   });
 });
 

--- a/ui/src/scratches.ts
+++ b/ui/src/scratches.ts
@@ -56,6 +56,20 @@ export function isUntouched(scratch: Scratch): boolean {
   return !scratch.ran && scratch.code === scratch.generatedCode;
 }
 
+// Two untouched scratches of the same call are one browsing buffer written
+// twice: same code, same title, same dimmed row. So a call reopens the buffer
+// that already holds it rather than adding another beside it.
+export function findUntouched(scratches: Scratch[], code: string, originAppName: string | undefined): Scratch | undefined {
+  return scratches.find((scratch) => isUntouched(scratch) && scratch.code === code && scratch.originAppName === originAppName);
+}
+
+// Reopening is not work, so it settles nothing — it only says this buffer is
+// the one being browsed, which is what keeps it at the top of the list and out
+// of the way of the pruner.
+export function reopen(scratch: Scratch, now: number): Scratch {
+  return { ...scratch, updatedAt: now };
+}
+
 export function takeOver(scratch: Scratch, code: string, originAppName: string | undefined, now: number): Scratch {
   return {
     ...scratch,


### PR DESCRIPTION
Clicking a method now reopens an untouched scratch that already holds exactly that call rather than creating a second copy of it. Two browsing buffers of the same call were one buffer written twice — same code, same title, same dimmed row.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XPJ5j6iasE6HMkHzjBYmH)_