### PR TITLE
Stopped starting Kaja on the compile log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,18 @@ inset only when the sidebar is collapsed).
   holding edits that exist nowhere else (`holdsWork` — Variables, an app form) is
   never the one evicted. `views[0]` is on screen; `views[1]` is what `⌘P⏎`
   returns to.
+- **Kaja never starts on the compile log**, because the log is a report on this
+  session's apps rather than a document: starting on it means starting on an
+  account of a compilation that hasn't run, and with no apps on one that never
+  can — a switcher naming a file whose body is the no-apps blankslate. So
+  `serializeViews` leaves it out and `restoreViews` skips a stored one, and when
+  the last app goes the view is dropped rather than left standing (`App.tsx`).
+  Nothing open is the better answer either way: with apps it is the screen that
+  says picking a call writes you a script, and without them the one that says
+  where apps come from. Which of those two is right depends on the
+  configuration, so **neither is shown until it has loaded** — the compile
+  log's own `Loading configuration…` was the only thing that used to cover that
+  moment.
 - **Preview went with it.** Italic tabs, double-click-to-keep and
   "the first keystroke promotes it" only ever existed to stop tabs accumulating.
   With one pane showing one thing nothing accumulates, so `preview`, `keepTab`,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1627,6 +1627,17 @@ export function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onRunCurrentTab]);
 
+  // With no apps there is nothing to have compiled, so the log stops existing
+  // rather than sitting there naming the no-apps blankslate. It is never
+  // restored into one, so deleting the last app is the only way in.
+  useEffect(() => {
+    if (!configurationLoaded || apps.length > 0) return;
+    applyViews((views) => {
+      const compiler = views.find((view) => view.type === "compiler");
+      return compiler ? dropView(views, compiler.id) : views;
+    });
+  }, [apps.length, configurationLoaded, applyViews]);
+
   // Opens the compile log, expanded on an app when one is named. Nothing else
   // opens it: compiling is reported in the status bar, and the log is where you
   // go when it has something to say.
@@ -2052,10 +2063,13 @@ export function App() {
               layout={editorLayout}
               onToggleLayout={onToggleEditorLayout}
             />
+            {/* Which of the two nothing-open screens is right depends on
+                whether the workspace names any apps, so until the configuration
+                answers that, neither is shown. */}
             {views.length === 0 && configurationLoaded && apps.length === 0 && (
               <FirstAppBlankslate onNewAppClick={onNewAppClick} canUpdateConfiguration={runtime.canUpdateConfiguration} />
             )}
-            {views.length === 0 && (apps.length > 0 || !configurationLoaded) && (
+            {views.length === 0 && configurationLoaded && apps.length > 0 && (
               <NoFileBlankslate onOpenFinder={() => setFinder("first")} onNewScratch={onNewScratch} recent={recentFiles} />
             )}
             {views.length > 0 && (

--- a/ui/src/views.test.ts
+++ b/ui/src/views.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { dropView, serializeViews, setAppFormEditMode, showAppForm, showCompiler, showVariables, View, viewIdentity, visit } from "./views";
+import { dropView, restoreViews, serializeViews, setAppFormEditMode, showAppForm, showCompiler, showVariables, View, viewIdentity, visit } from "./views";
 import { buildApp } from "./appTypes";
 
 // Views carry Monaco models in the app; here they are stubs, so they are built
@@ -76,10 +76,20 @@ describe("viewIdentity", () => {
 
 describe("serializeViews", () => {
   it("stores which scratch a view shows, never its code", () => {
-    const views: View[] = [view("compiler-1", 1), scratchView("scratch-1", "s1")];
+    const views: View[] = [scratchView("scratch-1", "s1")];
     const result = serializeViews(views, () => undefined);
 
-    expect(result.views).toEqual([{ type: "compiler" }, { type: "scratch", scratchId: "s1", viewState: undefined }]);
+    expect(result.views).toEqual([{ type: "scratch", scratchId: "s1", viewState: undefined }]);
+  });
+
+  // The log reports on this session's apps, so it is not somewhere kaja can
+  // start: it is left out on the way down, and skipped on the way back up when
+  // an older build wrote one.
+  it("leaves the compile log out, and doesn't restore a stored one", () => {
+    const views: View[] = [view("compiler-1", 1), scratchView("scratch-1", "s1")];
+    expect(serializeViews(views, () => undefined).views).toEqual([{ type: "scratch", scratchId: "s1", viewState: undefined }]);
+
+    expect(restoreViews({ views: [{ type: "compiler" } as any] }, [])).toEqual([]);
   });
 
   it("uses live editor view state over stored view state", () => {

--- a/ui/src/views.ts
+++ b/ui/src/views.ts
@@ -250,10 +250,6 @@ interface PersistedScratchView {
   viewState?: object;
 }
 
-interface PersistedCompilerView {
-  type: "compiler";
-}
-
 interface PersistedScriptView {
   type: "script";
   scriptPath: string;
@@ -262,10 +258,16 @@ interface PersistedScriptView {
   viewState?: object;
 }
 
-type PersistedView = PersistedScratchView | PersistedCompilerView | PersistedScriptView;
+type PersistedView = PersistedScratchView | PersistedScriptView;
 
 // The visit order is the order of the list, so nothing else has to be stored:
 // what was on screen is what restores first.
+//
+// The compile log is not among them. It is a report on this session's apps, not
+// a document, so starting on it means starting on an account of a compilation
+// that hasn't run — and with no apps, on one that never can, which is a
+// switcher naming a file whose body is the no-apps blankslate. Nothing is open
+// instead, which is the screen that says picking a call writes you a script.
 export interface PersistedViewState {
   views: PersistedView[];
 }
@@ -274,9 +276,7 @@ export function serializeViews(views: View[], getViewState: (id: string) => mona
   const serialized: PersistedView[] = [];
 
   for (const view of views) {
-    if (view.type === "compiler") {
-      serialized.push({ type: "compiler" });
-    } else if (view.type === "scratch") {
+    if (view.type === "scratch") {
       serialized.push({ type: "scratch", scratchId: view.scratchId, viewState: (getViewState(view.id) ?? view.viewState) as object | undefined });
     } else if (view.type === "script") {
       serialized.push({
@@ -296,11 +296,6 @@ export function restoreViews(state: PersistedViewState | undefined, scratches: S
   const views: View[] = [];
 
   for (const persisted of state?.views ?? []) {
-    if (persisted.type === "compiler") {
-      views.push({ ...nextView("compiler"), type: "compiler" });
-      continue;
-    }
-
     if (persisted.type === "script") {
       const view = nextView("script");
       views.push({
@@ -312,6 +307,9 @@ export function restoreViews(state: PersistedViewState | undefined, scratches: S
       });
       continue;
     }
+
+    // State written by a build that persisted the compile log still names it.
+    if (persisted.type !== "scratch") continue;
 
     // A scratch pruned while its view was cached simply doesn't come back.
     const scratch = scratches.find((candidate) => candidate.id === persisted.scratchId);


### PR DESCRIPTION
The compile log is no longer persisted across sessions and is dropped when the last app goes, so Kaja opens on the screen that says picking a call writes you a script — or, with no apps, on the one that says where apps come from. Neither blankslate shows until the configuration says which is right.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJHTC2YdpAT68ZBtjwowpt)_