### PR TITLE
Split the run console into a list and a canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,10 @@ method in the sidebar is a *template*, not a document — clicking it fills a
   filled into it, which is usually what tells two goes at the same call apart;
   anything bigger or nested stays quiet rather than picking a field out of a
   crowd), `ListShows → GetShow`, `CreateShow +2`. Zero values never count —
-  that is what a generated request starts with.
+  that is what a generated request starts with. The **canvas verbs never count
+  either**: `kaja` is imported like a service and called like one, but
+  `kaja.table(...)` is the script drawing rather than a call it made, so a script
+  that only draws would otherwise be titled `text +3`.
 - **The title re-derives at deliberate moments, never while typing**: on a run
   (`markRun`) and on an append (`withCode`), because both are punctuation. There
   is **no rename** — naming a script and saving it are the same act, so the code
@@ -235,77 +238,143 @@ service*), and it never ran again: whatever you got on day one you kept forever.
   differ, and ignoring them lands an existing workspace on the cold start, which
   is a better tree than their stale contents would rebuild.
 
-## The console reports runs
+## A run has two views
 
-**A run is the unit** (`runs.ts`): one press of Run, one header, one duration,
-one verdict, with the calls it made nested under it. One script can make three
-calls, and three unrelated rows say nothing about the thing you actually pressed.
+**A run is the unit** (`runs.ts`): one press of Run, one duration, one verdict,
+with everything it produced under it. One script can make three calls, and three
+unrelated rows say nothing about the thing you actually pressed.
 
-**And the console belongs to the file** (`runHistory.ts`). There is no shared
+**And a run has two views of that, because they want opposite things.** The
+**list** is the flat audit log — one row per call, in wall order, always
+complete; that is what makes it scannable at two hundred rows and lets every row
+carry the same extra channels. The **canvas** is the rendered output — varied,
+and free to fold what is repetitive. Every attempt to serve both in one surface
+bent one of them out of shape, so one segmented control in the header switches
+them and **everything else about the header stops moving**. That is the change
+that pays for the restructure.
+
+**A row is a call and only a call.** No disclosure triangles, no block rows, no
+run row. Splitting the views is what deletes the double-statement problem — an
+index of "table · 42 rows" rows sitting above the same tables rendered below —
+and it is why Request/Response/Headers moved **down onto the payload pane**: the
+header no longer rearranges itself as the selection moves, and the pane never
+reflows as you step through the log.
+
+**The console belongs to the file** (`runHistory.ts`). There is no shared
 console: a run lands in the console of the script it was pressed on and stays
 there, so switching files switches consoles and coming back finds the runs, the
-selection and the tab as they were left. With one pane showing one file, a
-console reporting some other file's run under the code on screen was the same
-"which one is current" problem the tab strip removal set out to answer.
+selection, the tab and the view as they were left.
 
 - **Keyed by file, not held on the view.** `RunHistory` is `{ [fileId]:
   FileConsole }`, where a `fileId` is a scratch id or a script path and a
-  `FileConsole` is that file's runs, calls, selection and tab. Views are a
+  `FileConsole` is that file's runs, items, selection, tab and view. Views are a
   ten-slot cache, so a console living on one would be thrown away by ordinary
   navigation. ("Source" was the old name for this and is taken: it means an
   app's generated proto TypeScript.)
+- **An item is anything that happened in a run** — a call, a block the script
+  drew, or the log messages it printed. Blocks are items rather than a parallel
+  world, so they inherit run grouping, ordering, the per-file console and the
+  store without any of it being written twice.
 - **The scope is what makes the history worth stepping through.** `⌃↑`/`⌃↓` walk
-  *this call's* runs, so one go at it is comparable against the last — which is
-  what the run history was for. Caps are per file (25 runs, 300 calls), so a
-  chatty script can no longer evict another's history; fifty files hold a console
-  at once and the least recently run is let go.
+  *this file's* runs, so one go at it is comparable against the last. Caps are
+  per file (25 runs, 300 items), so a chatty script can no longer evict another's
+  history; fifty files hold a console at once and the least recently run is let go.
+- **Runs are numbered, not named.** A console holds one script's runs, so naming
+  each after that script says the same thing on every row — the pill reads `Run
+  3 · 14:03 · 1.2 s` and the picker hangs off it, which keeps run identity in the
+  one place it already lives. The number is the run's own (`Run.number`, assigned
+  in `startRun`), because a position would renumber as the oldest runs are
+  trimmed out from under it. `Run.title` still carries the derived script name,
+  which is what the window title and the store read.
+- **Two extra channels on every row, and no third.** The **loop key**
+  (`loopKey.ts`) is the identifying value read off the request — the only thing
+  making two hundred identical method names tellable apart — and it shares its
+  field list with `scratchTitle` so "what identifies a call" is defined once. The
+  **duration bar** is drawn against the slowest call in the run, so finding the
+  slow one is a shape you see rather than four digits you read; a run with
+  nothing to compare gets no bars.
+- **The log is never collapsed or summarised away.** It stays complete at any
+  length, and the tail bar says what is out of sight (`13 more`) rather than
+  standing in for it. Loop folding belongs on the canvas only.
 - **A run that has nowhere to land is not kept.** An agent running code that was
   never saved has no file, so no console; it still gets its results back. A call
   arriving with no run open gets one under the file the last run came from, which
   is where a late call almost certainly belongs.
 - **A run keeps going when you navigate away from it**, and its console is no
   longer on screen to say so — so the sidebar row does, with a spinner in place
-  of its icon (`runningFileIds`). Run/Stop in the command row still tracks the
-  *active* run, because Stop has to abort what it is showing.
+  of its icon (`runningFileIds`), or the waiting ring below. Run/Stop in the
+  command row still tracks the *active* run, because Stop has to abort what it is
+  showing — including a run parked on a question, which is awaiting an answer
+  rather than a call.
 - **Renaming or saving moves the console; deleting takes it with the file.**
   Saving a scratch to disk changes what the file is called, not what it is, so
   its runs follow it from the scratch id to the path (`renameFile`). Discarding a
   scratch is undoable, so its console is held alongside it and comes back.
-- **Three rules make the grouping hold.** ① A run's status is the **worst status
-  it contains** (`worstStatus`) — there is no "partially succeeded", and the
-  header dot is the only thing anyone needs to read after a press. ② A
-  **single-item run renders as one row**, header and call merged, so the 90% case
-  stays as flat as it was. ③ Calls inside a run are ordered by start, never
-  re-sorted, and keep their own durations; the header's duration is **wall time
-  for the whole script**, which is the number that differs from the sum when
-  calls run concurrently.
-- **The history lists runs, not calls.** Same select, one level up: each row is a
-  run with its call count, today's above a dimmed date header for older ones.
-  `⌃↑`/`⌃↓` step through runs. Selecting a call fills the response below;
-  selecting the run header shows the run's own summary instead.
+- **A run's status is the worst status it contains** (`worstStatus`) — there is
+  no "partially succeeded", and the pill's dot is the only thing anyone needs to
+  read after a press. Items are ordered by start, never re-sorted, and keep their
+  own durations; the run's duration is **wall time for the whole script**, which
+  is the number that differs from the sum when calls run concurrently.
 - **A new run always takes the console** (`followSelection`), because pressing Run
   is a request to see what it did — from an older run stepped back to as much as
   from the last one. Everything short of a new run stays where it is put: a call
   landing in a later run leaves a stepped-back one alone, and only inside the run
   being watched does the cursor follow the newest call, which is what selects one
   in flight the moment it is issued rather than when its response lands.
-- **Run names reuse the derived script names**, so the console and the sidebar
-  speak the same language. The window title follows the same name, from the
-  scratch list rather than the view — running or appending re-derives a title
-  without the view itself changing.
-- **Live and last-time are different states, and the header is the only place
-  that can say which.** Reopening a script gives you its code and, if we still
-  hold it, its last run (`runStore.ts`): the header carries a `Last run` pill and
-  a date instead of a clock, and the body sits at 70% opacity. Pressing Run
-  replaces it in place — a run made in this session always wins over a stored
-  one. Retention can be short because **expiry is a stated state, not a silent
-  hole**: headers are kept for the fifty most recently run files, payloads for
-  seven days (or dropped at once if they don't fit), and a run whose payloads have
-  gone keeps its header over a single line — `Response no longer kept — run to
-  see it live`. Clearing the history clears the store too.
+- **Live and last-time are different states.** Reopening a script gives you its
+  code and, if we still hold it, its last run (`runStore.ts`), at 70% opacity.
+  Pressing Run replaces it in place — a run made in this session always wins over
+  a stored one. Retention can be short because **expiry is a stated state, not a
+  silent hole**: headers are kept for the fifty most recently run files, payloads
+  for seven days (or dropped at once if they don't fit), and a run whose payloads
+  have gone says `Response no longer kept — run to see it live`. Clearing the
+  history clears the store too.
 - **With no run there is nothing to select.** The console drops its header
   entirely until something has been run, rather than showing Response as
   selected and the other two as disabled over an empty panel.
+
+## The canvas is what a run drew
+
+**A script says what it made, never how it looks.** The block set is closed and
+tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask` — and
+that is the guard, not a starting point: the moment a script can paint pixels the
+console is a rendering engine and every block becomes a support surface. There is
+no `kaja.html`, no styling arguments, no layout control.
+
+- **Ordered, never placed.** Blocks stack in the order they were emitted, like
+  calls do. "Canvas" is the name; the thing is a document. Free 2D positioning is
+  the single feature that would turn this into a quarter of work.
+- **A table is a handle, because a loop is why tables exist here.** `kaja.table`
+  returns something with `.row(...)`, and rows land one at a time so the canvas
+  repaints as the loop runs — waiting for it to finish would make the interesting
+  part the part you can't watch. Blocks are recorded against their own id
+  (`recordBlock`), so a block that fills in stays where it was emitted rather
+  than jumping to the end.
+- **Calls appear as one-line cards.** They can stay minimal because the complete
+  record is one click away: clicking a card selects that call's row in the list
+  and switches to it. The payload is never unrolled into the flow — that is
+  master/detail smuggled back in at 90°.
+- **A block that asks is a block that pauses the run.** `kaja.ask` is drawn where
+  it happened and the canvas stops there — the empty space under it *is* the
+  pause. Answering appends the next block. A dialogue is not a fifth block type;
+  it is what a sequence of asks reads as.
+- **Splitting the views reintroduces exactly one problem: a run can be waiting on
+  the tab you are not looking at.** So a parked run says so three times before
+  you can leave it — an amber dot on the Canvas tab, an amber bar at the tail of
+  the log with `Go to canvas`, and the run pill going amber — and a fourth time
+  once you have, as an amber ring on the sidebar row (`waitingFileIds`), because
+  a spinner there would say the script was working rather than waiting. The log
+  stays readable throughout: the pause blocks the script, not your reading.
+- **An ask with no canvas falls back to the dialog.** A run with no file has no
+  console to draw on (an agent running code that was never saved), and the modal
+  needs no surface of its own. A question that was never answered is stored as
+  cancelled, because the promise it was blocking died with the session.
+- **Which view a run opens in** (`defaultView`): a run that drew something opens
+  on its canvas — it was executed for its output, and the log is where you go
+  when the output is wrong — while a run that only made calls opens on its log,
+  since its canvas would be a true but redundant view of the same calls. An
+  explicit choice outranks that and sticks per file: debugging is a mode, not a
+  click.
 
 ## The empty state
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "./cn";
 import { CommandRow } from "./CommandRow";
 import { Console } from "./Console";
-import { ConsoleTab, newRunId, Run, RunSelection } from "./runs";
+import { ConsoleTab, ConsoleView, newRunId, Run, RunSelection } from "./runs";
 import {
   adoptStoredRuns,
   clearFile,
@@ -19,6 +19,7 @@ import {
   fileConsole,
   hasCallsInFlight,
   putFile,
+  recordBlock,
   recordCall,
   recordLogs,
   renameFile,
@@ -26,9 +27,11 @@ import {
   runningFileIds,
   setSelection,
   setTab,
+  setView,
   settleRun,
   startRun,
   takeFile,
+  waitingFileIds,
   FileConsole,
 } from "./runHistory";
 import { dropStoredFile, loadRuns, renameStoredFile, saveRuns } from "./runStore";
@@ -37,6 +40,7 @@ import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
 import { Gutter } from "./Gutter";
+import { Block } from "./blocks";
 import { AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
@@ -438,17 +442,47 @@ export function App() {
     [openRun],
   );
 
-  // Open the input dialog for a `kaja.ask(...)` call, resolving once the user
-  // submits. Rejecting on cancel is handled by the dialog itself.
-  const onAsk = useCallback((message: string) => {
+  // Something the script drew. Blocks arrive more than once — a table paints row
+  // by row — so they are recorded against their own id rather than appended.
+  const onBlockUpdate = useCallback(
+    (blockId: string, block: Block) => {
+      const run = openRun("Script output");
+      setHistory((current) => recordBlock(current, run.fileId, run.id, blockId, block, Date.now()));
+    },
+    [openRun],
+  );
+
+  /**
+   * A `kaja.ask(...)` is answered on the canvas of the run that asked it, so the
+   * promise waits here keyed by the block the question was drawn as. A run with
+   * no console has no canvas to draw on — an agent running code that was never
+   * saved — and falls back to the dialog, which needs no surface of its own.
+   */
+  const pendingAsksRef = useRef(new Map<string, { resolve: (answer: string) => void; reject: (error: unknown) => void }>());
+
+  const onAsk = useCallback((message: string, blockId: string) => {
     return new Promise<string>((resolve, reject) => {
-      setAskPrompt({ message, value: "", resolve, reject });
+      if (!currentRunRef.current?.fileId) {
+        setAskPrompt({ message, value: "", resolve, reject });
+        return;
+      }
+      pendingAsksRef.current.set(blockId, { resolve, reject });
     });
   }, []);
 
+  const settleAsk = useCallback((blockId: string, settle: (pending: { resolve: (answer: string) => void; reject: (error: unknown) => void }) => void) => {
+    const pending = pendingAsksRef.current.get(blockId);
+    if (!pending) return;
+    pendingAsksRef.current.delete(blockId);
+    settle(pending);
+  }, []);
+
+  const onAnswerAsk = useCallback((blockId: string, answer: string) => settleAsk(blockId, (pending) => pending.resolve(answer)), [settleAsk]);
+  const onCancelAsk = useCallback((blockId: string) => settleAsk(blockId, (pending) => pending.reject(new AskCancelledError())), [settleAsk]);
+
   const kajaRef = useRef<Kaja>(null);
   if (!kajaRef.current) {
-    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk);
+    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onBlockUpdate);
   }
 
   // Clearing a file's history clears what is being held of it for next time too;
@@ -1581,13 +1615,15 @@ export function App() {
   }, [currentFileId]);
 
   // Stop aborts the calls the run has in flight; the script itself stops at the
-  // call it was awaiting.
+  // call it was awaiting. A run parked on a question is awaiting an answer
+  // rather than a call, so Stop has to end that too or the script never returns.
   const onStopActiveRun = useCallback(() => {
+    for (const blockId of [...pendingAsksRef.current.keys()]) onCancelAsk(blockId);
     setActiveRun((run) => {
       run?.controller?.abort();
       return null;
     });
-  }, []);
+  }, [onCancelAsk]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -1849,6 +1885,7 @@ export function App() {
   // Which files have something in the air, so a run started on one script says
   // so while you are looking at another.
   const runningFiles = useMemo(() => runningFileIds(history), [history]);
+  const waitingFiles = useMemo(() => waitingFileIds(history), [history]);
 
   const onConsoleSelect = useCallback(
     (selection: RunSelection | null) => setHistory((current) => setSelection(current, currentFileId, selection, Date.now())),
@@ -1856,6 +1893,8 @@ export function App() {
   );
 
   const onConsoleTabChange = useCallback((tab: ConsoleTab) => setHistory((current) => setTab(current, currentFileId, tab, Date.now())), [currentFileId]);
+
+  const onConsoleViewChange = useCallback((view: ConsoleView) => setHistory((current) => setView(current, currentFileId, view, Date.now())), [currentFileId]);
 
   // What the empty state offers instead of an illustration: the last few things
   // you were in. On a first run there are none and the list is simply absent.
@@ -1979,6 +2018,7 @@ export function App() {
                 onPinScript={isDesktopMac ? onPinScript : undefined}
                 pinnedScriptPath={pinnedScriptPath}
                 runningFileIds={runningFiles}
+                waitingFileIds={waitingFiles}
                 scratches={scratches}
                 currentScratchId={currentView?.type === "scratch" ? currentView.scratchId : undefined}
                 onScratchSelect={onScratchSelect}
@@ -2117,8 +2157,12 @@ export function App() {
                         items={currentConsole.items}
                         selection={currentConsole.selection}
                         tab={currentConsole.tab}
+                        view={currentConsole.view}
                         onSelect={onConsoleSelect}
                         onTabChange={onConsoleTabChange}
+                        onViewChange={onConsoleViewChange}
+                        onAnswer={onAnswerAsk}
+                        onCancelAsk={onCancelAsk}
                         onClear={currentFileId ? () => onClearConsole(currentFileId) : undefined}
                       />
                     </div>

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,0 +1,228 @@
+import { ChevronRight } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
+import { cn } from "./cn";
+import { MethodCall } from "./kaja";
+import { callErrorCode, formatDuration } from "./callFormat";
+import { ConsoleItem, RunGroup } from "./runs";
+import { Log, LogLevel } from "./server/api";
+
+interface CanvasProps {
+  group: RunGroup;
+  onAnswer: (blockId: string, answer: string) => void;
+  onCancelAsk: (blockId: string) => void;
+  // Clicking a call card takes you to that call's row in the log, which is where
+  // its complete record is. The card can stay minimal because of it.
+  onSelectCall: (itemId: string) => void;
+}
+
+/**
+ * What the run drew, in emission order. Calls appear as one-line cards where the
+ * story needs them — they can stay minimal because the complete record is one
+ * click away in the list.
+ */
+export function Canvas({ group, onAnswer, onCancelAsk, onSelectCall }: CanvasProps) {
+  if (group.run.payloadsExpired) {
+    return <Canvas.Notice>Canvas no longer kept — run to see it live</Canvas.Notice>;
+  }
+  if (group.items.length === 0) {
+    return <Canvas.Notice>{group.inFlight ? "Waiting for the first call…" : "This run drew nothing."}</Canvas.Notice>;
+  }
+
+  return (
+    <div className={cn("flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-3 font-mono text-xs", group.run.stale && "opacity-70")}>
+      {group.items.map((item) => (
+        // Blocks keep their full height and the canvas scrolls. Without this a
+        // long table is squeezed to a couple of rows to make the run fit — the
+        // rows are still there, which is what makes it look like a rendering
+        // bug rather than a layout one.
+        <div key={item.id} className="shrink-0">
+          <Canvas.Item item={item} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={onSelectCall} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+Canvas.Notice = function ({ children }: { children: React.ReactNode }) {
+  return <div className="flex min-h-0 flex-1 items-center justify-center p-3 text-center text-xs text-muted-foreground">{children}</div>;
+};
+
+interface ItemProps {
+  item: ConsoleItem;
+  onAnswer: (blockId: string, answer: string) => void;
+  onCancelAsk: (blockId: string) => void;
+  onSelectCall: (itemId: string) => void;
+}
+
+Canvas.Item = function ({ item, onAnswer, onCancelAsk, onSelectCall }: ItemProps) {
+  if (item.call) return <Canvas.CallCard call={item.call} onSelect={() => onSelectCall(item.id)} />;
+  if (item.logs) return <Canvas.Logs logs={item.logs} />;
+  if (!item.block) return null;
+  return <Canvas.Block id={item.id} block={item.block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
+};
+
+interface BlockProps {
+  id: string;
+  block: Block;
+  onAnswer: (blockId: string, answer: string) => void;
+  onCancelAsk: (blockId: string) => void;
+}
+
+Canvas.Block = function ({ id, block, onAnswer, onCancelAsk }: BlockProps) {
+  switch (block.kind) {
+    case "text":
+      return <Canvas.Text block={block} />;
+    case "code":
+      return <Canvas.Code block={block} />;
+    case "table":
+      return <Canvas.Table block={block} />;
+    case "ask":
+      return <Canvas.Ask id={id} block={block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
+  }
+};
+
+Canvas.Text = function ({ block }: { block: TextBlock }) {
+  return <div className="whitespace-pre-wrap break-words leading-relaxed text-foreground">{block.text}</div>;
+};
+
+Canvas.Code = function ({ block }: { block: CodeBlock }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-card">
+      {block.language && <div className="border-b border-border px-2.5 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">{block.language}</div>}
+      <pre className="overflow-x-auto px-2.5 py-2 leading-relaxed text-foreground">{block.code}</pre>
+    </div>
+  );
+};
+
+// A wide table scrolls inside itself; the canvas never scrolls sideways as a
+// whole, because everything above and below it would move with it.
+Canvas.Table = function ({ block }: { block: TableBlock }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            {block.columns.map((column, index) => (
+              <th
+                key={index}
+                className="whitespace-nowrap border-b border-border py-1 pr-4 text-left text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+              >
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {block.rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {row.map((cell, cellIndex) => (
+                <td key={cellIndex} className="border-b border-border/50 py-1 pr-4 align-top text-foreground">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {block.rows.length === 0 && <div className="py-1.5 text-muted-foreground">No rows yet…</div>}
+    </div>
+  );
+};
+
+interface AskProps {
+  id: string;
+  block: AskBlock;
+  onAnswer: (blockId: string, answer: string) => void;
+  onCancelAsk: (blockId: string) => void;
+}
+
+/**
+ * The question the run is stopped on. Amber is Kaja's "needs you" colour, and it
+ * is the whole signal here: the block, the Canvas tab's dot and the run pill all
+ * carry it, so a parked run is findable from wherever you happen to be.
+ */
+Canvas.Ask = function ({ id, block, onAnswer, onCancelAsk }: AskProps) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const waiting = block.answer === undefined && !block.cancelled;
+
+  useEffect(() => {
+    if (waiting) inputRef.current?.focus();
+  }, [waiting]);
+
+  return (
+    <div className={cn("flex flex-col gap-2 rounded-r-md border-l-2 py-2.5 pl-3 pr-3", waiting ? "border-amber-500 bg-amber-500/10" : "border-border bg-card")}>
+      <div className={cn("whitespace-pre-wrap break-words", waiting ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground")}>{block.question}</div>
+      {waiting ? (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500 bg-background px-2.5 py-1.5">
+          <input
+            ref={inputRef}
+            data-testid="canvas-ask-input"
+            className="min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
+            placeholder="Answer…"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                onAnswer(id, value);
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                onCancelAsk(id);
+              }
+            }}
+          />
+          <span className="shrink-0 text-muted-foreground">⏎</span>
+        </div>
+      ) : (
+        <div className={cn("break-words", block.cancelled ? "italic text-muted-foreground" : "text-foreground")}>
+          {block.cancelled ? "Cancelled" : block.answer}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// A call on the canvas is a one-line card: enough to place it in the story, and
+// a click away from the row that holds everything about it.
+Canvas.CallCard = function ({ call, onSelect }: { call: MethodCall; onSelect: () => void }) {
+  const status = call.error ? "error" : call.output === undefined && call.streamOutputs === undefined ? "pending" : "success";
+  const code = callErrorCode(call);
+
+  return (
+    <button
+      type="button"
+      data-testid="canvas-call-card"
+      className="flex w-full items-center gap-2.5 rounded-md border border-border bg-card px-2.5 py-1.5 text-left hover:bg-accent"
+      onClick={onSelect}
+    >
+      <ChevronRight size={12} className="shrink-0 text-muted-foreground" />
+      <span
+        className={cn("h-1.5 w-1.5 shrink-0 rounded-full", status === "error" ? "bg-red-500" : status === "pending" ? "bg-muted-foreground" : "bg-emerald-500")}
+      />
+      <span className="min-w-0 flex-1 truncate text-foreground">
+        {call.service.name}.{call.method.name}
+      </span>
+      {code && <span className="shrink-0 rounded-full bg-destructive/15 px-2 py-0.5 text-[10px] text-destructive">{code}</span>}
+      <span className="shrink-0 tabular-nums text-muted-foreground">{formatDuration(call.durationMs)}</span>
+    </button>
+  );
+};
+
+// A script that threw is the run's own failure rather than any one call's, so it
+// lands on the canvas as the last thing that happened.
+Canvas.Logs = function ({ logs }: { logs: Log[] }) {
+  const failed = logs.some((log) => log.level === LogLevel.LEVEL_ERROR);
+  return (
+    <div
+      className={cn("flex flex-col gap-1 rounded-r-md border-l-2 py-2.5 pl-3 pr-3", failed ? "border-destructive bg-destructive/10" : "border-border bg-card")}
+    >
+      {logs.map((log, index) => (
+        <div key={index} className={cn("whitespace-pre-wrap break-words", failed ? "text-destructive" : "text-foreground")}>
+          {log.message.trim()}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -1,16 +1,36 @@
-import { Check, ChevronDown, ChevronRight, ChevronUp, ChevronsUpDown, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
-import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, ChevronsUpDown, ChevronUp, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
+import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { blockText } from "./blocks";
+import { barFraction, callErrorCode, dotClass, formatBytes, formatDuration, payloadBytes, statusClass } from "./callFormat";
 import { formatClockTime, formatDayLabel, formatElapsed, isSameDay } from "./callTime";
+import { Canvas } from "./Canvas";
 import { cn } from "./cn";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { IconButton } from "./components/icon-button";
+import { SegmentedControl } from "./components/segmented-control";
 import { Spinner } from "./components/spinner";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
 import { MethodCall } from "./kaja";
-import { callCount, ConsoleItem, ConsoleTab, followSelection, groupRuns, itemName, itemStatus, Run, RunGroup, RunSelection, RunStatus } from "./runs";
+import { loopKey } from "./loopKey";
+import {
+  awaitingItem,
+  callItems,
+  ConsoleItem,
+  ConsoleTab,
+  ConsoleView,
+  defaultView,
+  followSelection,
+  groupRuns,
+  itemStatus,
+  Run,
+  RunGroup,
+  RunSelection,
+  RunStatus,
+  slowestCall,
+} from "./runs";
 import { runShortcutLabel } from "./RunButton";
-import { Log, LogLevel } from "./server/api";
+import { LogLevel } from "./server/api";
 import { unwrapFailure, upstreamRequestLine } from "./upstreamHeaders";
 
 export type { ConsoleItem } from "./runs";
@@ -19,19 +39,24 @@ export type { ConsoleItem } from "./runs";
 // never turns the console header into a full-height surface.
 const RUN_ROW_HEIGHT = 32;
 const MAX_VISIBLE_RUN_ROWS = 8;
-// Beyond this the qualified call name is truncated from the left, so the method
-// — the part that identifies the call — survives.
-const MAX_TRIGGER_NAME_LENGTH = 28;
-// Both time columns are reserved: the longest value they can ever hold sets the
-// geometry once, so nothing moves as calls settle and age.
-const DETAIL_COLUMN_CLASS = "w-[9ch] shrink-0 truncate text-right font-mono text-xs tabular-nums text-muted-foreground";
-const TIME_COLUMN_CLASS = "w-[8ch] shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground";
+// The log's rows are a fixed height, which is what lets the tail bar say how
+// many of them are still below without measuring any of them.
+const CALL_ROW_HEIGHT = 24;
+// How much of the console the log may take before the payload pane stops
+// shrinking. The pane is the thing being read; the log is how you choose it.
+const MAX_LOG_HEIGHT = "45%";
+// The widest a duration bar is drawn, in pixels.
+const BAR_WIDTH = 88;
 
-const consoleTabClass = "cursor-pointer select-none whitespace-nowrap text-sm text-muted-foreground hover:text-foreground";
+const consoleTabClass = "cursor-pointer select-none whitespace-nowrap text-xs text-muted-foreground hover:text-foreground";
 const consoleTabActiveClass = "font-medium text-foreground";
 // Utilities carry no resting chrome: they are worth no more weight than the tabs
 // beside them.
 const utilityButtonClass = "h-6 w-6 rounded-md hover:bg-accent hover:text-foreground";
+// Both time columns are reserved: the longest value they can ever hold sets the
+// geometry once, so nothing moves as calls settle and age.
+const DETAIL_COLUMN_CLASS = "w-[9ch] shrink-0 truncate text-right font-mono text-xs tabular-nums text-muted-foreground";
+const TIME_COLUMN_CLASS = "w-[8ch] shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground";
 
 interface ConsoleProps {
   // Which file's console this is. It is the whole scope: the runs are that
@@ -40,15 +65,40 @@ interface ConsoleProps {
   runs: Run[];
   items: ConsoleItem[];
   // Where the console is pointing and what it is showing of the selected call.
-  // Both are kept per file by the caller, so coming back finds it as it was.
+  // All three are kept per file by the caller, so coming back finds it as it was.
   selection: RunSelection | null;
   tab: ConsoleTab;
+  // Undefined until a view has been chosen, which is what lets a run that drew
+  // something open on its canvas without overriding a choice already made.
+  view?: ConsoleView;
   onSelect: (selection: RunSelection | null) => void;
   onTabChange: (tab: ConsoleTab) => void;
+  onViewChange: (view: ConsoleView) => void;
+  onAnswer: (blockId: string, answer: string) => void;
+  onCancelAsk: (blockId: string) => void;
   onClear?: () => void;
 }
 
-export function Console({ fileId, runs, items, selection, tab: activeTab, onSelect, onTabChange, onClear }: ConsoleProps) {
+/**
+ * A console belongs to a script and holds its runs; a run has two views of the
+ * same data. The list is the flat audit log — one row per call, in wall order,
+ * always complete. The canvas is the rendered output. One segmented control
+ * switches them, and everything else about the header stops moving.
+ */
+export function Console({
+  fileId,
+  runs,
+  items,
+  selection,
+  tab: activeTab,
+  view,
+  onSelect,
+  onTabChange,
+  onViewChange,
+  onAnswer,
+  onCancelAsk,
+  onClear,
+}: ConsoleProps) {
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState(false);
 
@@ -86,14 +136,16 @@ export function Console({ fileId, runs, items, selection, tab: activeTab, onSele
   }, [fileId, newest?.run.id, newest?.items.length, groups.length]);
 
   const selectedGroup = groups.find((group) => group.run.id === selection?.runId);
-  const selectedItem = selectedGroup?.items.find((item) => item.id === selection?.itemId);
+  const rows = selectedGroup ? callItems(selectedGroup) : [];
+  const selectedItem = rows.find((item) => item.id === selection?.itemId);
   const selectedCall = selectedItem?.call;
-  const selectedLogs = selectedItem?.logs;
+  const activeView = view ?? defaultView(selectedGroup);
+  const waiting = selectedGroup ? awaitingItem(selectedGroup) : undefined;
 
   const selectRun = useCallback(
     (group: RunGroup) => {
-      const last = group.items[group.items.length - 1];
-      onSelect({ runId: group.run.id, itemId: last?.id });
+      const calls = callItems(group);
+      onSelect({ runId: group.run.id, itemId: calls[calls.length - 1]?.id });
     },
     [onSelect],
   );
@@ -115,12 +167,32 @@ export function Console({ fileId, runs, items, selection, tab: activeTab, onSele
   }, [groups, selection?.runId, selectRun]);
 
   const handleCopy = useCallback(() => {
-    jsonViewerRef.current?.copyToClipboard();
+    if (activeView === "canvas") {
+      const text = (selectedGroup?.items ?? [])
+        .map((item) => (item.block ? blockText(item.block) : item.call ? `${item.call.service.name}.${item.call.method.name}` : ""))
+        .filter((line) => line.length > 0)
+        .join("\n\n");
+      navigator.clipboard?.writeText(text);
+    } else {
+      jsonViewerRef.current?.copyToClipboard();
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), 1200);
-  }, []);
+  }, [activeView, selectedGroup]);
 
-  // With no run there is no selection to show and no tabs to choose between:
+  // Clicking a call on the canvas is a request for its complete record, which
+  // only the log has — so it takes you there rather than unrolling a payload
+  // into the flow.
+  const selectFromCanvas = useCallback(
+    (itemId: string) => {
+      if (!selectedGroup) return;
+      onViewChange("list");
+      onSelect({ runId: selectedGroup.run.id, itemId });
+    },
+    [selectedGroup, onSelect, onViewChange],
+  );
+
+  // With no run there is no selection to show and no views to choose between:
   // a selected Response over an empty panel implies a state the console doesn't
   // have. The empty line is the only thing that should speak.
   if (groups.length === 0) {
@@ -131,25 +203,42 @@ export function Console({ fileId, runs, items, selection, tab: activeTab, onSele
     );
   }
 
-  const showUtilities = selectedCall !== undefined && (activeTab === "request" || activeTab === "response");
+  const showUtilities = activeView === "canvas" || selectedCall !== undefined;
   const position = selectedGroup ? groups.indexOf(selectedGroup) + 1 : groups.length;
-  // The header row is what ties a script's calls to the press that made them, so
-  // it appears whenever there is more than one — and on a stale run, where it is
-  // the only place that can say "this is not live".
-  const showRunHeader = selectedGroup !== undefined && (selectedGroup.items.length > 1 || selectedGroup.run.stale === true);
-  const showRunChildren = (selectedGroup?.items.length ?? 0) > 1;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
-      {/* One row spanning the full console width: which run, how to step through
-          them, what to look at, and what to do with it. Narrowing it never wraps
-          a second line. Everything holds its size and leaves in order of what it
-          is worth — the run's time, then its call count, then the stepper (whose
-          history the trigger and ⌃↑/⌃↓ still reach), then the payload utilities
-          — and the run's name truncates through all of it. */}
+      {/* One row spanning the full console width, and it holds its shape: which
+          run, which view, how to step through them, and what to do with what is
+          shown. Nothing here rearranges as the selection moves — that is the
+          change the split pays for. Everything leaves in order of what it is
+          worth as the panel narrows, and the run pill truncates through all of
+          it. */}
       <div className="@container flex h-[35px] shrink-0 items-center gap-3 overflow-hidden border-b border-border px-3">
         <Console.RunSelect groups={groups} selectedGroup={selectedGroup} onSelect={selectRun} onClear={onClear} now={now} />
-        <div className="flex shrink-0 items-center gap-1 @max-[540px]:hidden">
+        <div className="h-4 w-px shrink-0 bg-border" />
+        <SegmentedControl className="h-[26px] shrink-0 p-[2px]" aria-label="Run view">
+          <SegmentedControl.Button
+            selected={activeView === "list"}
+            className="h-[20px] px-2.5 py-0 text-xs"
+            onClick={() => onViewChange("list")}
+            data-testid="console-view-list"
+          >
+            List
+          </SegmentedControl.Button>
+          <SegmentedControl.Button
+            selected={activeView === "canvas"}
+            className="h-[20px] gap-1.5 px-2.5 py-0 text-xs"
+            onClick={() => onViewChange("canvas")}
+            data-testid="console-view-canvas"
+          >
+            Canvas
+            {/* One of three chances to notice a parked run before you leave the
+                script — the others are the tail of the log and the run pill. */}
+            {waiting && activeView !== "canvas" && <span data-testid="canvas-badge" className="h-1.5 w-1.5 rounded-full bg-amber-500" />}
+          </SegmentedControl.Button>
+        </SegmentedControl>
+        <div className="flex shrink-0 items-center gap-1 @max-[560px]:hidden">
           <IconButton
             icon={ChevronUp}
             aria-label="Previous run"
@@ -174,77 +263,279 @@ export function Console({ fileId, runs, items, selection, tab: activeTab, onSele
             {position} of {groups.length}
           </span>
         </div>
-        {selectedCall && (
-          <>
-            <div className="h-4 w-px shrink-0 bg-border" />
-            <Console.DetailTabs methodCall={selectedCall} activeTab={activeTab} onTabChange={onTabChange} />
-          </>
-        )}
         {showUtilities && (
           <div className="ml-auto flex shrink-0 items-center gap-2 @max-[430px]:hidden">
+            {activeView === "list" && (
+              <>
+                <IconButton
+                  icon={FoldVertical}
+                  aria-label="Fold all"
+                  variant="ghost"
+                  size="sm"
+                  className={utilityButtonClass}
+                  onClick={() => jsonViewerRef.current?.foldAll()}
+                />
+                <IconButton
+                  icon={UnfoldVertical}
+                  aria-label="Unfold all"
+                  variant="ghost"
+                  size="sm"
+                  className={utilityButtonClass}
+                  onClick={() => jsonViewerRef.current?.unfoldAll()}
+                />
+                <div className="h-4 w-px bg-border" />
+              </>
+            )}
             <IconButton
-              icon={FoldVertical}
-              aria-label="Fold all"
+              icon={copied ? Check : Copy}
+              aria-label={activeView === "canvas" ? "Copy canvas" : "Copy JSON"}
               variant="ghost"
               size="sm"
               className={utilityButtonClass}
-              onClick={() => jsonViewerRef.current?.foldAll()}
+              onClick={handleCopy}
             />
-            <IconButton
-              icon={UnfoldVertical}
-              aria-label="Unfold all"
-              variant="ghost"
-              size="sm"
-              className={utilityButtonClass}
-              onClick={() => jsonViewerRef.current?.unfoldAll()}
-            />
-            <div className="h-4 w-px bg-border" />
-            <IconButton icon={copied ? Check : Copy} aria-label="Copy JSON" variant="ghost" size="sm" className={utilityButtonClass} onClick={handleCopy} />
           </div>
         )}
       </div>
 
-      {/* The response owns the full width of the console below the header, on
-          the same sunken surface as the editor — the split between them is a
-          hairline, not a value step. */}
-      <div className="flex min-h-0 flex-1 flex-col bg-background">
-        {selectedGroup && showRunHeader && (
-          <Console.RunHeaderRow
-            group={selectedGroup}
-            selected={selection?.itemId === undefined}
-            expanded={showRunChildren}
-            onSelect={() => onSelect({ runId: selectedGroup.run.id })}
-            now={now}
-          />
-        )}
-        {selectedGroup &&
-          showRunChildren &&
-          selectedGroup.items.map((item) => (
-            <Console.CallChildRow
+      {selectedGroup && activeView === "canvas" ? (
+        <Canvas group={selectedGroup} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={selectFromCanvas} />
+      ) : selectedGroup ? (
+        <Console.ListView
+          group={selectedGroup}
+          rows={rows}
+          selection={selection}
+          activeTab={activeTab}
+          selectedCall={selectedCall}
+          waiting={waiting !== undefined}
+          jsonViewerRef={jsonViewerRef}
+          now={now}
+          onSelect={onSelect}
+          onTabChange={onTabChange}
+          onGoToCanvas={() => onViewChange("canvas")}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface ListViewProps {
+  group: RunGroup;
+  rows: ConsoleItem[];
+  selection: RunSelection | null;
+  activeTab: ConsoleTab;
+  selectedCall?: MethodCall;
+  waiting: boolean;
+  jsonViewerRef: React.MutableRefObject<JsonViewerHandle | null>;
+  now: number;
+  onSelect: (selection: RunSelection | null) => void;
+  onTabChange: (tab: ConsoleTab) => void;
+  onGoToCanvas: () => void;
+}
+
+/**
+ * The flat audit log. A row is a call and only a call — no disclosure triangles,
+ * no block rows, no run row — which is what keeps it scannable at two hundred
+ * rows and lets every row carry the same two extra channels.
+ */
+Console.ListView = function ({
+  group,
+  rows,
+  selection,
+  activeTab,
+  selectedCall,
+  waiting,
+  jsonViewerRef,
+  now,
+  onSelect,
+  onTabChange,
+  onGoToCanvas,
+}: ListViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rowsBelow = useRowsBelow(scrollRef, rows.length);
+  const slowest = useMemo(() => slowestCall(group), [group]);
+  const failures = rows.filter((item) => itemStatus(item) === "error").length;
+  const scriptFailed = group.items.some((item) => item.logs?.some((log) => log.level === LogLevel.LEVEL_ERROR));
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div ref={scrollRef} className="@container shrink overflow-y-auto" style={{ maxHeight: MAX_LOG_HEIGHT }}>
+        {rows.length === 0 ? (
+          <div className="flex h-[24px] items-center px-3 text-xs text-muted-foreground">
+            {/* A run parked on a question is in flight but is not on its way to
+                a call — the tail bar below already says what it is doing. */}
+            {group.inFlight && !waiting ? "Waiting for the first call…" : "No calls."}
+          </div>
+        ) : (
+          rows.map((item) => (
+            <Console.CallRow
               key={item.id}
               item={item}
               selected={item.id === selection?.itemId}
-              onSelect={() => onSelect({ runId: selectedGroup.run.id, itemId: item.id })}
+              slowest={slowest}
+              stale={group.run.stale === true}
+              onSelect={() => onSelect({ runId: group.run.id, itemId: item.id })}
               now={now}
             />
-          ))}
-        <div className={cn("flex min-h-0 flex-1 flex-col", selectedGroup?.run.stale && "opacity-70")}>
-          {selectedGroup?.run.payloadsExpired ? (
-            <div className="flex items-center gap-2 px-4 py-3">
-              <span className="text-xs text-muted-foreground">Response no longer kept — run to see it live</span>
-              <span className="font-mono text-xs text-muted-foreground">{runShortcutLabel}</span>
-            </div>
-          ) : selectedCall ? (
-            <Console.DetailContent methodCall={selectedCall} activeTab={activeTab} onTabChange={onTabChange} jsonViewerRef={jsonViewerRef} />
-          ) : selectedLogs ? (
-            <Console.LogContent logs={selectedLogs} />
-          ) : selectedGroup ? (
-            <Console.RunSummary group={selectedGroup} />
-          ) : null}
-        </div>
+          ))
+        )}
+      </div>
+
+      <Console.TailBar waiting={waiting} scriptFailed={scriptFailed} rowsBelow={rowsBelow} failures={failures} onGoToCanvas={onGoToCanvas} />
+
+      {/* The payload sits in a pane of its own that never reflows as you move
+          through the log — which is why Request/Response/Headers live down here
+          rather than in the header. */}
+      <div className={cn("flex min-h-0 flex-1 flex-col border-t border-border", group.run.stale && "opacity-70")}>
+        {group.run.payloadsExpired ? (
+          <div className="flex items-center gap-2 px-4 py-3">
+            <span className="text-xs text-muted-foreground">Response no longer kept — run to see it live</span>
+            <span className="font-mono text-xs text-muted-foreground">{runShortcutLabel}</span>
+          </div>
+        ) : selectedCall ? (
+          <Console.DetailContent methodCall={selectedCall} activeTab={activeTab} onTabChange={onTabChange} jsonViewerRef={jsonViewerRef} />
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center text-xs text-muted-foreground">
+            {rows.length === 0 ? "Nothing to show." : "Select a call."}
+          </div>
+        )}
       </div>
     </div>
   );
+};
+
+interface TailBarProps {
+  waiting: boolean;
+  scriptFailed: boolean;
+  rowsBelow: number;
+  failures: number;
+  onGoToCanvas: () => void;
+}
+
+/**
+ * What the log can't say inside a row. A run parked on a question, or one whose
+ * script threw, is a fact about the whole run, and the log stays readable while
+ * it waits — the pause blocks the script, not your reading.
+ */
+Console.TailBar = function ({ waiting, scriptFailed, rowsBelow, failures, onGoToCanvas }: TailBarProps) {
+  if (!waiting && !scriptFailed && rowsBelow <= 0 && failures === 0) return null;
+
+  const state = waiting ? "waiting" : scriptFailed ? "failed" : "counts";
+
+  return (
+    <div
+      data-testid="console-tail"
+      className={cn(
+        "flex h-[26px] shrink-0 items-center gap-2 border-t px-3 font-mono text-xs",
+        state === "waiting" && "border-l-2 border-l-amber-500 border-t-border bg-amber-500/10",
+        state === "failed" && "border-l-2 border-l-destructive border-t-border bg-destructive/10",
+        state === "counts" && "border-t-border",
+      )}
+    >
+      {state === "waiting" && (
+        <>
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
+          <span className="text-amber-600 dark:text-amber-400">Waiting for an answer</span>
+        </>
+      )}
+      {state === "failed" && <span className="text-destructive">Script failed</span>}
+      {state === "counts" && rowsBelow > 0 && <span className="text-muted-foreground">{rowsBelow} more</span>}
+      <div className="ml-auto flex shrink-0 items-center gap-3">
+        {failures > 0 && <span className="text-amber-600 dark:text-amber-400">{failures === 1 ? "1 error" : `${failures} errors`}</span>}
+        {(state === "waiting" || state === "failed") && (
+          <button
+            type="button"
+            className={cn(
+              "rounded-full border px-2 py-0.5 text-xs",
+              state === "waiting" ? "border-amber-500 text-amber-600 dark:text-amber-400" : "border-destructive text-destructive",
+            )}
+            onClick={onGoToCanvas}
+          >
+            Go to canvas
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface CallRowProps {
+  item: ConsoleItem;
+  selected: boolean;
+  slowest?: number;
+  stale: boolean;
+  onSelect: () => void;
+  now: number;
+}
+
+/**
+ * One call, and the same shape for every one of them: when it happened, what it
+ * was, which pass through the loop it belonged to, and how long it took — as a
+ * number and as a length.
+ */
+Console.CallRow = memo(function CallRow({ item, selected, slowest, stale, onSelect, now }: CallRowProps) {
+  const call = item.call!;
+  const status = itemStatus(item);
+  const pending = status === "pending" || status === "streaming";
+  const errorCode = callErrorCode(call);
+  const key = loopKey(call.input);
+  const fraction = barFraction(call.durationMs, slowest);
+
+  return (
+    <div
+      data-testid="console-call-row"
+      className={cn("flex shrink-0 cursor-pointer items-center gap-2.5 px-3", selected ? "bg-accent" : "hover:bg-accent/50", stale && "opacity-75")}
+      style={{ height: CALL_ROW_HEIGHT }}
+      onClick={onSelect}
+    >
+      {pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(status))} />}
+      <span className="w-[8ch] shrink-0 font-mono text-xs tabular-nums text-muted-foreground @max-[360px]:hidden">{formatClockTime(item.timestamp)}</span>
+      <span className={cn("min-w-0 flex-1 truncate font-mono text-xs", selected ? "text-foreground" : "text-muted-foreground")}>
+        {call.service.name}.{call.method.name}
+      </span>
+      {key && <span className="shrink-0 truncate font-mono text-xs text-muted-foreground/80 @max-[440px]:hidden">{key}</span>}
+      {errorCode && <span className="shrink-0 font-mono text-xs text-destructive">{errorCode}</span>}
+      {fraction !== undefined && (
+        <span className="shrink-0 @max-[500px]:hidden" style={{ width: BAR_WIDTH }} aria-hidden>
+          <span
+            className={cn("block h-[6px] rounded-sm", status === "error" ? "bg-destructive/40" : "bg-muted-foreground/30")}
+            style={{ width: `${fraction * 100}%` }}
+          />
+        </span>
+      )}
+      <span className={DETAIL_COLUMN_CLASS}>{pending ? formatElapsed(now - item.timestamp) : formatDuration(call.durationMs)}</span>
+    </div>
+  );
+});
+
+/**
+ * How many rows are still below the fold. The log is never collapsed or
+ * summarised away — it stays complete at any length — so this says what is out
+ * of sight rather than standing in for it.
+ */
+function useRowsBelow(ref: React.RefObject<HTMLDivElement | null>, total: number): number {
+  const [rowsBelow, setRowsBelow] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const measure = () => {
+      const shown = Math.round((element.scrollTop + element.clientHeight) / CALL_ROW_HEIGHT);
+      setRowsBelow(Math.max(0, total - shown));
+    };
+
+    measure();
+    element.addEventListener("scroll", measure, { passive: true });
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => {
+      element.removeEventListener("scroll", measure);
+      observer.disconnect();
+    };
+  }, [ref, total]);
+
+  return rowsBelow;
 }
 
 interface RunSelectProps {
@@ -255,13 +546,14 @@ interface RunSelectProps {
   now: number;
 }
 
-// The whole history behind one 26px trigger: the trigger answers "which run am I
-// looking at", the list answers "which other ones are there". It lists runs
-// rather than calls, so everything under a date header is by definition not
-// live.
+/**
+ * Run identity stays in the one place it already lives, and the header keeps its
+ * shape. The pill inherits the status of the run it names, so a waiting or
+ * failed run is legible without opening the menu.
+ */
 Console.RunSelect = function ({ groups, selectedGroup, onSelect, onClear, now }: RunSelectProps) {
   const [open, setOpen] = useState(false);
-  const summary = selectedGroup ? runSummary(selectedGroup, now) : undefined;
+  const summary = selectedGroup ? runSummary(selectedGroup, groups, now) : undefined;
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -269,21 +561,27 @@ Console.RunSelect = function ({ groups, selectedGroup, onSelect, onClear, now }:
         <button
           type="button"
           data-testid="console-call-select"
-          className="flex h-[26px] min-w-0 items-center gap-2 rounded-md border border-border bg-card px-2.5 hover:bg-accent"
+          className={cn(
+            "flex h-[26px] min-w-0 items-center gap-2 rounded-md border bg-card px-2.5 hover:bg-accent",
+            summary?.waiting ? "border-amber-500/60" : "border-border",
+          )}
           title={summary?.name}
         >
-          {summary?.pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", summary?.dotClass)} />}
-          <span className="max-w-[190px] truncate font-mono text-xs text-foreground">{truncateStart(summary?.name ?? "", MAX_TRIGGER_NAME_LENGTH)}</span>
+          {summary?.pending && !summary.waiting ? (
+            <Spinner className="size-3" />
+          ) : (
+            <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", summary?.dotClass)} />
+          )}
+          <span className="shrink-0 font-mono text-xs text-foreground">{summary?.name}</span>
           {summary?.detail && (
-            <span className={cn(DETAIL_COLUMN_CLASS, "@max-[620px]:hidden")} title={summary.detail}>
+            <span className={cn("truncate font-mono text-xs", summary.waiting ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground")}>
               {summary.detail}
             </span>
           )}
-          {summary?.time && <span className={cn(TIME_COLUMN_CLASS, "@max-[700px]:hidden")}>{summary.time}</span>}
           <ChevronsUpDown size={13} className="shrink-0 text-muted-foreground" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="bottom" className="w-[420px] p-0">
+      <DropdownMenuContent align="start" side="bottom" className="w-[300px] p-0">
         <div className="flex items-center justify-between border-b border-border px-3 py-2">
           <span className="text-xs tracking-[0.06em] text-muted-foreground">RUNS</span>
           <span className="font-mono text-xs text-muted-foreground">{groups.length}</span>
@@ -325,118 +623,80 @@ interface RunRowProps extends RunSummaryLine {
 }
 
 // Memoized so the tick that counts up an in-flight run only re-renders that
-// run's row; every settled row holds a value that no longer changes. Both
-// columns are rendered even when empty, so the list stays aligned.
-Console.RunRow = memo(function RunRow({ name, detail, time, dotClass, pending, stale, isSelected, onSelect }: RunRowProps) {
+// run's row; every settled row holds a value that no longer changes.
+Console.RunRow = memo(function RunRow({ name, detail, dotClass: dot, pending, waiting, stale, isSelected, onSelect }: RunRowProps) {
   return (
     <DropdownMenuItem
       data-testid="console-row"
       className={cn("h-8 gap-3 rounded-none px-3", isSelected && "bg-accent", stale && "opacity-75")}
       onSelect={onSelect}
     >
-      {pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass)} />}
+      {pending && !waiting ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dot)} />}
       <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">{name}</span>
-      <span className={DETAIL_COLUMN_CLASS} title={detail}>
+      <span className={cn("shrink-0 truncate font-mono text-xs", waiting ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground")} title={detail}>
         {detail}
       </span>
-      <span className={TIME_COLUMN_CLASS}>{time}</span>
     </DropdownMenuItem>
   );
 });
 
-interface RunHeaderRowProps {
-  group: RunGroup;
-  selected: boolean;
-  expanded: boolean;
-  onSelect: () => void;
-  now: number;
+interface DetailContentProps {
+  methodCall: MethodCall;
+  activeTab: ConsoleTab;
+  onTabChange: (tab: ConsoleTab) => void;
+  jsonViewerRef: React.MutableRefObject<JsonViewerHandle | null>;
 }
 
-// One press of Run, stated once: status, script name, what happened, wall
-// duration, clock. Its status is the worst status inside it, so a green run
-// means every call passed.
-Console.RunHeaderRow = function ({ group, selected, expanded, onSelect, now }: RunHeaderRowProps) {
-  const { run, status, inFlight, failures } = group;
-  const calls = callCount(group);
+Console.DetailContent = function ({ methodCall, activeTab, onTabChange, jsonViewerRef }: DetailContentProps) {
+  const isStreaming = methodCall.streamOutputs !== undefined;
+  const hasResponse = methodCall.output !== undefined || methodCall.error !== undefined || (isStreaming && methodCall.streamOutputs!.length > 0);
+  const hasError = methodCall.error !== undefined;
+
+  // Switch to response tab when response arrives
+  useEffect(() => {
+    if (hasResponse && activeTab === "request") {
+      onTabChange("response");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasResponse]);
+
+  let content;
+  let rawText: string | undefined;
+  if (activeTab === "request") {
+    content = methodCall.input;
+  } else if (hasError) {
+    // Same rule as the response below: an HTTP failure arrives wrapped in what
+    // carried it here, and the body the API sent is the failure.
+    content = unwrapFailure(methodCall.error);
+  } else if (isStreaming) {
+    rawText = methodCall.streamOutputs!.map((msg) => JSON.stringify(unwrapEnvelope(methodCall.outputType, msg), null, 2)).join("\n\n");
+  } else {
+    // An app that carries HTTP inside gRPC has to put a body protobuf has no
+    // shape for — an array, a scalar — in a field of its own. That field is the
+    // encoding, not the response, so the response is what it holds.
+    content = unwrapEnvelope(methodCall.outputType, methodCall.output);
+  }
 
   return (
-    <div
-      data-testid="console-run-header"
-      className={cn("flex h-8 shrink-0 cursor-pointer items-center gap-2 border-b border-border px-3", selected ? "bg-accent" : "bg-card")}
-      onClick={onSelect}
-    >
-      <span className="flex w-[13px] shrink-0 items-center justify-center text-muted-foreground">
-        {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
-      </span>
-      {inFlight ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(status), run.stale && "opacity-50")} />}
-      <span className={cn("min-w-0 flex-1 truncate font-mono text-xs", run.stale ? "text-muted-foreground" : "font-medium text-foreground")}>{run.title}</span>
-      {run.stale && <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">Last run</span>}
-      {/* What failed is the news; how many calls there were is what the trigger
-          already carries. */}
-      {failures > 0 ? (
-        <span className="shrink-0 font-mono text-xs text-muted-foreground">{failures} failed</span>
-      ) : (
-        calls > 1 && <span className="shrink-0 font-mono text-xs text-muted-foreground">{calls} calls</span>
-      )}
-      <span className={DETAIL_COLUMN_CLASS}>{inFlight ? formatElapsed(now - run.startedAt) : formatDuration(run.durationMs)}</span>
-      <span className={cn(TIME_COLUMN_CLASS, "opacity-75")}>{run.stale ? formatStaleTime(run.startedAt) : formatClockTime(run.startedAt)}</span>
-    </div>
-  );
-};
-
-interface CallChildRowProps {
-  item: ConsoleItem;
-  selected: boolean;
-  onSelect: () => void;
-  now: number;
-}
-
-// Calls inside a run are ordered by start, never re-sorted, and keep their own
-// durations; the run header's duration is the wall time for the whole script.
-Console.CallChildRow = function ({ item, selected, onSelect, now }: CallChildRowProps) {
-  const status = itemStatus(item);
-  const pending = item.call !== undefined && (status === "pending" || status === "streaming");
-  const errorCode = item.call ? callErrorCode(item.call) : undefined;
-
-  return (
-    <div
-      data-testid="console-call-row"
-      className={cn("flex h-[30px] shrink-0 cursor-pointer items-center gap-2 border-b border-border pl-[34px] pr-3", selected && "bg-accent")}
-      onClick={onSelect}
-    >
-      {pending ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(status))} />}
-      <span className={cn("min-w-0 flex-1 truncate font-mono text-xs", selected ? "text-foreground" : "text-muted-foreground")}>{itemName(item)}</span>
-      {errorCode && <span className="shrink-0 font-mono text-xs text-destructive">{errorCode}</span>}
-      <span className={DETAIL_COLUMN_CLASS}>{pending ? formatElapsed(now - item.timestamp) : formatDuration(item.call?.durationMs)}</span>
-    </div>
-  );
-};
-
-// What the run header selects: the press as a whole, rather than any one call it
-// made.
-Console.RunSummary = function ({ group }: { group: RunGroup }) {
-  const calls = callCount(group);
-  const label = { pending: "Running", streaming: "Streaming", success: "OK", error: "Failed" }[group.status];
-
-  return (
-    <div className="min-h-0 flex-1 overflow-auto px-4 py-3 font-mono text-xs">
-      <div className="flex items-center gap-3 pb-2">
-        <span className={cn("font-medium", statusClass(group.status))}>{label}</span>
-        <span className="text-muted-foreground">
-          {calls} {calls === 1 ? "call" : "calls"}
-        </span>
-        {group.run.durationMs !== undefined && <span className="tabular-nums text-muted-foreground">{formatDuration(group.run.durationMs)} wall</span>}
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* The pane names itself: which part of the call on the left, and what
+          came back of it on the right. Without the readout a successful call and
+          an empty one look the same. */}
+      <div className="flex h-[28px] shrink-0 items-center gap-4 overflow-hidden px-3">
+        <Console.DetailTabs methodCall={methodCall} activeTab={activeTab} onTabChange={onTabChange} />
+        {activeTab !== "headers" && <Console.ResponseSummary methodCall={methodCall} content={content} rawText={rawText} />}
       </div>
-      {group.items.length === 0 ? (
-        <div className="text-muted-foreground">This run made no calls.</div>
+      {activeTab === "headers" ? (
+        <Console.HeadersContent methodCall={methodCall} />
+      ) : activeTab === "response" && !hasResponse ? (
+        <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Waiting for a response…</div>
       ) : (
-        group.items.map((item) => (
-          <div key={item.id} className="flex items-center gap-2 py-0.5">
-            <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(itemStatus(item)))} />
-            <span className="min-w-0 flex-1 truncate text-muted-foreground">{itemName(item)}</span>
-            <span className="tabular-nums text-muted-foreground">{formatDuration(item.call?.durationMs)}</span>
-          </div>
-        ))
+        <>
+          {activeTab === "response" && hasError && methodCall.url && (
+            <div className="border-y border-border bg-destructive/10 px-4 py-1.5 font-mono text-xs text-destructive">POST {methodCall.url}</div>
+          )}
+          <JsonViewer ref={jsonViewerRef} value={content} rawText={rawText} />
+        </>
       )}
     </div>
   );
@@ -458,87 +718,11 @@ Console.DetailTabs = function ({ methodCall, activeTab, onTabChange }: DetailTab
     </span>
   );
 
-  // A failed call colours its dot and its status line, and nothing else — the
-  // header stays neutral.
   return (
     <div className="flex shrink-0 items-center gap-4">
       {tab("request", "Request")}
       {tab("response", `Response${isStreaming && streamCount > 0 ? ` (${streamCount})` : ""}`)}
       {tab("headers", "Headers")}
-    </div>
-  );
-};
-
-interface LogContentProps {
-  logs: Log[];
-}
-
-Console.LogContent = function ({ logs }: LogContentProps) {
-  return (
-    <div className="min-h-0 flex-1 overflow-auto px-4 py-3 font-mono text-xs">
-      {logs.map((log, index) => (
-        <div key={index} className={cn("whitespace-pre-wrap break-words", classForLogLevel(log.level))}>
-          <span className="mr-2 text-[10px] uppercase opacity-70">{labelForLogLevel(log.level)}</span>
-          {log.message.trim()}
-        </div>
-      ))}
-    </div>
-  );
-};
-
-interface DetailContentProps {
-  methodCall: MethodCall;
-  activeTab: ConsoleTab;
-  onTabChange: (tab: ConsoleTab) => void;
-  jsonViewerRef: React.MutableRefObject<JsonViewerHandle | null>;
-}
-
-Console.DetailContent = function ({ methodCall, activeTab, onTabChange, jsonViewerRef }: DetailContentProps) {
-  const isStreaming = methodCall.streamOutputs !== undefined;
-  const hasResponse = methodCall.output !== undefined || methodCall.error !== undefined || (isStreaming && methodCall.streamOutputs!.length > 0);
-  const hasError = methodCall.error !== undefined;
-
-  // Switch to response tab when response arrives
-  useEffect(() => {
-    if (hasResponse && activeTab === "request") {
-      onTabChange("response");
-    }
-  }, [hasResponse]);
-
-  if (activeTab === "headers") {
-    return <Console.HeadersContent methodCall={methodCall} />;
-  }
-
-  let content;
-  let rawText: string | undefined;
-  if (activeTab === "request") {
-    content = methodCall.input;
-  } else if (hasError) {
-    // Same rule as the response below: an HTTP failure arrives wrapped in what
-    // carried it here, and the body the API sent is the failure.
-    content = unwrapFailure(methodCall.error);
-  } else if (isStreaming) {
-    rawText = methodCall.streamOutputs!.map((msg) => JSON.stringify(unwrapEnvelope(methodCall.outputType, msg), null, 2)).join("\n\n");
-  } else {
-    // An app that carries HTTP inside gRPC has to put a body protobuf has no
-    // shape for — an array, a scalar — in a field of its own. That field is the
-    // encoding, not the response, so the response is what it holds.
-    content = unwrapEnvelope(methodCall.outputType, methodCall.output);
-  }
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      {activeTab === "response" && !hasResponse ? (
-        <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Waiting for a response…</div>
-      ) : (
-        <>
-          {activeTab === "response" && <Console.ResponseSummary methodCall={methodCall} content={content} rawText={rawText} />}
-          {activeTab === "response" && hasError && methodCall.url && (
-            <div className="border-b border-border bg-destructive/10 px-4 py-1.5 font-mono text-xs text-destructive">POST {methodCall.url}</div>
-          )}
-          <JsonViewer ref={jsonViewerRef} value={content} rawText={rawText} />
-        </>
-      )}
     </div>
   );
 };
@@ -549,9 +733,8 @@ interface ResponseSummaryProps {
   rawText?: string;
 }
 
-// A one-line readout above the payload: what came back, how long it took and how
-// big it is. Without it a successful call and an empty one look the same. Status
-// colour appears here and in the call's dot, and nowhere else.
+// What came back, how long it took and how big it is. Status colour appears
+// here and in the call's dot, and nowhere else.
 Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSummaryProps) {
   const status = callStatus(methodCall);
   const label = { pending: "Pending", streaming: "Streaming", success: "OK", error: callErrorCode(methodCall) ?? "Error" }[status];
@@ -560,14 +743,14 @@ Console.ResponseSummary = function ({ methodCall, content, rawText }: ResponseSu
   const streamCount = methodCall.streamOutputs?.length;
 
   return (
-    <div className="flex shrink-0 items-center gap-3 overflow-hidden whitespace-nowrap px-4 pb-2 pt-3 font-mono text-xs">
+    <div className="ml-auto flex shrink-0 items-center gap-3 overflow-hidden whitespace-nowrap font-mono text-xs">
       <span data-testid="console-status" className={cn("shrink-0 font-medium", statusClass(status))}>
         {label}
       </span>
-      {duration && <span className="shrink-0 tabular-nums text-muted-foreground">{duration}</span>}
-      {size && <span className="shrink-0 tabular-nums text-muted-foreground">{size}</span>}
+      {duration && <span className="shrink-0 tabular-nums text-muted-foreground @max-[430px]:hidden">{duration}</span>}
+      {size && <span className="shrink-0 tabular-nums text-muted-foreground @max-[500px]:hidden">{size}</span>}
       {streamCount !== undefined && (
-        <span className="shrink-0 text-muted-foreground">
+        <span className="shrink-0 text-muted-foreground @max-[560px]:hidden">
           {streamCount} {streamCount === 1 ? "message" : "messages"}
         </span>
       )}
@@ -656,28 +839,43 @@ Console.HeadersTable = function ({ headers }: HeadersTableProps) {
 
 interface RunSummaryLine {
   name: string;
-  // The call count, or how many of them failed.
+  // When it ran and how it went, in one string: `14:03 · 1.2 s`, `13:51 ·
+  // waiting`, `13:44 · failed`.
   detail?: string;
-  // Wall-clock time the run was made.
-  time?: string;
   dotClass: string;
   pending: boolean;
+  waiting: boolean;
 }
 
-// The columns every row in the history shares — the trigger shows them for the
+// The columns every row in the history shares — the pill shows them for the
 // selected run, the list for all of them.
-function runSummary(group: RunGroup, now: number): RunSummaryLine {
-  const calls = callCount(group);
+function runSummary(group: RunGroup, groups: RunGroup[], now: number): RunSummaryLine {
+  const waiting = awaitingItem(group) !== undefined;
+  const time = group.run.stale ? formatStaleTime(group.run.startedAt) : formatClockTime(group.run.startedAt);
+  const outcome = waiting
+    ? "waiting"
+    : group.inFlight
+      ? formatElapsed(now - group.run.startedAt)
+      : group.status === "error"
+        ? "failed"
+        : formatDuration(group.run.durationMs);
+
   return {
-    name: group.run.title,
-    // While the run is in flight its own elapsed time is the interesting number;
-    // once it lands, how many calls it made — and for a run of one, where there
-    // is no count worth stating, how long it took.
-    detail: group.inFlight ? formatElapsed(now - group.run.startedAt) : calls > 1 ? `${calls} calls` : formatDuration(group.run.durationMs),
-    time: group.run.stale ? formatStaleTime(group.run.startedAt) : formatClockTime(group.run.startedAt),
-    dotClass: cn(dotClass(group.status), group.run.stale && "opacity-50"),
+    name: runName(group, groups),
+    detail: outcome ? `${time} · ${outcome}` : time,
+    dotClass: cn(waiting ? "bg-amber-500" : dotClass(group.status), group.run.stale && "opacity-50"),
     pending: group.inFlight,
+    waiting,
   };
+}
+
+/**
+ * A console holds one script's runs, so naming each one after that script says
+ * the same thing every row. They are numbered instead, and the number is the
+ * run's own — a position would renumber as the oldest runs are trimmed.
+ */
+function runName(group: RunGroup, groups: RunGroup[]): string {
+  return `Run ${group.run.number ?? groups.indexOf(group) + 1}`;
 }
 
 interface DayGroupedRow {
@@ -692,7 +890,7 @@ interface DayGroupedRow {
 // back into; today needs none. Everything under a date header is by definition
 // not live.
 function dayGroupedRows(groups: RunGroup[], now: number): DayGroupedRow[] {
-  const rows = [...groups].reverse().map((group) => ({ group, summary: runSummary(group, now) }));
+  const rows = [...groups].reverse().map((group) => ({ group, summary: runSummary(group, groups, now) }));
   let previousTimestamp = now;
   return rows.map((row) => {
     const timestamp = row.group.run.startedAt;
@@ -700,12 +898,6 @@ function dayGroupedRows(groups: RunGroup[], now: number): DayGroupedRow[] {
     previousTimestamp = timestamp;
     return { ...row, dayLabel };
   });
-}
-
-// Keep the tail — for a qualified call name that is the method, the part that
-// says which call this is.
-function truncateStart(text: string, maxLength: number): string {
-  return text.length > maxLength ? `…${text.slice(text.length - maxLength + 1)}` : text;
 }
 
 function callStatus(methodCall: MethodCall): RunStatus {
@@ -719,85 +911,4 @@ function callStatus(methodCall: MethodCall): RunStatus {
 // happened on some other day is not the thing you need to read.
 function formatStaleTime(timestamp: number): string {
   return isSameDay(timestamp, Date.now()) ? formatClockTime(timestamp) : formatDayLabel(timestamp);
-}
-
-function statusClass(status: RunStatus): string {
-  return {
-    pending: "text-muted-foreground",
-    streaming: "text-primary",
-    success: "text-emerald-600 dark:text-emerald-400",
-    error: "text-destructive",
-  }[status];
-}
-
-function dotClass(status: RunStatus): string {
-  return {
-    pending: "bg-muted-foreground",
-    streaming: "bg-primary",
-    success: "bg-emerald-500",
-    error: "bg-red-500",
-  }[status];
-}
-
-// gRPC and Twirp errors carry a status code (e.g. "INVALID_ARGUMENT"); anything
-// else just shows as a plain error.
-// How a failed call is labelled: an upstream HTTP failure by its status, and
-// anything else by its gRPC/Twirp status code. A call against an HTTP app failed
-// with a 404, not with NOT_FOUND — the gRPC code is the tunnel, not the failure.
-function callErrorCode(methodCall: MethodCall): string | undefined {
-  const status = methodCall.error?.status;
-  if (typeof status === "number" && status > 0) return String(status);
-  const code = methodCall.error?.code;
-  return typeof code === "string" && code.length > 0 && code.length <= 24 ? code : undefined;
-}
-
-function formatDuration(durationMs?: number): string | undefined {
-  if (durationMs === undefined) return undefined;
-  return durationMs < 1000 ? `${durationMs} ms` : `${(durationMs / 1000).toFixed(durationMs < 10000 ? 2 : 1)} s`;
-}
-
-function payloadBytes(content: unknown, rawText?: string): number | undefined {
-  let text = rawText;
-  if (text === undefined) {
-    if (content === undefined) return undefined;
-    try {
-      text = JSON.stringify(content);
-    } catch {
-      return undefined;
-    }
-  }
-  return text === undefined ? undefined : new TextEncoder().encode(text).length;
-}
-
-function formatBytes(bytes?: number): string | undefined {
-  if (bytes === undefined) return undefined;
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function labelForLogLevel(level: LogLevel): string {
-  switch (level) {
-    case LogLevel.LEVEL_DEBUG:
-      return "DEBUG";
-    case LogLevel.LEVEL_INFO:
-      return "LOG";
-    case LogLevel.LEVEL_WARN:
-      return "WARN";
-    case LogLevel.LEVEL_ERROR:
-      return "ERROR";
-  }
-}
-
-function classForLogLevel(level: LogLevel): string {
-  switch (level) {
-    case LogLevel.LEVEL_DEBUG:
-      return "text-muted-foreground";
-    case LogLevel.LEVEL_INFO:
-      return "text-foreground";
-    case LogLevel.LEVEL_WARN:
-      return "text-amber-600 dark:text-amber-400";
-    case LogLevel.LEVEL_ERROR:
-      return "text-destructive";
-  }
 }

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -91,12 +91,35 @@ export declare const kaja: {
    */
   variables: ${kajaVariablesType(variableNames)};
   /**
-   * Pause the script and pop up a dialog asking the user for input. Resolves
-   * with the submitted text; if the user cancels, the script stops.
+   * Pause the script and ask the user for input. The question is drawn on the
+   * run's canvas and the run stops there until it is answered. Resolves with
+   * the submitted text; if the user cancels, the script stops.
    *
    *   const name = await kaja.ask("What's your name?");
    */
   ask(message: string): Promise<string>;
+  /**
+   * Write a line onto the run's canvas.
+   *
+   *   kaja.text(\`Reconciling \${accounts.length} accounts\`);
+   */
+  text(text: string): void;
+  /**
+   * Put a snippet of code on the run's canvas.
+   *
+   *   kaja.code(query, "sql");
+   */
+  code(code: string, language?: string): void;
+  /**
+   * Start a table on the run's canvas and hand back a handle to fill it. Rows
+   * appear as they are added, so a loop paints rather than reporting at the end.
+   *
+   *   const table = kaja.table(["id", "name", "status"]);
+   *   for (const account of accounts) {
+   *     table.row(account.id, account.name, await check(account));
+   *   }
+   */
+  table(columns: string[], rows?: unknown[][]): { row(...cells: unknown[]): void };
   /** UUID helpers. */
   uuid: {
     /**

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -77,10 +77,29 @@ const ROW_ACTION = "size-[18px] min-h-0 min-w-0 [&_svg]:size-3";
  * It goes inside a `TreeView.LeadingVisual` and never wraps one — `TreeView.Item`
  * picks its slots out by child type, so a wrapper lands the glyph in the label.
  */
-function ScriptGlyph({ running, pinned, saved, dim, dot = true }: { running?: boolean; pinned?: boolean; saved?: boolean; dim?: boolean; dot?: boolean }) {
+function ScriptGlyph({
+  running,
+  waiting,
+  pinned,
+  saved,
+  dim,
+  dot = true,
+}: {
+  running?: boolean;
+  waiting?: boolean;
+  pinned?: boolean;
+  saved?: boolean;
+  dim?: boolean;
+  dot?: boolean;
+}) {
   return (
     <span className="flex size-3 items-center justify-center">
-      {running ? (
+      {/* A run parked on a question is still running, but a spinner would say it
+          is working on something. The ring is the same amber the canvas and the
+          run pill use for "this needs you". */}
+      {waiting ? (
+        <span aria-hidden title="Waiting for an answer" className="size-[5px] rounded-full bg-amber-500 ring-[3px] ring-amber-500/25" />
+      ) : running ? (
         <Spinner className="size-3" />
       ) : pinned ? (
         <Pin size={12} />
@@ -144,6 +163,8 @@ interface SidebarProps {
   // Files with a run still in the air. A run keeps going when you navigate away
   // from it, and its console is no longer on screen to say so — the row is.
   runningFileIds?: Set<string>;
+  // Files whose run has stopped on a `kaja.ask(...)` and needs an answer.
+  waitingFileIds?: Set<string>;
   // A read-only configuration doesn't disable the verbs that change apps, it
   // doesn't offer them: New and Delete both go, so there is no way to reach a
   // form whose only button can't be pressed. Settings stays — reading an app's
@@ -190,6 +211,7 @@ export function Sidebar({
   currentScriptPath,
   pinnedScriptPath,
   runningFileIds,
+  waitingFileIds,
   canUpdateConfiguration = true,
   onSelect,
   onScratchSelect,
@@ -442,7 +464,13 @@ export function Sidebar({
                       current={currentScriptPath === script.path}
                     >
                       <TreeView.LeadingVisual>
-                        <ScriptGlyph running={runningFileIds?.has(script.path)} pinned={pinnedScriptPath === script.path} saved dot={canSave} />
+                        <ScriptGlyph
+                          running={runningFileIds?.has(script.path)}
+                          waiting={waitingFileIds?.has(script.path)}
+                          pinned={pinnedScriptPath === script.path}
+                          saved
+                          dot={canSave}
+                        />
                       </TreeView.LeadingVisual>
                       {script.name}
                       <TreeView.TrailingVisual>
@@ -491,7 +519,12 @@ export function Sidebar({
                           seat the three buttons buys 11px the row doesn't need,
                           and costs a label that moves as you reach for it. */}
                       <TreeView.LeadingVisual>
-                        <ScriptGlyph running={runningFileIds?.has(scratch.id)} dim={isUntouched(scratch)} dot={canSave} />
+                        <ScriptGlyph
+                          running={runningFileIds?.has(scratch.id)}
+                          waiting={waitingFileIds?.has(scratch.id)}
+                          dim={isUntouched(scratch)}
+                          dot={canSave}
+                        />
                       </TreeView.LeadingVisual>
                       <ScratchLabel scratch={scratch} />
                       <TreeView.TrailingVisual className={active ? "w-auto gap-0.5" : undefined}>

--- a/ui/src/blocks.test.ts
+++ b/ui/src/blocks.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { Block, blockLabel, blockText, formatCell, isAwaitingAnswer } from "./blocks";
+
+describe("isAwaitingAnswer", () => {
+  it("is true only for a question nobody has answered", () => {
+    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?" })).toBe(true);
+    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe(false);
+  });
+
+  // A cancelled ask stopped the script rather than parking it, so the run is
+  // over — showing it as waiting would offer an input nothing is listening to.
+  it("is false for a question that was cancelled", () => {
+    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", cancelled: true })).toBe(false);
+  });
+
+  it("is false for anything a run merely drew", () => {
+    expect(isAwaitingAnswer({ kind: "text", text: "Reconciling" })).toBe(false);
+  });
+});
+
+describe("blockLabel", () => {
+  it("describes a table by its size, not by its first cell", () => {
+    expect(blockLabel({ kind: "table", columns: ["id"], rows: [["a"], ["b"]] })).toBe("2 rows");
+    expect(blockLabel({ kind: "table", columns: ["id"], rows: [["a"]] })).toBe("1 row");
+  });
+
+  it("takes the first line of a block of text", () => {
+    expect(blockLabel({ kind: "text", text: "Reconciling 42 accounts\nagainst the June ledger" })).toBe("Reconciling 42 accounts");
+  });
+
+  it("names an ask by the question it asked", () => {
+    expect(blockLabel({ kind: "ask", question: "Which ledger?" })).toBe("Which ledger?");
+  });
+});
+
+describe("blockText", () => {
+  // The copy button hands out something pasteable, so a table leaves as its own
+  // rows rather than as a drawing of them.
+  it("copies a table as its columns and rows", () => {
+    const table: Block = { kind: "table", columns: ["id", "status"], rows: [["ac_1", "matched"]] };
+    expect(blockText(table)).toBe("id\tstatus\nac_1\tmatched");
+  });
+
+  it("copies a question with what it was answered", () => {
+    expect(blockText({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe("Which ledger?\njune");
+  });
+});
+
+describe("formatCell", () => {
+  it("keeps a scalar as itself", () => {
+    expect(formatCell("matched")).toBe("matched");
+    expect(formatCell(41.2)).toBe("41.2");
+    expect(formatCell(false)).toBe("false");
+  });
+
+  // A column that is sometimes a value and sometimes "[object Object]" is worse
+  // than one that is always readable.
+  it("never lets a cell land as [object Object]", () => {
+    expect(formatCell({ short: 41.2 })).toBe('{"short":41.2}');
+  });
+
+  it("shows an absent cell as empty rather than as the word for absent", () => {
+    expect(formatCell(null)).toBe("");
+    expect(formatCell(undefined)).toBe("");
+  });
+});

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -1,0 +1,100 @@
+/**
+ * What a run drew. A script says what it made, never how it looks, so the set is
+ * closed and small — the canvas renders these four and nothing else. The moment
+ * a script can paint, the console is a rendering engine and every block becomes
+ * a support surface.
+ */
+export interface TextBlock {
+  kind: "text";
+  text: string;
+}
+
+export interface CodeBlock {
+  kind: "code";
+  code: string;
+  language?: string;
+}
+
+export interface TableBlock {
+  kind: "table";
+  columns: string[];
+  rows: string[][];
+}
+
+/**
+ * The one block that is a question rather than an answer. It has no value until
+ * the run is answered, and until then the run is parked on it — which is what
+ * makes the canvas a canvas rather than a report.
+ */
+export interface AskBlock {
+  kind: "ask";
+  question: string;
+  answer?: string;
+  cancelled?: boolean;
+}
+
+export type Block = TextBlock | CodeBlock | TableBlock | AskBlock;
+
+let sequence = 0;
+
+export function newBlockId(): string {
+  sequence++;
+  return `block-${Date.now().toString(36)}-${sequence}`;
+}
+
+// The run is stopped here until this is answered. A cancelled ask stopped the
+// script instead, so it is settled rather than waiting.
+export function isAwaitingAnswer(block: Block): boolean {
+  return block.kind === "ask" && block.answer === undefined && block.cancelled !== true;
+}
+
+// How a block is named where only one line fits. A table is described by its
+// size, because its first cell is rarely what tells two tables apart.
+export function blockLabel(block: Block): string {
+  switch (block.kind) {
+    case "text":
+      return firstLine(block.text) || "Text";
+    case "code":
+      return firstLine(block.code) || "Code";
+    case "table":
+      return `${block.rows.length} ${block.rows.length === 1 ? "row" : "rows"}`;
+    case "ask":
+      return block.question;
+  }
+}
+
+// The canvas as text, for the copy button. A table goes out as its columns and
+// rows rather than as a drawing of one, so it can be pasted somewhere useful.
+export function blockText(block: Block): string {
+  switch (block.kind) {
+    case "text":
+      return block.text;
+    case "code":
+      return block.code;
+    case "table":
+      return [block.columns, ...block.rows].map((cells) => cells.join("\t")).join("\n");
+    case "ask":
+      return block.cancelled ? `${block.question}\n(cancelled)` : `${block.question}\n${block.answer ?? ""}`;
+  }
+}
+
+// Cells arrive from a script, so they are whatever the script had — a number, a
+// date, an object it never meant to print. Everything lands as text, because a
+// table column that is sometimes a value and sometimes "[object Object]" is
+// worse than one that is always readable.
+export function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value);
+  if (value instanceof Date) return value.toISOString();
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function firstLine(text: string): string {
+  const line = text.trim().split("\n")[0] ?? "";
+  return line.length > 60 ? `${line.slice(0, 59)}…` : line;
+}

--- a/ui/src/callFormat.test.ts
+++ b/ui/src/callFormat.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { barFraction, callErrorCode, formatDuration } from "./callFormat";
+import { MethodCall } from "./kaja";
+
+function failed(error: unknown): MethodCall {
+  return { error } as MethodCall;
+}
+
+describe("barFraction", () => {
+  it("draws each call against the slowest one in its run", () => {
+    expect(barFraction(690, 690)).toBe(1);
+    expect(barFraction(345, 690)).toBe(0.5);
+  });
+
+  // A column that is empty for the fast calls reads as missing data rather than
+  // as a measurement, so the shortest bar is still a bar.
+  it("leaves a visible sliver for a call too fast to draw", () => {
+    expect(barFraction(1, 100_000)).toBe(0.04);
+  });
+
+  it("has no length to draw for a call still in flight", () => {
+    expect(barFraction(undefined, 690)).toBeUndefined();
+  });
+
+  it("draws nothing in a run with nothing to compare against", () => {
+    expect(barFraction(120, undefined)).toBeUndefined();
+  });
+});
+
+describe("callErrorCode", () => {
+  // A call against an HTTP app failed with a 404, not with NOT_FOUND — the gRPC
+  // code is the tunnel, not the failure.
+  it("labels an upstream failure by its HTTP status", () => {
+    expect(callErrorCode(failed({ status: 409, code: "ALREADY_EXISTS" }))).toBe("409");
+  });
+
+  it("labels a genuine gRPC failure by its status code", () => {
+    expect(callErrorCode(failed({ code: "UNAUTHENTICATED" }))).toBe("UNAUTHENTICATED");
+  });
+
+  it("has no label for a failure that carries neither", () => {
+    expect(callErrorCode(failed({ message: "boom" }))).toBeUndefined();
+  });
+});
+
+describe("formatDuration", () => {
+  it("stays in milliseconds under a second", () => {
+    expect(formatDuration(210)).toBe("210 ms");
+  });
+
+  it("loses a decimal place once the numbers get long", () => {
+    expect(formatDuration(1200)).toBe("1.20 s");
+    expect(formatDuration(161_000)).toBe("161.0 s");
+  });
+});

--- a/ui/src/callFormat.ts
+++ b/ui/src/callFormat.ts
@@ -1,0 +1,76 @@
+import { MethodCall } from "./kaja";
+import { RunStatus } from "./runs";
+
+/**
+ * How a call reads wherever it is shown. The list and the canvas describe the
+ * same calls, so they describe them the same way — a duration, a status colour
+ * and an error label mean one thing in Kaja, not two.
+ */
+
+/**
+ * How a failed call is labelled: an upstream HTTP failure by its status, and
+ * anything else by its gRPC/Twirp status code. A call against an HTTP app failed
+ * with a 404, not with NOT_FOUND — the gRPC code is the tunnel, not the failure.
+ */
+export function callErrorCode(methodCall: MethodCall): string | undefined {
+  const status = methodCall.error?.status;
+  if (typeof status === "number" && status > 0) return String(status);
+  const code = methodCall.error?.code;
+  return typeof code === "string" && code.length > 0 && code.length <= 24 ? code : undefined;
+}
+
+export function formatDuration(durationMs?: number): string | undefined {
+  if (durationMs === undefined) return undefined;
+  return durationMs < 1000 ? `${durationMs} ms` : `${(durationMs / 1000).toFixed(durationMs < 10000 ? 2 : 1)} s`;
+}
+
+export function payloadBytes(content: unknown, rawText?: string): number | undefined {
+  let text = rawText;
+  if (text === undefined) {
+    if (content === undefined) return undefined;
+    try {
+      text = JSON.stringify(content);
+    } catch {
+      return undefined;
+    }
+  }
+  return text === undefined ? undefined : new TextEncoder().encode(text).length;
+}
+
+export function formatBytes(bytes?: number): string | undefined {
+  if (bytes === undefined) return undefined;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function statusClass(status: RunStatus): string {
+  return {
+    pending: "text-muted-foreground",
+    streaming: "text-primary",
+    success: "text-emerald-600 dark:text-emerald-400",
+    error: "text-destructive",
+  }[status];
+}
+
+export function dotClass(status: RunStatus): string {
+  return {
+    pending: "bg-muted-foreground",
+    streaming: "bg-primary",
+    success: "bg-emerald-500",
+    error: "bg-red-500",
+  }[status];
+}
+
+/**
+ * How long a call's bar is, as a fraction of the widest one in its run. Finding
+ * the slow call in two hundred becomes a shape you see rather than four digits
+ * you read. A call still running has no length yet, and a run with nothing to
+ * compare against gets no bars at all.
+ */
+export function barFraction(durationMs: number | undefined, slowestMs: number | undefined): number | undefined {
+  if (durationMs === undefined || slowestMs === undefined || slowestMs <= 0) return undefined;
+  // A very fast call still gets a visible sliver, so the column reads as a
+  // measurement rather than as an empty cell.
+  return Math.max(0.04, Math.min(1, durationMs / slowestMs));
+}

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -141,6 +141,7 @@ test("defaultInput generates a request that serializes", () => {
     new Kaja(
       () => {},
       async () => "",
+      () => {},
     ),
   );
 

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,5 +1,6 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
+import { AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
 import { rememberValues } from "./typeMemory";
 
 // Thrown when the user cancels a `kaja.ask(...)` prompt. The task runner
@@ -11,8 +12,25 @@ export class AskCancelledError extends Error {
   }
 }
 
+// The question is asked by the block; this is what waits for it to be answered.
+// The id is what the answer comes back against, so an ask on a canvas nobody is
+// looking at is still the one that resolves.
 export interface AskRequest {
-  (message: string): Promise<string>;
+  (message: string, blockId: string): Promise<string>;
+}
+
+// A block arriving, or the same block again with more in it.
+export interface BlockUpdate {
+  (blockId: string, block: Block): void;
+}
+
+/**
+ * A table that is still being filled in. A loop is the reason tables exist here,
+ * so rows land one at a time and the canvas repaints as they do — waiting for
+ * the loop to finish would make the interesting part the part you can't watch.
+ */
+export interface Table {
+  row(...cells: unknown[]): void;
 }
 
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
@@ -93,16 +111,72 @@ export class Kaja {
     },
   };
   #onAsk: AskRequest;
+  #onBlockUpdate: BlockUpdate;
 
-  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest) {
+  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest, onBlockUpdate: BlockUpdate) {
     this._internal = new KajaInternal(onMethodCallUpdate);
     this.#onAsk = onAsk;
+    this.#onBlockUpdate = onBlockUpdate;
   }
 
-  // Pause the script and pop up a dialog asking the user for input. Resolves
-  // with the submitted text; rejects (aborting the script) if the user cancels.
-  ask(message: string): Promise<string> {
-    return this.#onAsk(message);
+  /**
+   * Pause the script and ask the user for input. The question is drawn on the
+   * run's canvas where it happened, and the canvas stops there until it is
+   * answered — the empty space under it is the pause. Resolves with the
+   * submitted text; rejects (aborting the script) if the user cancels.
+   */
+  async ask(message: string): Promise<string> {
+    const blockId = newBlockId();
+    const question: AskBlock = { kind: "ask", question: message };
+    this.#onBlockUpdate(blockId, question);
+    try {
+      const answer = await this.#onAsk(message, blockId);
+      this.#onBlockUpdate(blockId, { ...question, answer });
+      return answer;
+    } catch (error) {
+      this.#onBlockUpdate(blockId, { ...question, cancelled: true });
+      throw error;
+    }
+  }
+
+  /**
+   * Write a line onto the run's canvas.
+   *
+   *   kaja.text(`Reconciling ${accounts.length} accounts`);
+   */
+  text(text: string): void {
+    const block: TextBlock = { kind: "text", text };
+    this.#onBlockUpdate(newBlockId(), block);
+  }
+
+  /**
+   * Put a snippet of code on the canvas — a query a script built, a payload it
+   * is about to send.
+   */
+  code(code: string, language?: string): void {
+    const block: CodeBlock = { kind: "code", code, language };
+    this.#onBlockUpdate(newBlockId(), block);
+  }
+
+  /**
+   * Start a table on the canvas and hand back a handle to fill it. Rows appear
+   * as they are added, so a loop paints rather than reporting at the end.
+   *
+   *   const table = kaja.table(["id", "name", "status"]);
+   *   for (const account of accounts) table.row(account.id, account.name, "matched");
+   */
+  table(columns: string[], rows: unknown[][] = []): Table {
+    const blockId = newBlockId();
+    const block: TableBlock = { kind: "table", columns: columns.map(formatCell), rows: rows.map((row) => row.map(formatCell)) };
+    this.#onBlockUpdate(blockId, block);
+    return {
+      row: (...cells: unknown[]) => {
+        // A new array each time: the canvas compares what it was handed against
+        // what it holds, and a row pushed into the same array is invisible to it.
+        block.rows = [...block.rows, cells.map(formatCell)];
+        this.#onBlockUpdate(blockId, { ...block });
+      },
+    };
   }
 
   // Builders for google.protobuf.Value, Struct and ListValue, so a field of one

--- a/ui/src/loopKey.test.ts
+++ b/ui/src/loopKey.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { loopKey } from "./loopKey";
+
+describe("loopKey", () => {
+  it("reads the value that identifies what the call was about", () => {
+    expect(loopKey({ id: "in_0001" })).toBe("in_0001");
+  });
+
+  it("prefers an explicit id over a name", () => {
+    expect(loopKey({ name: "Northwind Ltd", accountId: "ac_8813" })).toBe("ac_8813");
+  });
+
+  it("finds the subject through one envelope", () => {
+    expect(loopKey({ invoice: { number: 7, id: "in_0002" } })).toBe("in_0002");
+  });
+
+  it("takes a number as readily as a string", () => {
+    expect(loopKey({ id: 41 })).toBe("41");
+  });
+
+  it("has nothing to say about a request that identifies nothing", () => {
+    expect(loopKey({ limit: 50, includeArchived: true })).toBeUndefined();
+  });
+
+  // A generated request holds zero values, so a call nobody filled in must not
+  // come out labelled with the emptiness of its own template.
+  it("ignores the zero values a generated request starts with", () => {
+    expect(loopKey({ id: "" })).toBeUndefined();
+    expect(loopKey({ id: 0 })).toBeUndefined();
+    expect(loopKey({ id: "0" })).toBeUndefined();
+  });
+
+  it("truncates a key too long to sit in a row", () => {
+    expect(loopKey({ id: "a".repeat(40) })).toBe(`${"a".repeat(21)}…`);
+  });
+
+  it("has nothing to read off a request that is not an object", () => {
+    expect(loopKey(undefined)).toBeUndefined();
+    expect(loopKey("in_0001")).toBeUndefined();
+    expect(loopKey([{ id: "in_0001" }])).toBeUndefined();
+  });
+});

--- a/ui/src/loopKey.ts
+++ b/ui/src/loopKey.ts
@@ -1,0 +1,62 @@
+/**
+ * Fields whose value identifies the thing a call is about. One definition, read
+ * twice: `scratchTitle` reads it off the source to name a script, and the run
+ * log reads it off the request to tell two hundred calls to the same method
+ * apart. Ordered — an explicit id beats a name.
+ */
+export const SUBJECT_FIELDS = [/^id$/i, /_id$/i, /Id$/, /^slug$/i, /^key$/i, /^code$/i, /^name$/i, /^email$/i, /^title$/i];
+
+const MAX_KEY = 22;
+// Deep enough for a request that wraps its subject in one envelope, shallow
+// enough that a key never comes from somewhere nobody would look.
+const MAX_DEPTH = 2;
+
+/**
+ * The value that tells one call in a loop from the next, read from the request
+ * it was made with. Undefined when nothing in the request identifies anything,
+ * which is the common case for a call made once — there the method name is
+ * already unique in the run and the slot stays empty.
+ */
+export function loopKey(input: unknown): string | undefined {
+  if (!isPlainObject(input)) return undefined;
+  for (const pattern of SUBJECT_FIELDS) {
+    const found = find(input, pattern, 0);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function find(object: { [key: string]: unknown }, pattern: RegExp, depth: number): string | undefined {
+  for (const [name, value] of Object.entries(object)) {
+    if (pattern.test(name)) {
+      const scalar = identifying(value);
+      if (scalar !== undefined) return scalar;
+    }
+    if (depth < MAX_DEPTH && isPlainObject(value)) {
+      const nested = find(value, pattern, depth + 1);
+      if (nested !== undefined) return nested;
+    }
+  }
+  return undefined;
+}
+
+// A generated request holds zero values, so an empty string or a 0 is the
+// absence of an answer rather than one worth showing. A 64-bit field is
+// generated as a string, so its zero arrives as text.
+function identifying(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" || /^-?0+$/.test(trimmed) ? undefined : truncate(trimmed);
+  }
+  if (typeof value === "number") return value === 0 ? undefined : truncate(String(value));
+  if (typeof value === "bigint") return value === 0n ? undefined : truncate(String(value));
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is { [key: string]: unknown } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function truncate(value: string): string {
+  return value.length > MAX_KEY ? `${value.slice(0, MAX_KEY - 1)}…` : value;
+}

--- a/ui/src/runHistory.test.ts
+++ b/ui/src/runHistory.test.ts
@@ -7,6 +7,7 @@ import {
   fileConsole,
   hasCallsInFlight,
   putFile,
+  recordBlock,
   recordCall,
   recordLogs,
   renameFile,
@@ -14,9 +15,11 @@ import {
   runningFileIds,
   setSelection,
   setTab,
+  setView,
   settleRun,
   startRun,
   takeFile,
+  waitingFileIds,
 } from "./runHistory";
 import { Run } from "./runs";
 import { LogLevel } from "./server/api";
@@ -197,5 +200,73 @@ describe("hasCallsInFlight", () => {
     expect(hasCallsInFlight(fileConsole(history, "a"), "r1")).toBe(true);
     history = recordCall(history, "a", "r1", call("c1", { shows: [] }), NOW);
     expect(hasCallsInFlight(fileConsole(history, "a"), "r1")).toBe(false);
+  });
+});
+
+describe("recordBlock", () => {
+  const asked = { kind: "ask", question: "Which ledger?" } as const;
+
+  it("keeps a block where it was emitted as it fills in", () => {
+    let history: RunHistory = startRun({}, run("r1", "f1"), NOW);
+    history = recordBlock(history, "f1", "r1", "b1", { kind: "table", columns: ["id"], rows: [] }, NOW);
+    history = recordCall(history, "f1", "r1", call("c1", {}), NOW);
+    history = recordBlock(history, "f1", "r1", "b1", { kind: "table", columns: ["id"], rows: [["ac_1"]] }, NOW);
+
+    const items = fileConsole(history, "f1").items;
+    expect(items.map((item) => (item.block ? "block" : "call"))).toEqual(["block", "call"]);
+    expect(items[0].block).toEqual({ kind: "table", columns: ["id"], rows: [["ac_1"]] });
+  });
+
+  it("has nowhere to put a block from a run with no console", () => {
+    expect(recordBlock({}, undefined, "r1", "b1", asked, NOW)).toEqual({});
+  });
+
+  it("says which files are stopped waiting for an answer", () => {
+    let history: RunHistory = startRun({}, run("r1", "f1"), NOW);
+    history = recordBlock(history, "f1", "r1", "b1", asked, NOW);
+    expect(waitingFileIds(history)).toEqual(new Set(["f1"]));
+
+    history = recordBlock(history, "f1", "r1", "b1", { ...asked, answer: "june" }, NOW);
+    expect(waitingFileIds(history)).toEqual(new Set());
+  });
+});
+
+describe("run numbering", () => {
+  it("counts a file's runs from one", () => {
+    let history: RunHistory = startRun({}, run("r1", "f1"), NOW);
+    history = startRun(history, run("r2", "f1"), NOW);
+    expect(fileConsole(history, "f1").runs.map((entry) => entry.number)).toEqual([1, 2]);
+  });
+
+  // `Run 3` has to still say Run 3 after the run it was counted against has been
+  // trimmed out from under it.
+  it("never reuses a number the trimmed runs already spent", () => {
+    let history: RunHistory = {};
+    for (let index = 0; index < 30; index++) history = startRun(history, run(`r${index}`, "f1"), NOW);
+    const runs = fileConsole(history, "f1").runs;
+    expect(runs.length).toBe(25);
+    expect(runs[runs.length - 1].number).toBe(30);
+    expect(runs[0].number).toBe(6);
+  });
+
+  it("numbers each file's runs on its own", () => {
+    let history: RunHistory = startRun({}, run("r1", "f1"), NOW);
+    history = startRun(history, run("r2", "f2"), NOW);
+    expect(fileConsole(history, "f2").runs[0].number).toBe(1);
+  });
+});
+
+describe("setView", () => {
+  it("is unset until a view has been chosen", () => {
+    const history = startRun({}, run("r1", "f1"), NOW);
+    expect(fileConsole(history, "f1").view).toBeUndefined();
+  });
+
+  // Debugging is a mode, not a click: the choice outlives the run that prompted it.
+  it("sticks to the file across later runs", () => {
+    let history: RunHistory = startRun({}, run("r1", "f1"), NOW);
+    history = setView(history, "f1", "list", NOW);
+    history = startRun(history, run("r2", "f1"), NOW);
+    expect(fileConsole(history, "f1").view).toBe("list");
   });
 });

--- a/ui/src/runHistory.ts
+++ b/ui/src/runHistory.ts
@@ -1,5 +1,6 @@
+import { Block, isAwaitingAnswer } from "./blocks";
 import { isCallInFlight, MethodCall } from "./kaja";
-import { ConsoleItem, ConsoleTab, newItemId, Run, RunSelection } from "./runs";
+import { ConsoleItem, ConsoleTab, ConsoleView, newItemId, Run, RunSelection } from "./runs";
 import { Log } from "./server/api";
 
 /**
@@ -20,6 +21,10 @@ export interface FileConsole {
   // which is what a file that has never been looked at wants.
   selection: RunSelection | null;
   tab: ConsoleTab;
+  // Which of the two views this file is being read in. Undefined until it is
+  // chosen, which is what lets a run that drew something open on its canvas
+  // while an explicit choice still outranks it and sticks.
+  view?: ConsoleView;
   // Whether the store has been consulted for this file yet, so it is read once
   // rather than on every visit.
   loaded: boolean;
@@ -95,7 +100,13 @@ function withFile(history: RunHistory, fileId: string, now: number, change: (fil
  */
 export function startRun(history: RunHistory, run: Run, now: number): RunHistory {
   if (!run.fileId) return history;
-  return withFile(history, run.fileId, now, (file) => ({ ...file, runs: [...file.runs, run] }));
+  return withFile(history, run.fileId, now, (file) => ({ ...file, runs: [...file.runs, { ...run, number: nextRunNumber(file.runs) }] }));
+}
+
+// Runs are numbered per file, counting from one and never reused, so `Run 3`
+// still says Run 3 after the oldest runs have been trimmed out from under it.
+function nextRunNumber(runs: Run[]): number {
+  return runs.reduce((highest, run) => Math.max(highest, run.number ?? 0), 0) + 1;
 }
 
 // Calls arrive more than once as they stream and settle, so a call already in
@@ -108,6 +119,23 @@ export function recordCall(history: RunHistory, fileId: string | undefined, runI
       return { ...file, items: file.items.map((item, i) => (i === index ? { ...item, call: { ...call } } : item)) };
     }
     return { ...file, items: [...file.items, { id: newItemId(), runId, timestamp: call.timestamp, call: { ...call } }] };
+  });
+}
+
+/**
+ * Something the run drew. A block arrives more than once — a table paints row by
+ * row, an ask is emitted as a question and again as an answer — so a block
+ * already in the run is replaced in place rather than appended, which is what
+ * keeps it where it was emitted instead of jumping to the end when it changes.
+ */
+export function recordBlock(history: RunHistory, fileId: string | undefined, runId: string, blockId: string, block: Block, now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => {
+    const index = file.items.findIndex((item) => item.id === blockId);
+    if (index > -1) {
+      return { ...file, items: file.items.map((item, i) => (i === index ? { ...item, block } : item)) };
+    }
+    return { ...file, items: [...file.items, { id: blockId, runId, timestamp: now, block }] };
   });
 }
 
@@ -153,6 +181,28 @@ export function setSelection(history: RunHistory, fileId: string | undefined, se
 export function setTab(history: RunHistory, fileId: string | undefined, tab: ConsoleTab, now: number): RunHistory {
   if (!fileId) return history;
   return withFile(history, fileId, now, (file) => (file.tab === tab ? file : { ...file, tab }));
+}
+
+// Choosing a view is a decision about how this script is being read, so it
+// sticks until it is changed — a later run does not put it back.
+export function setView(history: RunHistory, fileId: string | undefined, view: ConsoleView, now: number): RunHistory {
+  if (!fileId) return history;
+  return withFile(history, fileId, now, (file) => (file.view === view ? file : { ...file, view }));
+}
+
+// Whether the file is stopped on a question. A run keeps going when you navigate
+// away from it, so the sidebar reads this to say so on a script whose canvas is
+// no longer on screen to.
+export function isWaitingForAnswer(file: FileConsole): boolean {
+  return file.items.some((item) => item.block !== undefined && isAwaitingAnswer(item.block));
+}
+
+export function waitingFileIds(history: RunHistory): Set<string> {
+  const waiting = new Set<string>();
+  for (const [fileId, file] of Object.entries(history)) {
+    if (isWaitingForAnswer(file)) waiting.add(fileId);
+  }
+  return waiting;
 }
 
 // Saving a scratch to disk changes what the file is called, not what it is, so

--- a/ui/src/runStore.test.ts
+++ b/ui/src/runStore.test.ts
@@ -106,3 +106,25 @@ describe("pruneArchive", () => {
     expect(pruneArchive(archive, NOW)).toEqual({});
   });
 });
+
+describe("blocks in the store", () => {
+  it("brings back what a run drew", () => {
+    const items: ConsoleItem[] = [
+      { id: "b1", runId: "r1", timestamp: NOW, block: { kind: "table", columns: ["id"], rows: [["ac_1"]] } },
+      { id: "b2", runId: "r1", timestamp: NOW, block: { kind: "ask", question: "Which ledger?", answer: "june" } },
+    ];
+    const loaded = deserializeFile(serializeFile([run], items, NOW));
+    expect(loaded.items.map((item) => item.block)).toEqual([
+      { kind: "table", columns: ["id"], rows: [["ac_1"]] },
+      { kind: "ask", question: "Which ledger?", answer: "june" },
+    ]);
+  });
+
+  // The promise the question was blocking died with the session, so reading it
+  // back as still waiting would offer an input nothing is listening to.
+  it("stores a question nobody answered as one that was abandoned", () => {
+    const items: ConsoleItem[] = [{ id: "b1", runId: "r1", timestamp: NOW, block: { kind: "ask", question: "Which ledger?" } }];
+    const loaded = deserializeFile(serializeFile([run], items, NOW));
+    expect(loaded.items[0].block).toEqual({ kind: "ask", question: "Which ledger?", cancelled: true });
+  });
+});

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -1,4 +1,5 @@
 import { Method, Service } from "./apps";
+import { Block, isAwaitingAnswer } from "./blocks";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { MethodCall } from "./kaja";
 import { ConsoleItem, Run } from "./runs";
@@ -39,11 +40,14 @@ interface StoredCall {
   durationMs?: number;
 }
 
+// A block is already plain JSON, so it survives the store as itself — there is
+// nothing to flatten and nothing that can't come back.
 interface StoredItem {
   id: string;
   timestamp: number;
   call?: StoredCall;
   logs?: Log[];
+  block?: Block;
 }
 
 interface StoredRun {
@@ -141,7 +145,16 @@ export function serializeFile(runs: Run[], items: ConsoleItem[], now: number): S
 }
 
 function toStoredItem(item: ConsoleItem): StoredItem {
-  return { id: item.id, timestamp: item.timestamp, call: item.call ? toStoredCall(item.call) : undefined, logs: item.logs };
+  return { id: item.id, timestamp: item.timestamp, call: item.call ? toStoredCall(item.call) : undefined, logs: item.logs, block: storedBlock(item.block) };
+}
+
+// A question that was never answered is stored as one that was abandoned: the
+// promise it was blocking died with the session, so reading it back as still
+// waiting would show a run parked on an input nothing is listening to.
+function storedBlock(block: Block | undefined): Block | undefined {
+  if (block === undefined) return undefined;
+  if (block.kind === "ask" && isAwaitingAnswer(block)) return { ...block, cancelled: true };
+  return block;
 }
 
 function payloadBytes(items: StoredItem[]): number {
@@ -158,7 +171,14 @@ export function deserializeFile(stored: StoredFile): LoadedRuns {
   for (const entry of stored.runs) {
     runs.push(entry.run);
     for (const item of entry.items) {
-      items.push({ id: item.id, runId: entry.run.id, timestamp: item.timestamp, call: item.call ? fromStoredCall(item.call) : undefined, logs: item.logs });
+      items.push({
+        id: item.id,
+        runId: entry.run.id,
+        timestamp: item.timestamp,
+        call: item.call ? fromStoredCall(item.call) : undefined,
+        logs: item.logs,
+        block: item.block,
+      });
     }
   }
   return { runs, items };

--- a/ui/src/runs.test.ts
+++ b/ui/src/runs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { MethodCall } from "./kaja";
-import { callCount, ConsoleItem, followSelection, groupRuns, isSingleItemRun, Run, worstStatus } from "./runs";
+import { Block } from "./blocks";
+import { awaitingItem, callCount, callItems, ConsoleItem, defaultView, followSelection, groupRuns, hasDrawing, Run, slowestCall, worstStatus } from "./runs";
 import { LogLevel } from "./server/api";
 
 const NOW = 1_700_000_000_000;
@@ -25,6 +26,10 @@ function call(id: string, runId: string, changes: Partial<MethodCall> = {}): Con
 
 function logs(id: string, runId: string, level: LogLevel): ConsoleItem {
   return { id, runId, timestamp: NOW, logs: [{ level, message: "hello" }] };
+}
+
+function block(id: string, runId: string, block: Block): ConsoleItem {
+  return { id, runId, timestamp: NOW, block };
 }
 
 describe("worstStatus", () => {
@@ -85,12 +90,6 @@ describe("callCount", () => {
   it("counts calls, not the log lines the script printed", () => {
     const [group] = groupRuns([run("r1")], [call("a", "r1"), logs("b", "r1", LogLevel.LEVEL_INFO)]);
     expect(callCount(group)).toBe(1);
-    expect(isSingleItemRun(group)).toBe(false);
-  });
-
-  it("treats a run of one as a single row, so the common case gains no chrome", () => {
-    const [group] = groupRuns([run("r1")], [call("a", "r1")]);
-    expect(isSingleItemRun(group)).toBe(true);
   });
 });
 
@@ -123,5 +122,78 @@ describe("followSelection", () => {
 
   it("has nothing to select once the history is cleared", () => {
     expect(followSelection({ runId: "r1", itemId: "a" }, [], true)).toBeNull();
+  });
+});
+
+describe("the two views", () => {
+  const table: Block = { kind: "table", columns: ["id"], rows: [["ac_1"]] };
+
+  // A row is a call and only a call — that is what stops the log and the canvas
+  // saying the same thing twice.
+  it("keeps everything but calls out of the log", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1"), block("b", "r1", table), logs("c", "r1", LogLevel.LEVEL_INFO)]);
+    expect(callItems(group).map((item) => item.id)).toEqual(["a"]);
+    expect(callCount(group)).toBe(1);
+  });
+
+  it("opens a run that drew something on its canvas", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1"), block("b", "r1", table)]);
+    expect(hasDrawing(group)).toBe(true);
+    expect(defaultView(group)).toBe("canvas");
+  });
+
+  // A run that only called has a canvas of call cards, which is a true but
+  // redundant view of its log — not what the console should open on.
+  it("opens a run that only made calls on its log", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1"), call("b", "r1")]);
+    expect(defaultView(group)).toBe("list");
+  });
+
+  it("opens on the log when there is no run at all", () => {
+    expect(defaultView(undefined)).toBe("list");
+  });
+});
+
+describe("a run parked on a question", () => {
+  const asked: Block = { kind: "ask", question: "Which ledger?" };
+  const answered: Block = { kind: "ask", question: "Which ledger?", answer: "june" };
+
+  it("is still in flight, though nothing is in the air", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1"), block("b", "r1", asked)]);
+    expect(group.inFlight).toBe(true);
+    expect(group.status).toBe("pending");
+    expect(awaitingItem(group)?.id).toBe("b");
+  });
+
+  it("is over once the question has been answered", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1"), block("b", "r1", answered)]);
+    expect(group.inFlight).toBe(false);
+    expect(group.status).toBe("success");
+    expect(awaitingItem(group)).toBeUndefined();
+  });
+
+  // A run read back from the store happened in an earlier session: whatever it
+  // was waiting for is long gone.
+  it("is never live again once it has been read back from the store", () => {
+    const [group] = groupRuns([run("r1", { stale: true })], [block("b", "r1", asked)]);
+    expect(group.inFlight).toBe(false);
+  });
+});
+
+describe("slowestCall", () => {
+  it("is what every duration bar is drawn against", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1", { durationMs: 120 }), call("b", "r1", { durationMs: 690 })]);
+    expect(slowestCall(group)).toBe(690);
+  });
+
+  // A bar only means something against another bar, so a run of one gets none.
+  it("has nothing to compare in a run of one call", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1", { durationMs: 120 })]);
+    expect(slowestCall(group)).toBeUndefined();
+  });
+
+  it("ignores a call that has not finished yet", () => {
+    const [group] = groupRuns([run("r1")], [call("a", "r1", { durationMs: 120 }), call("b", "r1", { output: undefined })]);
+    expect(slowestCall(group)).toBeUndefined();
   });
 });

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -1,3 +1,4 @@
+import { Block, blockLabel, isAwaitingAnswer } from "./blocks";
 import { isCallInFlight, MethodCall } from "./kaja";
 import { Log, LogLevel } from "./server/api";
 
@@ -8,9 +9,14 @@ import { Log, LogLevel } from "./server/api";
  */
 export interface Run {
   id: string;
-  // The script's derived name at the time it was run, so the console and the
-  // sidebar speak the same language.
+  // The script's derived name at the time it was run. The console belongs to one
+  // file, so every run in it carries much the same name and the header numbers
+  // them instead; this is what the window title and the store still read.
   title: string;
+  // Which run of this file it is, counting from one and never reused. The
+  // header says `Run 3`, so it has to survive the oldest runs being trimmed —
+  // a position in the list would renumber underneath you.
+  number?: number;
   // The file it came from — a scratch id or a script path. The console belongs
   // to the file, so this is what decides which console a run lands in. ("Source"
   // is taken: it means an app's generated proto TypeScript.)
@@ -27,13 +33,19 @@ export interface Run {
   payloadsExpired?: boolean;
 }
 
-// One line in the console: a call the run made, or the log messages it printed.
+/**
+ * One thing that happened in a run: a call it made, something it drew, or the
+ * log messages it printed. Blocks are items rather than a parallel world, so
+ * they inherit run grouping, ordering, the per-file console and the store
+ * without any of it being written twice.
+ */
 export interface ConsoleItem {
   id: string;
   runId: string;
   timestamp: number;
   call?: MethodCall;
   logs?: Log[];
+  block?: Block;
 }
 
 export type RunStatus = "pending" | "streaming" | "success" | "error";
@@ -41,6 +53,15 @@ export type RunStatus = "pending" | "streaming" | "success" | "error";
 // Which part of the selected call is showing. It is remembered per file along
 // with the selection, so going back to a script finds its console as it was.
 export type ConsoleTab = "request" | "response" | "headers";
+
+/**
+ * The two views of one run. The list is the flat audit log — one row per call,
+ * in wall order, always complete. The canvas is the rendered output. They want
+ * opposite things: the log wants to be uniform and boring, which is what makes
+ * it scannable at two hundred rows; the canvas wants to be varied. Serving both
+ * in one surface bends one of them out of shape.
+ */
+export type ConsoleView = "list" | "canvas";
 
 export interface RunGroup {
   run: Run;
@@ -77,12 +98,21 @@ export function logsStatus(logs: Log[]): RunStatus {
   return logs.some((log) => log.level === LogLevel.LEVEL_ERROR) ? "error" : "success";
 }
 
+// A drawn block has already happened, so it is settled — except an ask, which is
+// the run stopped mid-flight waiting to be answered.
+export function blockStatus(block: Block): RunStatus {
+  return isAwaitingAnswer(block) ? "pending" : "success";
+}
+
 export function itemStatus(item: ConsoleItem): RunStatus {
-  return item.call ? callStatus(item.call) : item.logs ? logsStatus(item.logs) : "success";
+  if (item.call) return callStatus(item.call);
+  if (item.block) return blockStatus(item.block);
+  return item.logs ? logsStatus(item.logs) : "success";
 }
 
 export function itemName(item: ConsoleItem): string {
   if (item.call) return `${item.call.service.name}.${item.call.method.name}`;
+  if (item.block) return blockLabel(item.block);
   const logs = item.logs ?? [];
   return logs.length === 1 ? logs[0].message.trim() : `${logs.length} log messages`;
 }
@@ -121,26 +151,63 @@ export function groupRuns(runs: Run[], items: ConsoleItem[]): RunGroup[] {
         run,
         items: runItems,
         status: worstStatus(runItems),
-        inFlight: !run.stale && runItems.some((item) => item.call !== undefined && isCallInFlight(item.call)),
+        // A run parked on a question has nothing in the air, but it is not over
+        // either — the script is stopped inside it waiting to be answered.
+        inFlight:
+          !run.stale &&
+          runItems.some((item) => (item.call !== undefined && isCallInFlight(item.call)) || (item.block !== undefined && isAwaitingAnswer(item.block))),
         failures: runItems.filter((item) => itemStatus(item) === "error").length,
       };
     });
 }
 
-// How many calls the header reports. Log lines are the script talking, not calls
-// it made, so they don't count towards it.
+// The log is calls and only calls: a row is a call, full stop. Everything else a
+// run produced is on the canvas, which is what stops the two views saying the
+// same thing twice.
+export function callItems(group: RunGroup): ConsoleItem[] {
+  return group.items.filter((item) => item.call !== undefined);
+}
+
 export function callCount(group: RunGroup): number {
-  return group.items.filter((item) => item.call !== undefined).length;
+  return callItems(group).length;
 }
 
-// A single-item run renders as one row, header and call merged, so the common
-// case gains no chrome over what the console shows today.
-export function isSingleItemRun(group: RunGroup): boolean {
-  return group.items.length <= 1;
+// The question the run is stopped on, if it is stopped on one. This is what puts
+// a dot on the Canvas tab and an amber bar at the tail of the log.
+export function awaitingItem(group: RunGroup): ConsoleItem | undefined {
+  return group.items.find((item) => item.block !== undefined && isAwaitingAnswer(item.block));
 }
 
-// Which run is being looked at, and which of its calls. No call means the run
-// header itself is selected, which shows the run's own summary.
+// Whether the run drew anything of its own. A run that only made calls has a
+// canvas of call cards, which is a true but redundant view of its log — so it
+// is not what the console opens on.
+export function hasDrawing(group: RunGroup): boolean {
+  return group.items.some((item) => item.block !== undefined || item.logs !== undefined);
+}
+
+/**
+ * Which view a run opens in when nothing has been chosen. A script executed for
+ * its output opens on that output; one that only calls opens on its log, where
+ * everything it did actually is. An explicit choice outranks this and sticks per
+ * file — debugging is a mode, not a click.
+ */
+export function defaultView(group: RunGroup | undefined): ConsoleView {
+  return group && hasDrawing(group) ? "canvas" : "list";
+}
+
+/**
+ * The longest call in the run, which every duration bar is drawn against. Bars
+ * only mean something in a run with calls to compare, so a run of one gets none.
+ */
+export function slowestCall(group: RunGroup): number | undefined {
+  const durations = callItems(group)
+    .map((item) => item.call?.durationMs)
+    .filter((duration): duration is number => duration !== undefined);
+  return durations.length > 1 ? Math.max(...durations) : undefined;
+}
+
+// Which run is being looked at, and which of its calls. No call means nothing in
+// the log is selected yet, so the payload pane has nothing to show.
 export interface RunSelection {
   runId: string;
   itemId?: string;
@@ -160,5 +227,6 @@ export function followSelection(current: RunSelection | null, groups: RunGroup[]
   const newest = groups[groups.length - 1];
   if (!newest) return null;
   if (!isNewRun && current && current.runId !== newest.run.id && groups.some((group) => group.run.id === current.runId)) return current;
-  return { runId: newest.run.id, itemId: newest.items[newest.items.length - 1]?.id };
+  const calls = callItems(newest);
+  return { runId: newest.run.id, itemId: calls[calls.length - 1]?.id };
 }

--- a/ui/src/scratchTitle.test.ts
+++ b/ui/src/scratchTitle.test.ts
@@ -130,3 +130,22 @@ describe("proposeFileNames", () => {
     expect(proposeFileNames(["GetShow", "GetShow"], ["getShow.ts"])).toEqual(["getShow2", "getShow3"]);
   });
 });
+
+describe("scripts that draw", () => {
+  // kaja is imported like a service and called like one, but `kaja.table(...)`
+  // is the script drawing rather than a call it made.
+  it("is not named after the canvas verbs", () => {
+    const code = `import { kaja } from "kaja";\nkaja.text("hello");\nkaja.table(["id"]);\nkaja.code("SELECT 1", "sql");`;
+    expect(deriveScratchTitle(code)).toBeUndefined();
+  });
+
+  it("still names the call a drawing script makes", () => {
+    const code = `import { kaja } from "kaja";\nimport { Shows } from "theatre/shows";\nkaja.text("listing");\nawait Shows.ListShows({});`;
+    expect(deriveScratchTitle(code)).toBe("ListShows");
+  });
+
+  it("follows the runtime through an alias", () => {
+    const code = `import { kaja as k } from "kaja";\nk.text("hello");`;
+    expect(deriveScratchTitle(code)).toBeUndefined();
+  });
+});

--- a/ui/src/scratchTitle.ts
+++ b/ui/src/scratchTitle.ts
@@ -1,8 +1,6 @@
+import { SUBJECT_FIELDS } from "./loopKey";
 import ts from "typescript";
 
-// Fields whose value identifies the thing a call is about, so it is worth
-// putting in the title. Ordered: an explicit id beats a name.
-const SUBJECT_FIELDS = [/^id$/i, /_id$/i, /Id$/, /^slug$/i, /^key$/i, /^code$/i, /^name$/i, /^email$/i, /^title$/i];
 // A request small enough to read at a glance is described by its values, which
 // is usually where two explorations of the same call differ. A bigger one stays
 // quiet rather than picking an arbitrary field out of a crowd.
@@ -22,11 +20,19 @@ export interface ScratchCall {
 export function readCalls(code: string): ScratchCall[] {
   const file = ts.createSourceFile("scratch.ts", code, ts.ScriptTarget.Latest, /*setParentNodes*/ false, ts.ScriptKind.TS);
   const imported = importedNames(file);
+  const runtime = runtimeNames(file);
   const calls: ScratchCall[] = [];
 
   const visit = (node: ts.Node) => {
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.expression)) {
       const service = node.expression.expression.text;
+      // The kaja runtime is imported like a service and called like one, but
+      // `kaja.table(...)` is the script drawing rather than a call it made — a
+      // script that only draws would otherwise be titled `text +3`.
+      if (runtime.has(service)) {
+        ts.forEachChild(node, visit);
+        return;
+      }
       // With no imports to check against (a hand-written script), fall back to
       // the shape a service call has: a capitalized receiver.
       if (imported.size > 0 ? imported.has(service) : /^[A-Z]/.test(service)) {
@@ -41,9 +47,20 @@ export function readCalls(code: string): ScratchCall[] {
 }
 
 function importedNames(file: ts.SourceFile): Set<string> {
+  return boundNames(file, () => true);
+}
+
+// Whatever the kaja runtime was bound to in this file, alias included — Monaco's
+// auto-import can write the relative form of the module.
+function runtimeNames(file: ts.SourceFile): Set<string> {
+  return boundNames(file, (path) => path === "kaja" || path === "./kaja");
+}
+
+function boundNames(file: ts.SourceFile, wanted: (modulePath: string) => boolean): Set<string> {
   const names = new Set<string>();
   for (const statement of file.statements) {
     if (!ts.isImportDeclaration(statement)) continue;
+    if (!ts.isStringLiteral(statement.moduleSpecifier) || !wanted(statement.moduleSpecifier.text)) continue;
     const bindings = statement.importClause?.namedBindings;
     if (bindings && ts.isNamedImports(bindings)) {
       for (const element of bindings.elements) names.add(element.name.text);

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -6,6 +6,7 @@ function makeKaja(): Kaja {
   return new Kaja(
     () => {},
     async () => "",
+    () => {},
   );
 }
 


### PR DESCRIPTION
A run now has two views of the same data, switched by a segmented control in the console header: **List** is the flat audit log (one row per call, always complete), **Canvas** is what the script drew. Scripts draw with a closed set of verbs — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask` — and `kaja.ask` stops being a modal: the question is drawn where it happened and the canvas stops there until it is answered.

---
_Generated by [Claude Code](https://claude.ai/code/session_012PmtZVjMBx48JH856KL1vu)_