### PR TITLE
Opened the tree on what you call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,61 @@ what buys the horizontal room:
 - The sidebar **header stays 40px** regardless, because it lines up with the
   command row across the seam.
 
+## What the tree opens with
+
+**Expansion is a record of where you have been, not a guess about where you will
+go** (`treeExpansion.ts`). Three inputs decide it, in that order: the calls you
+have made, the nodes you have folded yourself, and — only before either of those
+can say anything — how much of an app fits on screen. Guessing once, on the day
+you know least, was the old rule (*the first two apps in `kaja.json`, their first
+service*), and it never ran again: whatever you got on day one you kept forever.
+
+- **The ledger is what you called, most recent first.** A `MethodUse` is
+  app/package/service/method and nothing else — the list is ordered, so there is
+  no timestamp and no count for anything to read. It is written from
+  `onMethodSelect`, which is the one door the tree *and* the finder both go
+  through, and from every call a script makes (`onMethodCallUpdate`), because a
+  call you ran counts at least as much as one you clicked. On load the tree opens
+  the path to the **three** most recent calls that still resolve; the budget is
+  spent across the whole tree, not per app, and a call whose proto has since
+  dropped it doesn't spend any of it.
+- **A fold is a decision, an expansion is a suggestion.** A node is `open`,
+  `shut`, or absent, and nothing derived ever writes over the first two — this is
+  what makes it safe for the ledger to be as aggressive as it is. Absent is the
+  only state a seed may fill, and opening a node by hand clears its own `shut`,
+  so the mess is never bigger than the nodes you touched and each is one click
+  from fixed. There is no global reset to offer.
+- **Size decides only on a cold start** (`autoOpenNodes`, 12 rows). It opens an
+  app as deep as it goes while staying under the budget, **a level whole or not
+  at all** — picking the first service out of a list is the arbitrariness this
+  replaced — and never less than one level, so an app always says what is in it.
+  A small API comes up open to its methods, one click from a script; a large one
+  shows its shape. Once there is a history, **silence about an app means shut**:
+  the fallback is the cold-start rule and nothing else, so seven apps you don't
+  use can't sit open forever. An app added since the ledger was written has
+  nothing to be silent with, so it falls back to its size the same way.
+- **An app is seeded once**, when it first has services, and after that the folds
+  are the truth — the tree can never rearrange itself under the cursor. Apps
+  compile at their own pace, so `seedFolds` seeds *some* apps against *all* of
+  them: the recent-call budget and the is-this-a-cold-start question are both
+  asked of the whole tree.
+- **Folds are pruned against what exists; the ledger is not.** An app that is
+  still compiling — or has no services for any other reason — has nothing to
+  match against, so its subtree is spared rather than cleared and re-seeded on
+  every reload. The ledger is never pruned against apps at all, because a failing
+  compile would erase the history that outlives it; it is capped instead, and a
+  stale entry simply never resolves.
+- **There are no fold-all and unfold-all buttons.** Both were about managing a
+  view of the tree, which stopped being something you do, and Fold All was the
+  one gesture that could write `shut` over everything at once and mute the whole
+  model from a button in the header. **⌥click a row** takes its subtree instead —
+  the same verb, scoped to where the cursor already is, at no cost in chrome. The
+  sidebar header's right side is now empty: the left side makes things, and that
+  is the whole header.
+- The old `expandedApps`/`expandedServices` keys are **not migrated**. Their ids
+  differ, and ignoring them lands an existing workspace on the cold start, which
+  is a better tree than their stale contents would rebuild.
+
 ## The console reports runs
 
 **A run is the unit** (`runs.ts`): one press of Run, one header, one duration,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -42,6 +42,7 @@ import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
 import { appendCall, createScratch, findUntouched, isUntouched, markRun, pruneScratches, reopen, Scratch, takeOver, withCode } from "./scratches";
 import { deriveScratchTitle, proposeFileName, proposeFileNames } from "./scratchTitle";
+import { methodUse, recordUse } from "./treeExpansion";
 import { generateMethodEditorCode } from "./appLoader";
 import { RunButton, useSyntaxErrors } from "./RunButton";
 import { Sidebar, TRAFFIC_LIGHTS_INSET } from "./Sidebar";
@@ -414,6 +415,9 @@ export function App() {
         if (i > -1) collector[i] = methodCall;
         else collector.push(methodCall);
       }
+      // A call a script actually made counts as much as one picked out of the
+      // tree, and more of them are made this way once you are working.
+      recordUse(methodUse(methodCall.appName, methodCall.service, methodCall.method));
       const run = openRun(methodCall.method.name);
       setHistory((current) => recordCall(current, run.fileId, run.id, methodCall, Date.now()));
     },
@@ -924,6 +928,9 @@ export function App() {
       // written into a model it already has.
       const code = await formatTypeScript(generateMethodEditorCode(app, service, method));
       const originAppName = app.configuration.name;
+      // What the sidebar tree opens with next time. Both the tree and the finder
+      // arrive here, so this is the one place a call is chosen.
+      recordUse(methodUse(originAppName, service, method));
       const now = Date.now();
       const current = viewsRef.current[0];
       const currentScratch = current?.type === "scratch" ? scratchesRef.current.find((s) => s.id === current.scratchId) : undefined;
@@ -1845,10 +1852,7 @@ export function App() {
     [currentFileId],
   );
 
-  const onConsoleTabChange = useCallback(
-    (tab: ConsoleTab) => setHistory((current) => setTab(current, currentFileId, tab, Date.now())),
-    [currentFileId],
-  );
+  const onConsoleTabChange = useCallback((tab: ConsoleTab) => setHistory((current) => setTab(current, currentFileId, tab, Date.now())), [currentFileId]);
 
   // What the empty state offers instead of an illustration: the last few things
   // you were in. On a first run there are none and the list is simply absent.

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   isOpen,
   loadFolds,
   loadLedger,
+  MethodUse,
   packageNodeId,
   pruneFolds,
   saveFolds,
@@ -253,13 +254,20 @@ export function Sidebar({
   // itself under the cursor.
   const seededApps = useRef<Set<string>>(new Set());
   const newApps = useRef<Set<string>>(new Set());
+  // The ledger as it stood when the window opened. A seed reasons about what you
+  // had called before this session, never about what has happened since: apps
+  // compile at their own pace, so a call made — or auto-opened by Kaja itself —
+  // while a slow app was still compiling would otherwise cancel that app's cold
+  // start and leave it shut for having been late.
+  const ledgerAtLoad = useRef<MethodUse[]>(undefined);
+  if (ledgerAtLoad.current === undefined) ledgerAtLoad.current = loadLedger();
 
   useEffect(() => {
     if (treeApps.length === 0) return;
 
     const targets = new Set(treeApps.filter((app) => app.services.length > 0 && !seededApps.current.has(app.name)).map((app) => app.name));
     if (targets.size > 0) {
-      setFolds((prev) => seedFolds(treeApps, targets, prev, loadLedger(), newApps.current));
+      setFolds((prev) => seedFolds(treeApps, targets, prev, ledgerAtLoad.current!, newApps.current));
       for (const name of targets) {
         seededApps.current.add(name);
         newApps.current.delete(name);

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   Check,
   CircleX,
   FileCode,
-  FoldVertical,
   Pencil,
   Pin,
   Plus,
@@ -18,7 +17,6 @@ import {
   Settings,
   Trash2,
   TriangleAlert,
-  UnfoldVertical,
   ChevronRight,
   Ellipsis,
   Plus as PlusIcon,
@@ -32,28 +30,27 @@ import { isUntouched, Scratch } from "./scratches";
 import { titleParts } from "./scratchTitle";
 import { appWarnings, firstErrorMessage } from "./compileSummary";
 import { getPersistedValue, setPersistedValue } from "./storage";
+import {
+  appNodeId,
+  Fold,
+  FoldMap,
+  groupServicesByPackage,
+  hasMultiplePackages,
+  isOpen,
+  loadFolds,
+  loadLedger,
+  packageNodeId,
+  pruneFolds,
+  saveFolds,
+  seedFolds,
+  serviceNodeId,
+  subtreeNodes,
+  TreeApp,
+} from "./treeExpansion";
 
 // Width the macOS traffic lights occupy at the window's left edge. The desktop
 // window hides its title bar, so whatever sits in that corner has to clear them.
 export const TRAFFIC_LIGHTS_INSET = 78;
-
-function hasMultiplePackages(services: Service[]): boolean {
-  if (services.length === 0) return false;
-  const first = services[0].packageName;
-  return services.some((s) => s.packageName !== first);
-}
-
-function groupServicesByPackage(services: Service[]): [string, Service[]][] {
-  const groups = new Map<string, Service[]>();
-  for (const service of services) {
-    const pkg = service.packageName;
-    if (!groups.has(pkg)) {
-      groups.set(pkg, []);
-    }
-    groups.get(pkg)!.push(service);
-  }
-  return [...groups.entries()];
-}
 
 const RECENT_SCRATCHES = 6;
 
@@ -239,158 +236,52 @@ export function Sidebar({
   useEffect(() => {
     setPersistedValue("scriptsExpanded", scriptsExpanded);
   }, [scriptsExpanded]);
-  const hadPersistedState = useRef(getPersistedValue<string[]>("expandedApps") !== undefined);
-
-  const [expandedApps, setExpandedApps] = useState<Set<string>>(() => {
-    const stored = getPersistedValue<string[]>("expandedApps");
-    if (Array.isArray(stored)) {
-      return new Set(stored.filter((v): v is string => typeof v === "string"));
-    }
-    return new Set<string>();
-  });
-
-  const [expandedServices, setExpandedServices] = useState<Set<string>>(() => {
-    const stored = getPersistedValue<string[]>("expandedServices");
-    if (Array.isArray(stored)) {
-      return new Set(stored.filter((v): v is string => typeof v === "string"));
-    }
-    return new Set<string>();
-  });
+  const [folds, setFolds] = useState<FoldMap>(loadFolds);
 
   const elementRefs = useRef<Map<string, HTMLElement>>(new Map());
   const pendingScrollRef = useRef<string | null>(null);
 
-  // Helper to get service element id
-  const getServiceElementId = (appName: string, service: Service) => {
-    const serviceKey = service.packageName ? `${service.packageName}.${service.name}` : service.name;
-    return `${appName}-${serviceKey}`;
-  };
-
-  // Helper to get package element id (used when multiple packages are shown as subtrees)
-  const getPackageElementId = (appName: string, packageName: string) => {
-    return `${appName}-pkg:${packageName}`;
-  };
-
-  // Persist expanded state
-  useEffect(() => {
-    setPersistedValue("expandedApps", [...expandedApps]);
-  }, [expandedApps]);
+  const treeApps: TreeApp[] = apps.map((app) => ({ name: app.configuration.name, services: app.services }));
 
   useEffect(() => {
-    setPersistedValue("expandedServices", [...expandedServices]);
-  }, [expandedServices]);
+    saveFolds(folds);
+  }, [folds]);
 
-  // On first visit, expand first two apps. On subsequent loads, prune stale keys.
+  // Apps already seeded, and apps added since the ledger was written. An app is
+  // seeded once, when it first has something to seed from; after that the folds
+  // are the truth and only a click changes them, so the tree can't rearrange
+  // itself under the cursor.
+  const seededApps = useRef<Set<string>>(new Set());
+  const newApps = useRef<Set<string>>(new Set());
+
   useEffect(() => {
-    if (apps.length === 0) return;
+    if (treeApps.length === 0) return;
 
-    if (!hadPersistedState.current) {
-      setExpandedApps((prev) => {
-        if (prev.size === 0) {
-          return new Set(apps.slice(0, 2).map((p) => p.configuration.name));
-        }
-        return prev;
-      });
-      setExpandedServices((prev) => {
-        if (prev.size === 0) {
-          const initialServices = new Set<string>();
-          apps.slice(0, 2).forEach((app) => {
-            if (app.services.length > 0) {
-              // If multiple packages, also expand the first package
-              if (hasMultiplePackages(app.services)) {
-                initialServices.add(getPackageElementId(app.configuration.name, app.services[0].packageName));
-              }
-              initialServices.add(getServiceElementId(app.configuration.name, app.services[0]));
-            }
-          });
-          return initialServices;
-        }
-        return prev;
-      });
-      // Only mark initialized once services exist, so defaults retry after compilation finishes
-      if (apps.some((p) => p.services.length > 0)) {
-        hadPersistedState.current = true;
-      }
-      return;
-    }
-
-    // Prune stale entries that no longer match current apps/services
-    const validApps = new Set(apps.map((p) => p.configuration.name));
-    const validServices = new Set<string>();
-    const compilingPrefixes: string[] = [];
-    for (const app of apps) {
-      if (app.compilation.status === "running" || app.compilation.status === "pending") {
-        compilingPrefixes.push(app.configuration.name + "-");
-      }
-      // Add package IDs as valid when multiple packages exist
-      if (hasMultiplePackages(app.services)) {
-        const seenPackages = new Set<string>();
-        for (const service of app.services) {
-          if (!seenPackages.has(service.packageName)) {
-            seenPackages.add(service.packageName);
-            validServices.add(getPackageElementId(app.configuration.name, service.packageName));
-          }
-        }
-      }
-      for (const service of app.services) {
-        validServices.add(getServiceElementId(app.configuration.name, service));
+    const targets = new Set(treeApps.filter((app) => app.services.length > 0 && !seededApps.current.has(app.name)).map((app) => app.name));
+    if (targets.size > 0) {
+      setFolds((prev) => seedFolds(treeApps, targets, prev, loadLedger(), newApps.current));
+      for (const name of targets) {
+        seededApps.current.add(name);
+        newApps.current.delete(name);
       }
     }
 
-    setExpandedApps((prev) => {
-      const pruned = new Set([...prev].filter((p) => validApps.has(p)));
-      if (pruned.size !== prev.size) return pruned;
-      return prev;
-    });
-
-    setExpandedServices((prev) => {
-      const pruned = new Set([...prev].filter((s) => validServices.has(s) || compilingPrefixes.some((prefix) => s.startsWith(prefix))));
-      if (pruned.size !== prev.size) return pruned;
-      return prev;
-    });
+    const compiling = new Set(
+      apps.filter((app) => app.compilation.status === "running" || app.compilation.status === "pending").map((app) => app.configuration.name),
+    );
+    setFolds((prev) => pruneFolds(prev, treeApps, compiling));
   }, [apps]);
 
-  // Auto-expand a just-added app. The app is expanded immediately;
-  // its first service (and first package, when several exist) is expanded once
-  // compilation finishes and services become available.
-  const pendingFirstServiceExpand = useRef<Set<string>>(new Set());
-
+  // A just-added app opens at once, and takes its depth from its size once it has
+  // compiled: it is new, so there is no history that could speak for it.
   useEffect(() => {
     if (!autoExpandApp) return;
     const { name } = autoExpandApp;
-    setExpandedApps((prev) => {
-      if (prev.has(name)) return prev;
-      const next = new Set(prev);
-      next.add(name);
-      return next;
-    });
-    pendingFirstServiceExpand.current.add(name);
-    pendingScrollRef.current = name;
+    newApps.current.add(name);
+    seededApps.current.delete(name);
+    setFolds((prev) => ({ ...prev, [appNodeId(name)]: "open" }));
+    pendingScrollRef.current = appNodeId(name);
   }, [autoExpandApp]);
-
-  useEffect(() => {
-    if (pendingFirstServiceExpand.current.size === 0) return;
-    const idsToExpand: string[] = [];
-    const ready: string[] = [];
-    for (const name of pendingFirstServiceExpand.current) {
-      const app = apps.find((p) => p.configuration.name === name);
-      if (app && app.services.length > 0) {
-        if (hasMultiplePackages(app.services)) {
-          idsToExpand.push(getPackageElementId(name, app.services[0].packageName));
-        }
-        idsToExpand.push(getServiceElementId(name, app.services[0]));
-        ready.push(name);
-      }
-    }
-    if (idsToExpand.length > 0) {
-      setExpandedServices((prev) => {
-        const next = new Set(prev);
-        idsToExpand.forEach((id) => next.add(id));
-        return next;
-      });
-      ready.forEach((n) => pendingFirstServiceExpand.current.delete(n));
-    }
-  }, [apps]);
 
   // Scroll expanded element into view after DOM updates
   const scrollIntoView = (elementId: string) => {
@@ -409,45 +300,22 @@ export function Sidebar({
       pendingScrollRef.current = null;
       scrollIntoView(elementId);
     }
-  }, [expandedApps, expandedServices]);
+  }, [folds]);
 
-  const toggleAppExpanded = (appName: string) => {
-    setExpandedApps((prev) => {
-      const next = new Set(prev);
-      if (next.has(appName)) {
-        next.delete(appName);
-      } else {
-        next.add(appName);
-        pendingScrollRef.current = appName;
+  /**
+   * Fold a node, and — on ⌥click — everything under it. That gesture is why
+   * there are no fold-all and unfold-all buttons in the header: it is the same
+   * verb, scoped to the row the cursor is already on, and it costs no chrome.
+   */
+  const setFold = (app: TreeApp, nodeId: string, fold: Fold, wholeSubtree: boolean) => {
+    setFolds((prev) => {
+      const next = { ...prev, [nodeId]: fold };
+      if (wholeSubtree) {
+        for (const child of subtreeNodes(app, nodeId)) next[child] = fold;
       }
       return next;
     });
-  };
-
-  const foldAll = () => {
-    setExpandedApps(new Set());
-    setExpandedServices(new Set());
-  };
-
-  const unfoldAll = () => {
-    const allApps = new Set(apps.map((p) => p.configuration.name));
-    const allServices = new Set<string>();
-    for (const app of apps) {
-      if (hasMultiplePackages(app.services)) {
-        const seenPackages = new Set<string>();
-        for (const service of app.services) {
-          if (!seenPackages.has(service.packageName)) {
-            seenPackages.add(service.packageName);
-            allServices.add(getPackageElementId(app.configuration.name, service.packageName));
-          }
-        }
-      }
-      for (const service of app.services) {
-        allServices.add(getServiceElementId(app.configuration.name, service));
-      }
-    }
-    setExpandedApps(allApps);
-    setExpandedServices(allServices);
+    if (fold === "open") pendingScrollRef.current = nodeId;
   };
 
   return (
@@ -479,17 +347,10 @@ export function Sidebar({
           <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New app" onClick={onNewAppClick} />
           {onVariablesClick && <IconButton icon={Braces} size="sm" variant="ghost" aria-label="Variables" onClick={onVariablesClick} />}
         </div>
-        <div style={{ flex: 1 }} />
-        <div
-          style={
-            reserveTrafficLights
-              ? ({ display: "flex", alignItems: "center", "--wails-draggable": "no-drag" } as React.CSSProperties)
-              : { display: "flex", alignItems: "center" }
-          }
-        >
-          <IconButton icon={FoldVertical} size="sm" variant="ghost" aria-label="Fold All" onClick={foldAll} />
-          <IconButton icon={UnfoldVertical} size="sm" variant="ghost" aria-label="Unfold All" onClick={unfoldAll} />
-        </div>
+        {/* Nothing on the right. Fold All and Unfold All lived here and were both
+            about managing a view of the tree, which stopped being something you
+            do: the tree opens on what you call, and ⌥click on a row takes its
+            whole subtree. The left side makes things; that is the whole header. */}
       </div>
       <div style={{ flex: 1, overflowY: "auto", padding: "4px 0", minHeight: 0 }}>
         {/* One list, not two. A script that has been saved and one that hasn't
@@ -654,17 +515,19 @@ export function Sidebar({
             rows can carry the same name across the seam. A rule keeps nobody
             reading them as one. */}
         {(hasScripts || hasScratches) && apps.length > 0 && <div className="my-1 h-px bg-border" />}
-        {apps.map((app) => {
+        {apps.map((app, appIndex) => {
           const appName = app.configuration.name;
-          const isExpanded = expandedApps.has(appName);
+          const treeApp = treeApps[appIndex];
+          const appId = appNodeId(appName);
+          const isExpanded = isOpen(folds, appId);
           const active = hoveredApp === appName || appMenu?.appName === appName;
 
           return (
             <nav
               key={appName}
               ref={(el) => {
-                if (el) elementRefs.current.set(appName, el);
-                else elementRefs.current.delete(appName);
+                if (el) elementRefs.current.set(appId, el);
+                else elementRefs.current.delete(appId);
               }}
               aria-label="Services and methods"
             >
@@ -675,7 +538,7 @@ export function Sidebar({
                 className={cn(SECTION_ROW, active ? "bg-accent" : "hover:bg-accent/50")}
                 onMouseEnter={() => setHoveredApp(appName)}
                 onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
-                onClick={() => toggleAppExpanded(appName)}
+                onClick={(e: React.MouseEvent) => setFold(treeApp, appId, isExpanded ? "shut" : "open", e.altKey)}
                 onContextMenu={(e: React.MouseEvent) => {
                   e.preventDefault();
                   setAppMenu({ appName, top: e.clientY, left: e.clientX });
@@ -700,30 +563,17 @@ export function Sidebar({
                       const multiplePackages = hasMultiplePackages(app.services);
 
                       const renderServiceItem = (service: Service) => {
-                        const serviceKey = service.packageName ? `${service.packageName}.${service.name}` : service.name;
-                        const svcId = `${appName}-${serviceKey}`;
-                        const isServiceExpanded = expandedServices.has(svcId);
+                        const svcId = serviceNodeId(appName, service);
                         return (
                           <TreeView.Item
                             id={svcId}
-                            key={serviceKey}
+                            key={svcId}
                             ref={(el: HTMLElement | null) => {
                               if (el) elementRefs.current.set(svcId, el);
                               else elementRefs.current.delete(svcId);
                             }}
-                            expanded={isServiceExpanded}
-                            onExpandedChange={(expanded) => {
-                              setExpandedServices((prev) => {
-                                const next = new Set(prev);
-                                if (expanded) {
-                                  next.add(svcId);
-                                } else {
-                                  next.delete(svcId);
-                                }
-                                return next;
-                              });
-                              if (expanded) scrollIntoView(svcId);
-                            }}
+                            expanded={isOpen(folds, svcId)}
+                            onExpandedChange={(expanded, event) => setFold(treeApp, svcId, expanded ? "open" : "shut", event.altKey)}
                           >
                             {service.name}
                             <TreeView.SubTree leaf>
@@ -769,8 +619,7 @@ export function Sidebar({
                       }
 
                       const packageNodes = groupServicesByPackage(app.services).map(([packageName, services]) => {
-                        const packageId = getPackageElementId(appName, packageName);
-                        const isPackageExpanded = expandedServices.has(packageId);
+                        const packageId = packageNodeId(appName, packageName);
                         return (
                           <TreeView.Item
                             id={packageId}
@@ -779,19 +628,8 @@ export function Sidebar({
                               if (el) elementRefs.current.set(packageId, el);
                               else elementRefs.current.delete(packageId);
                             }}
-                            expanded={isPackageExpanded}
-                            onExpandedChange={(expanded) => {
-                              setExpandedServices((prev) => {
-                                const next = new Set(prev);
-                                if (expanded) {
-                                  next.add(packageId);
-                                } else {
-                                  next.delete(packageId);
-                                }
-                                return next;
-                              });
-                              if (expanded) scrollIntoView(packageId);
-                            }}
+                            expanded={isOpen(folds, packageId)}
+                            onExpandedChange={(expanded, event) => setFold(treeApp, packageId, expanded ? "open" : "shut", event.altKey)}
                           >
                             {/* No icon: every package row carried the same one,
                                 which is 20px per row spent saying what the guide

--- a/ui/src/components/tree-view.tsx
+++ b/ui/src/components/tree-view.tsx
@@ -42,7 +42,9 @@ interface ItemProps {
   id?: string;
   current?: boolean;
   expanded?: boolean;
-  onExpandedChange?: (expanded: boolean) => void;
+  // The event is passed so a caller can read a modifier, e.g. ⌥click to take the
+  // whole subtree.
+  onExpandedChange?: (expanded: boolean, event: React.MouseEvent) => void;
   // The event is passed so a caller can read a modifier, e.g. ⌥click.
   onSelect?: (event: React.MouseEvent) => void;
   // Double click, the editor gesture for "I mean it": a single click opens a
@@ -80,7 +82,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>(({ id, current, expande
         id={id}
         tabIndex={onKeyDown ? 0 : undefined}
         onKeyDown={onKeyDown}
-        onClick={(event) => (hasSubtree ? onExpandedChange?.(!expanded) : onSelect?.(event))}
+        onClick={(event) => (hasSubtree ? onExpandedChange?.(!expanded, event) : onSelect?.(event))}
         onDoubleClick={hasSubtree ? undefined : onActivate}
         className={cn(
           "group flex h-[22px] cursor-pointer items-center gap-1.5 pl-2 pr-1 text-[13px] outline-none",

--- a/ui/src/treeExpansion.test.ts
+++ b/ui/src/treeExpansion.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import { Service } from "./apps";
+import {
+  appNodeId,
+  autoOpenNodes,
+  FoldMap,
+  MethodUse,
+  packageNodeId,
+  pruneFolds,
+  seedFolds,
+  serviceNodeId,
+  subtreeNodes,
+  TreeApp,
+  usePath,
+  withUse,
+} from "./treeExpansion";
+
+function service(name: string, packageName: string, methods: string[]): Service {
+  return {
+    name,
+    packageName,
+    sourcePath: `${packageName}.proto`,
+    clientStubModuleId: `${packageName}.${name}`,
+    methods: methods.map((method) => ({ name: method })),
+  };
+}
+
+function methods(prefix: string, count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `${prefix}${index + 1}`);
+}
+
+const tiny: TreeApp = { name: "tiny", services: [service("Shows", "theatre", ["ListShows", "GetShow"])] };
+
+const medium: TreeApp = {
+  name: "medium",
+  services: [service("Shows", "theatre", methods("M", 6)), service("Seats", "theatre", methods("N", 6)), service("Venues", "theatre", methods("O", 6))],
+};
+
+const huge: TreeApp = {
+  name: "huge",
+  services: Array.from({ length: 40 }, (_, index) => service(`Service${index}`, "big", methods("M", 5))),
+};
+
+const packaged: TreeApp = {
+  name: "packaged",
+  services: [service("Shows", "theatre", ["ListShows"]), service("Seats", "seating", ["Reserve"])],
+};
+
+const use = (app: string, pkg: string, svc: string, method: string): MethodUse => ({ app, package: pkg, service: svc, method });
+
+describe("autoOpenNodes", () => {
+  test("opens a small app all the way to its methods", () => {
+    expect(autoOpenNodes(tiny)).toEqual([appNodeId("tiny"), serviceNodeId("tiny", tiny.services[0])]);
+  });
+
+  test("stops at the service list when opening every service would not fit", () => {
+    // 3 services fit; 3 services plus their 18 methods do not.
+    expect(autoOpenNodes(medium)).toEqual([appNodeId("medium")]);
+  });
+
+  test("opens the app itself even when its first level overflows", () => {
+    expect(autoOpenNodes(huge)).toEqual([appNodeId("huge")]);
+  });
+
+  test("counts packages as their own level", () => {
+    expect(autoOpenNodes(packaged)).toEqual([
+      appNodeId("packaged"),
+      packageNodeId("packaged", "theatre"),
+      packageNodeId("packaged", "seating"),
+      serviceNodeId("packaged", packaged.services[0]),
+      serviceNodeId("packaged", packaged.services[1]),
+    ]);
+  });
+
+  test("never opens a level part way", () => {
+    // A budget that fits two of the three services opens none of them.
+    expect(autoOpenNodes(medium, 4)).toEqual([appNodeId("medium")]);
+  });
+});
+
+describe("usePath", () => {
+  test("resolves to the nodes between the app and the service", () => {
+    expect(usePath(packaged, use("packaged", "seating", "Seats", "Reserve"))).toEqual([
+      appNodeId("packaged"),
+      packageNodeId("packaged", "seating"),
+      serviceNodeId("packaged", packaged.services[1]),
+    ]);
+  });
+
+  test("omits the package level when there is only one package", () => {
+    expect(usePath(tiny, use("tiny", "theatre", "Shows", "GetShow"))).toEqual([appNodeId("tiny"), serviceNodeId("tiny", tiny.services[0])]);
+  });
+
+  test("does not resolve a call the proto no longer has", () => {
+    expect(usePath(tiny, use("tiny", "theatre", "Shows", "DeleteShow"))).toBeUndefined();
+    expect(usePath(tiny, use("tiny", "theatre", "Gone", "GetShow"))).toBeUndefined();
+    expect(usePath(tiny, use("tiny", "elsewhere", "Shows", "GetShow"))).toBeUndefined();
+  });
+});
+
+describe("seedFolds", () => {
+  const all = (apps: TreeApp[]) => new Set(apps.map((app) => app.name));
+  const none = new Set<string>();
+
+  test("a cold start goes by size, for every app", () => {
+    const apps = [tiny, medium];
+    const folds = seedFolds(apps, all(apps), {}, [], none);
+    expect(folds[appNodeId("tiny")]).toBe("open");
+    expect(folds[serviceNodeId("tiny", tiny.services[0])]).toBe("open");
+    expect(folds[appNodeId("medium")]).toBe("open");
+    expect(folds[serviceNodeId("medium", medium.services[0])]).toBeUndefined();
+  });
+
+  test("with a history, the recent calls decide", () => {
+    const apps = [tiny, medium];
+    const ledger = [use("medium", "theatre", "Venues", "O1")];
+    const folds = seedFolds(apps, all(apps), {}, ledger, none);
+    expect(folds[appNodeId("medium")]).toBe("open");
+    expect(folds[serviceNodeId("medium", medium.services[2])]).toBe("open");
+  });
+
+  test("an app no recent call names stays shut", () => {
+    const apps = [tiny, medium];
+    const folds = seedFolds(apps, all(apps), {}, [use("medium", "theatre", "Venues", "O1")], none);
+    expect(folds[appNodeId("tiny")]).toBeUndefined();
+  });
+
+  test("opens at most three paths", () => {
+    const apps = [huge];
+    const ledger = huge.services.slice(0, 5).map((svc) => use("huge", "big", svc.name, "M1"));
+    const folds = seedFolds(apps, all(apps), {}, ledger, none);
+    const open = huge.services.filter((svc) => folds[serviceNodeId("huge", svc)] === "open");
+    expect(open.map((svc) => svc.name)).toEqual(["Service0", "Service1", "Service2"]);
+  });
+
+  test("a call the proto no longer has does not spend the budget", () => {
+    const apps = [huge];
+    const ledger = [use("huge", "big", "Deleted", "M1"), ...huge.services.slice(0, 3).map((svc) => use("huge", "big", svc.name, "M1"))];
+    const folds = seedFolds(apps, all(apps), {}, ledger, none);
+    expect(huge.services.filter((svc) => folds[serviceNodeId("huge", svc)] === "open")).toHaveLength(3);
+  });
+
+  test("a ledger that resolves to nothing at all is a cold start", () => {
+    const apps = [tiny];
+    const folds = seedFolds(apps, all(apps), {}, [use("deleted-app", "theatre", "Shows", "GetShow")], none);
+    expect(folds[serviceNodeId("tiny", tiny.services[0])]).toBe("open");
+  });
+
+  test("a new app goes by size even when there is a history", () => {
+    const apps = [tiny, medium];
+    const ledger = [use("medium", "theatre", "Venues", "O1")];
+    const folds = seedFolds(apps, all(apps), {}, ledger, new Set(["tiny"]));
+    expect(folds[serviceNodeId("tiny", tiny.services[0])]).toBe("open");
+  });
+
+  test("never reopens a node that was folded by hand", () => {
+    const apps = [tiny];
+    const shut: FoldMap = { [serviceNodeId("tiny", tiny.services[0])]: "shut" };
+    expect(seedFolds(apps, all(apps), shut, [], none)[serviceNodeId("tiny", tiny.services[0])]).toBe("shut");
+    const ledger = [use("tiny", "theatre", "Shows", "GetShow")];
+    expect(seedFolds(apps, all(apps), shut, ledger, none)[serviceNodeId("tiny", tiny.services[0])]).toBe("shut");
+  });
+
+  test("seeds only its targets, but spends the budget on every app", () => {
+    const apps = [tiny, medium];
+    const ledger = [use("tiny", "theatre", "Shows", "GetShow"), use("medium", "theatre", "Venues", "O1")];
+    const folds = seedFolds(apps, new Set(["medium"]), {}, ledger, none);
+    expect(folds[appNodeId("tiny")]).toBeUndefined();
+    expect(folds[serviceNodeId("medium", medium.services[2])]).toBe("open");
+  });
+});
+
+describe("pruneFolds", () => {
+  test("drops nodes that are gone and keeps the rest", () => {
+    const folds: FoldMap = {
+      [appNodeId("tiny")]: "open",
+      [serviceNodeId("tiny", tiny.services[0])]: "open",
+      [serviceNodeId("tiny", service("Removed", "theatre", []))]: "shut",
+      [appNodeId("deleted")]: "open",
+    };
+    const pruned = pruneFolds(folds, [tiny], new Set());
+    expect(Object.keys(pruned).sort()).toEqual([appNodeId("tiny"), serviceNodeId("tiny", tiny.services[0])].sort());
+  });
+
+  test("leaves an app with nothing to match against alone", () => {
+    const uncompiled: TreeApp = { name: "tiny", services: [] };
+    const folds: FoldMap = { [serviceNodeId("tiny", tiny.services[0])]: "shut" };
+    expect(pruneFolds(folds, [uncompiled], new Set(["tiny"]))).toEqual(folds);
+    expect(pruneFolds(folds, [uncompiled], new Set())).toEqual(folds);
+  });
+
+  test("still drops a service its app no longer compiles", () => {
+    const folds: FoldMap = { [serviceNodeId("tiny", service("Removed", "theatre", []))]: "shut" };
+    expect(pruneFolds(folds, [tiny], new Set())).toEqual({});
+  });
+
+  test("returns the same object when nothing is stale", () => {
+    const folds: FoldMap = { [appNodeId("tiny")]: "open" };
+    expect(pruneFolds(folds, [tiny], new Set())).toBe(folds);
+  });
+});
+
+describe("subtreeNodes", () => {
+  test("an app takes its packages and its services", () => {
+    expect(subtreeNodes(packaged, appNodeId("packaged"))).toEqual([
+      packageNodeId("packaged", "theatre"),
+      packageNodeId("packaged", "seating"),
+      serviceNodeId("packaged", packaged.services[0]),
+      serviceNodeId("packaged", packaged.services[1]),
+    ]);
+  });
+
+  test("a package takes only its own services", () => {
+    expect(subtreeNodes(packaged, packageNodeId("packaged", "seating"))).toEqual([serviceNodeId("packaged", packaged.services[1])]);
+  });
+
+  test("a service has nothing under it but leaves", () => {
+    expect(subtreeNodes(tiny, serviceNodeId("tiny", tiny.services[0]))).toEqual([]);
+  });
+});
+
+describe("withUse", () => {
+  test("moves a call to the front without repeating it", () => {
+    const a = use("app", "pkg", "Svc", "A");
+    const b = use("app", "pkg", "Svc", "B");
+    expect(withUse([b, a], a)).toEqual([a, b]);
+  });
+
+  test("writes nothing when the call is already the most recent", () => {
+    const a = use("app", "pkg", "Svc", "A");
+    const ledger = [a, use("app", "pkg", "Svc", "B")];
+    expect(withUse(ledger, { ...a })).toBe(ledger);
+  });
+
+  test("caps the tail", () => {
+    const ledger = Array.from({ length: 200 }, (_, index) => use("app", "pkg", "Svc", `M${index}`));
+    expect(withUse(ledger, use("app", "pkg", "Svc", "New"))).toHaveLength(200);
+  });
+});

--- a/ui/src/treeExpansion.ts
+++ b/ui/src/treeExpansion.ts
@@ -1,0 +1,258 @@
+import { Method, Service } from "./apps";
+import { getPersistedValue, setPersistedValue } from "./storage";
+
+/**
+ * What the sidebar tree opens with. Expansion is a record of where you have
+ * been, not a guess about where you will go: three inputs decide it, in order —
+ * the calls you have made, the nodes you have folded yourself, and, only before
+ * either of those can say anything, how much of an app fits on screen.
+ */
+
+// A fold is a decision, an expansion is a suggestion: nothing derived here ever
+// reopens a node you closed. A node you have never touched is simply absent, and
+// absent is the only state a seed may write into.
+export type Fold = "open" | "shut";
+
+export interface FoldMap {
+  [nodeId: string]: Fold;
+}
+
+// What the model needs of an app: its name, and the services it compiled to.
+export interface TreeApp {
+  name: string;
+  services: Service[];
+}
+
+// One call, at the moment it was chosen or run. Only recency is kept — the list
+// is ordered, so there is no timestamp and no count for anything to read.
+export interface MethodUse {
+  app: string;
+  package: string;
+  service: string;
+  method: string;
+}
+
+// How many recent calls get the path to them opened. Three services is about
+// what stays legible above the fold; past that the tree becomes a list of
+// everything you have ever run.
+const RECENT_PATHS = 3;
+// Rows an app may open to when its size is all there is to go on. A sidebar with
+// other apps under it can spare about a screenful for one of them.
+const AUTO_ROWS = 12;
+// The ledger is recency, so its tail is dead weight rather than history.
+const LEDGER_LIMIT = 200;
+const LEDGER_KEY = "methodUses";
+
+export function appNodeId(appName: string): string {
+  return `app:${appName}`;
+}
+
+export function packageNodeId(appName: string, packageName: string): string {
+  return `pkg:${appName}/${packageName}`;
+}
+
+export function serviceNodeId(appName: string, service: Service): string {
+  return `svc:${appName}/${service.packageName}.${service.name}`;
+}
+
+export function hasMultiplePackages(services: Service[]): boolean {
+  if (services.length === 0) return false;
+  const first = services[0].packageName;
+  return services.some((service) => service.packageName !== first);
+}
+
+export function groupServicesByPackage(services: Service[]): [string, Service[]][] {
+  const groups = new Map<string, Service[]>();
+  for (const service of services) {
+    const existing = groups.get(service.packageName);
+    if (existing) existing.push(service);
+    else groups.set(service.packageName, [service]);
+  }
+  return [...groups.entries()];
+}
+
+export function isOpen(folds: FoldMap, nodeId: string): boolean {
+  return folds[nodeId] === "open";
+}
+
+// Levels below an app, outermost first: packages only exist as a level when the
+// app has more than one.
+function levelSizes(app: TreeApp): number[] {
+  const services = app.services.length;
+  const methods = app.services.reduce((total, service) => total + service.methods.length, 0);
+  if (!hasMultiplePackages(app.services)) return [services, methods];
+  return [groupServicesByPackage(app.services).length, services, methods];
+}
+
+// Rows the tree shows under an app opened `depth` levels deep: 1 reveals the
+// app's children, 2 reveals theirs, and so on.
+function rowsAtDepth(app: TreeApp, depth: number): number {
+  return levelSizes(app)
+    .slice(0, depth)
+    .reduce((total, size) => total + size, 0);
+}
+
+// The nodes that have to be open for that depth. A level opens whole or not at
+// all, which is what keeps this from picking one service out of a list.
+function nodesAtDepth(app: TreeApp, depth: number): string[] {
+  if (depth < 1) return [];
+  const nodes = [appNodeId(app.name)];
+  const multiple = hasMultiplePackages(app.services);
+  if (depth >= 2) {
+    if (multiple) nodes.push(...groupServicesByPackage(app.services).map(([packageName]) => packageNodeId(app.name, packageName)));
+    else nodes.push(...app.services.map((service) => serviceNodeId(app.name, service)));
+  }
+  if (depth >= 3 && multiple) nodes.push(...app.services.map((service) => serviceNodeId(app.name, service)));
+  return nodes;
+}
+
+/**
+ * How far into an app to open when nothing is known about it: as deep as it goes
+ * while staying inside `budget` rows, and never less than its first level, so an
+ * app you just added always says what is in it. A small API ends up open to its
+ * methods — a click away from a script — and a large one shows its shape.
+ */
+export function autoOpenNodes(app: TreeApp, budget: number = AUTO_ROWS): string[] {
+  for (let depth = levelSizes(app).length; depth > 1; depth--) {
+    if (rowsAtDepth(app, depth) <= budget) return nodesAtDepth(app, depth);
+  }
+  return nodesAtDepth(app, 1);
+}
+
+/**
+ * The nodes between an app and one of its methods, or undefined when the call no
+ * longer exists — a ledger entry outlives the proto that named it.
+ */
+export function usePath(app: TreeApp, use: MethodUse): string[] | undefined {
+  const service = app.services.find((candidate) => candidate.name === use.service && candidate.packageName === use.package);
+  if (!service || !service.methods.some((method) => method.name === use.method)) return undefined;
+  const path = [appNodeId(app.name)];
+  if (hasMultiplePackages(app.services)) path.push(packageNodeId(app.name, service.packageName));
+  path.push(serviceNodeId(app.name, service));
+  return path;
+}
+
+/**
+ * Everything under a node, for the ⌥click that takes a whole subtree at once.
+ * It is fold-all and unfold-all scoped to where the cursor already is, which is
+ * what let the two header buttons go.
+ */
+export function subtreeNodes(app: TreeApp, nodeId: string): string[] {
+  if (nodeId === appNodeId(app.name)) {
+    const nodes = hasMultiplePackages(app.services) ? groupServicesByPackage(app.services).map(([name]) => packageNodeId(app.name, name)) : [];
+    return [...nodes, ...app.services.map((service) => serviceNodeId(app.name, service))];
+  }
+  for (const [packageName, services] of groupServicesByPackage(app.services)) {
+    if (nodeId === packageNodeId(app.name, packageName)) return services.map((service) => serviceNodeId(app.name, service));
+  }
+  return [];
+}
+
+/**
+ * What the apps in `targets` open with, given everything already folded and
+ * every call made. Apps compile at their own pace, so this seeds some of them
+ * against all of them: the recent-call budget is spent globally, and whether
+ * this is a cold start is asked of the whole tree rather than of one app.
+ *
+ * An app the ledger cannot speak for stays shut — once there is a history,
+ * silence about an app means you don't use it. The exception is an app that is
+ * new since the ledger was written, which has nothing to be silent with and so
+ * falls back to its size.
+ */
+export function seedFolds(apps: TreeApp[], targets: ReadonlySet<string>, folds: FoldMap, ledger: MethodUse[], newApps: ReadonlySet<string>): FoldMap {
+  const next = { ...folds };
+  const open = (nodeId: string) => {
+    if (next[nodeId] === undefined) next[nodeId] = "open";
+  };
+
+  const spokenFor = new Set<string>();
+  let paths = 0;
+  for (const use of ledger) {
+    if (paths >= RECENT_PATHS) break;
+    const app = apps.find((candidate) => candidate.name === use.app);
+    if (!app) continue;
+    const path = usePath(app, use);
+    if (!path) continue;
+    // Paths into apps seeded earlier still spend the budget: they are open, and
+    // three is meant to be three across the tree.
+    paths++;
+    spokenFor.add(app.name);
+    if (targets.has(app.name)) path.forEach(open);
+  }
+
+  const coldStart = paths === 0;
+  for (const app of apps) {
+    if (!targets.has(app.name) || spokenFor.has(app.name)) continue;
+    if (!coldStart && !newApps.has(app.name)) continue;
+    autoOpenNodes(app).forEach(open);
+  }
+
+  return next;
+}
+
+/**
+ * Drop folds for nodes that no longer exist. An app that is still compiling — or
+ * that has no services for any other reason — has nothing to match against, so
+ * its subtree is left alone rather than cleared and re-seeded on every reload.
+ */
+export function pruneFolds(folds: FoldMap, apps: TreeApp[], compiling: ReadonlySet<string>): FoldMap {
+  const live = new Set<string>();
+  const spared: string[] = [];
+  for (const app of apps) {
+    live.add(appNodeId(app.name));
+    if (compiling.has(app.name) || app.services.length === 0) spared.push(`pkg:${app.name}/`, `svc:${app.name}/`);
+    if (hasMultiplePackages(app.services)) {
+      for (const [packageName] of groupServicesByPackage(app.services)) live.add(packageNodeId(app.name, packageName));
+    }
+    for (const service of app.services) live.add(serviceNodeId(app.name, service));
+  }
+
+  const kept: FoldMap = {};
+  for (const [nodeId, fold] of Object.entries(folds)) {
+    if (live.has(nodeId) || spared.some((prefix) => nodeId.startsWith(prefix))) kept[nodeId] = fold;
+  }
+  return Object.keys(kept).length === Object.keys(folds).length ? folds : kept;
+}
+
+export function methodUse(appName: string, service: Service, method: Method): MethodUse {
+  return { app: appName, package: service.packageName, service: service.name, method: method.name };
+}
+
+function sameUse(a: MethodUse, b: MethodUse): boolean {
+  return a.app === b.app && a.package === b.package && a.service === b.service && a.method === b.method;
+}
+
+export function withUse(ledger: MethodUse[], use: MethodUse): MethodUse[] {
+  if (ledger.length > 0 && sameUse(ledger[0], use)) return ledger;
+  return [use, ...ledger.filter((entry) => !sameUse(entry, use))].slice(0, LEDGER_LIMIT);
+}
+
+export function loadLedger(): MethodUse[] {
+  const stored = getPersistedValue<MethodUse[]>(LEDGER_KEY);
+  return Array.isArray(stored) ? stored : [];
+}
+
+/**
+ * Record a call, from the tree, the finder, or a script that ran it. A method
+ * call reports itself many times over while it streams, so a use already at the
+ * front writes nothing.
+ */
+export function recordUse(use: MethodUse): void {
+  const ledger = loadLedger();
+  const next = withUse(ledger, use);
+  if (next !== ledger) setPersistedValue(LEDGER_KEY, next);
+}
+
+export function loadFolds(): FoldMap {
+  const stored = getPersistedValue<FoldMap>("treeFolds");
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) return {};
+  const folds: FoldMap = {};
+  for (const [nodeId, fold] of Object.entries(stored)) {
+    if (fold === "open" || fold === "shut") folds[nodeId] = fold;
+  }
+  return folds;
+}
+
+export function saveFolds(folds: FoldMap): void {
+  setPersistedValue("treeFolds", folds);
+}


### PR DESCRIPTION
The sidebar guessed its expansion once, on first visit — the first two apps in `kaja.json` and their first service — and never again. It now derives from what you have called, what you have folded yourself, and (only on a cold start) how much of an app fits on screen.

Fold All and Unfold All are gone with it: ⌥click a row takes its whole subtree, which is the same verb where the cursor already is.

---
_Generated by [Claude Code](https://claude.ai/code/session_018pQruLFiPyd4CbHPL3EAWr)_