### PR TITLE
Folded a loop into one row on the canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,38 @@ no `kaja.html`, no styling arguments, no layout control.
   record is one click away: clicking a card selects that call's row in the list
   and switches to it. The payload is never unrolled into the flow — that is
   master/detail smuggled back in at 90°.
+- **A loop is one row** (`callGroups.ts`). Ten cards saying the same method name
+  ten times is the log's job, and the log does it better — so consecutive calls
+  to one method fold into a single row: the name once, `×10`, and the loop key
+  that tells them apart (`groupKeyLabel`, reading `loopKey` — one key they all
+  share is stated once, many are named until they stop fitting). **Consecutive is
+  the whole rule.** Anything the script drew between two calls breaks the group,
+  because the canvas is the run in the order it happened and gathering calls that
+  weren't next to each other would rewrite the story to fit the fold. Two is not
+  worth a fold (`MIN_FOLD`): it saves one line and costs a click. The duration is
+  the group's **wall time**, not the sum of its calls, so a fan-out reports what
+  it actually cost — the same number a run's own duration is.
+  - **The ticks are what keep it a canvas rather than a summary.** One per call,
+    drawn against the slowest in the group, so which iteration was slow is a
+    shape here rather than a trip to the list — and each is its own way into that
+    call's record, which is what a bare `×10` would cost. The **strip** has the
+    width budget, not the tick: past a certain density every tick is the minimum
+    width and the strip stops claiming to measure anything, and past `MAX_TICKS`
+    it draws what fits and says how many it left out. A tick too thin to hit is
+    worse than one that admits it has nothing to say. Below the width the strip
+    needs it goes entirely and the row's name is the only way in, which is the
+    same degradation the log's columns make.
+  - **A fold never hides a failure.** The failed call keeps its own tick, in
+    destructive, and the row states the count — it is not split out into its own
+    card, because `×4` / error / `×5` is three rows for one loop and reads worse
+    than the one row that says `1 error`.
+  - **The selection is reflected back.** The tick for the call the log is pointing
+    at is lit, so stepping through the list is visible on the canvas. Without it
+    the arrow between the views only runs one way.
+- **There is no timeline strip above the canvas.** It is the obvious version of
+  the above and it is the double-statement problem again — an index of the same
+  calls sitting over the content. The fold has to *be* how a call renders in the
+  flow, not a summary added over it.
 - **A block that asks is a block that pauses the run.** `kaja.ask` is drawn where
   it happened and the canvas stops there — the empty space under it *is* the
   pause. Answering appends the next block. A dialogue is not a fifth block type;

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,14 +1,32 @@
 import { ChevronRight } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
+import { CanvasEntry, foldCalls, groupDuration, groupFailures, groupKeyLabel } from "./callGroups";
 import { cn } from "./cn";
-import { MethodCall } from "./kaja";
-import { callErrorCode, formatDuration } from "./callFormat";
-import { ConsoleItem, RunGroup } from "./runs";
+import { Spinner } from "./components/spinner";
+import { isCallInFlight, MethodCall } from "./kaja";
+import { loopKey } from "./loopKey";
+import { barFraction, callErrorCode, dotClass, formatDuration } from "./callFormat";
+import { ConsoleItem, itemStatus, RunGroup, slowestOf, worstStatus } from "./runs";
 import { Log, LogLevel } from "./server/api";
+
+// The strip of ticks a folded group draws, and the shape of one tick. The whole
+// strip is budgeted rather than each tick, so ten calls read as a duration
+// profile and thirty read as a count — a tick too thin to hit is worse than one
+// that admits it has nothing left to say.
+const STRIP_WIDTH = 240;
+const TICK_GAP = 2;
+const TICK_MIN_WIDTH = 5;
+const TICK_MAX_WIDTH = 26;
+// Past this the ticks are drawn for the first calls only and the row says how
+// many it left out, on the same rule as the log's tail bar.
+const MAX_TICKS = 32;
 
 interface CanvasProps {
   group: RunGroup;
+  // Which call the log is pointing at, so stepping through it is visible here
+  // too. The canvas → list arrow is one click; this is the way back.
+  selectedItemId?: string;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
   // Clicking a call card takes you to that call's row in the log, which is where
@@ -19,9 +37,12 @@ interface CanvasProps {
 /**
  * What the run drew, in emission order. Calls appear as one-line cards where the
  * story needs them — they can stay minimal because the complete record is one
- * click away in the list.
+ * click away in the list — and a run of consecutive calls to one method folds
+ * into a single row, which is the whole reason the canvas is not the log.
  */
-export function Canvas({ group, onAnswer, onCancelAsk, onSelectCall }: CanvasProps) {
+export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onSelectCall }: CanvasProps) {
+  const entries = useMemo(() => foldCalls(group.items), [group.items]);
+
   if (group.run.payloadsExpired) {
     return <Canvas.Notice>Canvas no longer kept — run to see it live</Canvas.Notice>;
   }
@@ -30,14 +51,14 @@ export function Canvas({ group, onAnswer, onCancelAsk, onSelectCall }: CanvasPro
   }
 
   return (
-    <div className={cn("flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-3 font-mono text-xs", group.run.stale && "opacity-70")}>
-      {group.items.map((item) => (
+    <div className={cn("@container flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-3 font-mono text-xs", group.run.stale && "opacity-70")}>
+      {entries.map((entry) => (
         // Blocks keep their full height and the canvas scrolls. Without this a
         // long table is squeezed to a couple of rows to make the run fit — the
         // rows are still there, which is what makes it look like a rendering
         // bug rather than a layout one.
-        <div key={item.id} className="shrink-0">
-          <Canvas.Item item={item} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={onSelectCall} />
+        <div key={entry.id} className="shrink-0">
+          <Canvas.Entry entry={entry} selectedItemId={selectedItemId} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={onSelectCall} />
         </div>
       ))}
     </div>
@@ -48,15 +69,21 @@ Canvas.Notice = function ({ children }: { children: React.ReactNode }) {
   return <div className="flex min-h-0 flex-1 items-center justify-center p-3 text-center text-xs text-muted-foreground">{children}</div>;
 };
 
-interface ItemProps {
-  item: ConsoleItem;
+interface EntryProps {
+  entry: CanvasEntry;
+  selectedItemId?: string;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
   onSelectCall: (itemId: string) => void;
 }
 
-Canvas.Item = function ({ item, onAnswer, onCancelAsk, onSelectCall }: ItemProps) {
-  if (item.call) return <Canvas.CallCard call={item.call} onSelect={() => onSelectCall(item.id)} />;
+Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onSelectCall }: EntryProps) {
+  if (entry.kind === "calls") {
+    return <Canvas.CallGroup name={entry.name} items={entry.items} selectedItemId={selectedItemId} onSelectCall={onSelectCall} />;
+  }
+
+  const item = entry.item;
+  if (item.call) return <Canvas.CallCard call={item.call} selected={item.id === selectedItemId} onSelect={() => onSelectCall(item.id)} />;
   if (item.logs) return <Canvas.Logs logs={item.logs} />;
   if (!item.block) return null;
   return <Canvas.Block id={item.id} block={item.block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
@@ -186,7 +213,7 @@ Canvas.Ask = function ({ id, block, onAnswer, onCancelAsk }: AskProps) {
 
 // A call on the canvas is a one-line card: enough to place it in the story, and
 // a click away from the row that holds everything about it.
-Canvas.CallCard = function ({ call, onSelect }: { call: MethodCall; onSelect: () => void }) {
+Canvas.CallCard = function ({ call, selected, onSelect }: { call: MethodCall; selected: boolean; onSelect: () => void }) {
   const status = call.error ? "error" : call.output === undefined && call.streamOutputs === undefined ? "pending" : "success";
   const code = callErrorCode(call);
 
@@ -194,7 +221,10 @@ Canvas.CallCard = function ({ call, onSelect }: { call: MethodCall; onSelect: ()
     <button
       type="button"
       data-testid="canvas-call-card"
-      className="flex w-full items-center gap-2.5 rounded-md border border-border bg-card px-2.5 py-1.5 text-left hover:bg-accent"
+      className={cn(
+        "flex w-full items-center gap-2.5 rounded-md border bg-card px-2.5 py-1.5 text-left hover:bg-accent",
+        selected ? "border-muted-foreground/40" : "border-border",
+      )}
       onClick={onSelect}
     >
       <ChevronRight size={12} className="shrink-0 text-muted-foreground" />
@@ -209,6 +239,136 @@ Canvas.CallCard = function ({ call, onSelect }: { call: MethodCall; onSelect: ()
     </button>
   );
 };
+
+interface CallGroupProps {
+  name: string;
+  items: ConsoleItem[];
+  selectedItemId?: string;
+  onSelectCall: (itemId: string) => void;
+}
+
+/**
+ * A loop, as one row. Ten calls to one method are ten identical cards saying the
+ * same name ten times, which is the log's job and the log does it better — so
+ * the canvas says the name once, how many there were, and what told them apart.
+ *
+ * The ticks are what keep it a canvas rather than a summary: one per call, drawn
+ * against the slowest in the group, so which iteration was slow is a shape here
+ * rather than a trip to the list — and each one is its own way into that call's
+ * complete record.
+ */
+Canvas.CallGroup = function ({ name, items, selectedItemId, onSelectCall }: CallGroupProps) {
+  const status = worstStatus(items);
+  const inFlight = items.some((item) => item.call !== undefined && isCallInFlight(item.call));
+  const slowest = slowestOf(items);
+  const failures = groupFailures(items);
+  const keys = groupKeyLabel(items);
+  const duration = formatDuration(groupDuration(items));
+  const shown = items.slice(0, MAX_TICKS);
+  const hidden = items.length - shown.length;
+  // The strip has the budget, not the tick: past a certain density every tick is
+  // the minimum width and the strip stops claiming to measure anything.
+  const slot = Math.max(TICK_MIN_WIDTH + TICK_GAP, Math.min(TICK_MAX_WIDTH + TICK_GAP, Math.floor(STRIP_WIDTH / shown.length)));
+
+  return (
+    <div data-testid="canvas-call-group" className="flex w-full items-center gap-2.5 rounded-md border border-border bg-card pr-2.5">
+      {/* The name is the way in for the whole group; the ticks are the way in
+          for one call of it. Below the width the strip needs, the name is the
+          only one left — the same degradation the log's columns make. */}
+      <button
+        type="button"
+        data-testid="canvas-group-label"
+        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-l-md py-1.5 pl-2.5 text-left hover:bg-accent"
+        onClick={() => onSelectCall(items[0].id)}
+      >
+        <ChevronRight size={12} className="shrink-0 text-muted-foreground" />
+        {inFlight ? <Spinner className="size-3" /> : <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotClass(status))} />}
+        <span className="shrink-0 truncate text-foreground">{name}</span>
+        <span className="shrink-0 tabular-nums text-muted-foreground">×{items.length}</span>
+        {keys && <span className="min-w-0 truncate text-muted-foreground/80 @max-[420px]:hidden">{keys}</span>}
+      </button>
+      <div className="flex shrink-0 items-center @max-[520px]:hidden" style={{ gap: TICK_GAP }}>
+        {shown.map((item, index) => (
+          <Canvas.Tick
+            key={item.id}
+            item={item}
+            name={name}
+            index={index}
+            total={items.length}
+            slowest={slowest}
+            maxWidth={slot - TICK_GAP}
+            selected={item.id === selectedItemId}
+            onSelect={() => onSelectCall(item.id)}
+          />
+        ))}
+        {hidden > 0 && (
+          <button
+            type="button"
+            className="pl-1 tabular-nums text-muted-foreground hover:text-foreground"
+            title={`${hidden} more not drawn — open the ${shown.length + 1}${nth(shown.length + 1)} in the list`}
+            onClick={() => onSelectCall(items[shown.length].id)}
+          >
+            +{hidden}
+          </button>
+        )}
+      </div>
+      {failures > 0 && <span className="shrink-0 text-destructive">{failures === 1 ? "1 error" : `${failures} errors`}</span>}
+      <span className="w-[9ch] shrink-0 truncate text-right tabular-nums text-muted-foreground">{duration}</span>
+    </div>
+  );
+};
+
+interface TickProps {
+  item: ConsoleItem;
+  name: string;
+  index: number;
+  total: number;
+  slowest?: number;
+  maxWidth: number;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+/**
+ * One call of a folded group: as long as it took, coloured only when it failed —
+ * the group's dot already says how the group went, so the strip is free to be a
+ * measurement. A call still in flight has no length yet and gets the minimum.
+ */
+Canvas.Tick = function ({ item, name, index, total, slowest, maxWidth, selected, onSelect }: TickProps) {
+  const status = itemStatus(item);
+  const duration = item.call?.durationMs;
+  const fraction = barFraction(duration, slowest);
+  const width = fraction === undefined ? TICK_MIN_WIDTH : Math.round(TICK_MIN_WIDTH + fraction * Math.max(0, maxWidth - TICK_MIN_WIDTH));
+  const key = loopKey(item.call?.input);
+  const detail = [key, formatDuration(duration)].filter((part) => part !== undefined).join(" · ");
+
+  return (
+    <button
+      type="button"
+      data-testid="canvas-call-tick"
+      className="group/tick shrink-0 py-1"
+      style={{ width }}
+      title={detail}
+      aria-label={`${name}, call ${index + 1} of ${total}${detail ? `, ${detail}` : ""}`}
+      aria-current={selected || undefined}
+      onClick={onSelect}
+    >
+      <span
+        className={cn(
+          "block h-[8px] rounded-[2px]",
+          status === "error" ? "bg-destructive/60" : status === "success" ? "bg-muted-foreground/35" : "bg-muted-foreground/15",
+          selected && "bg-foreground/70",
+          "group-hover/tick:bg-foreground/50",
+        )}
+      />
+    </button>
+  );
+};
+
+function nth(position: number): string {
+  if (position % 100 >= 11 && position % 100 <= 13) return "th";
+  return { 1: "st", 2: "nd", 3: "rd" }[position % 10] ?? "th";
+}
 
 // A script that threw is the run's own failure rather than any one call's, so it
 // lands on the canvas as the last thing that happened.

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -299,7 +299,7 @@ export function Console({
       </div>
 
       {selectedGroup && activeView === "canvas" ? (
-        <Canvas group={selectedGroup} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={selectFromCanvas} />
+        <Canvas group={selectedGroup} selectedItemId={selection?.itemId} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={selectFromCanvas} />
       ) : selectedGroup ? (
         <Console.ListView
           group={selectedGroup}

--- a/ui/src/callGroups.test.ts
+++ b/ui/src/callGroups.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import { CanvasEntry, foldCalls, groupDuration, groupFailures, groupKeyLabel } from "./callGroups";
+import { MethodCall } from "./kaja";
+import { ConsoleItem } from "./runs";
+import { LogLevel } from "./server/api";
+
+const NOW = 1_700_000_000_000;
+
+function call(id: string, method: string, changes: Partial<MethodCall> = {}): ConsoleItem {
+  const methodCall = {
+    id,
+    appName: "app",
+    service: { name: "Shows" },
+    method: { name: method },
+    input: {},
+    output: {},
+    timestamp: NOW,
+    durationMs: 100,
+    ...changes,
+  } as MethodCall;
+  return { id, runId: "r", timestamp: methodCall.timestamp, call: methodCall };
+}
+
+function text(id: string): ConsoleItem {
+  return { id, runId: "r", timestamp: NOW, block: { kind: "text", text: "hello" } };
+}
+
+function logs(id: string): ConsoleItem {
+  return { id, runId: "r", timestamp: NOW, logs: [{ level: LogLevel.LEVEL_INFO, message: "hello" }] };
+}
+
+function shape(entries: CanvasEntry[]): string[] {
+  return entries.map((entry) => (entry.kind === "calls" ? `${entry.name}×${entry.items.length}` : entry.item.id));
+}
+
+describe("foldCalls", () => {
+  it("leaves a run shorter than the minimum as its own cards", () => {
+    expect(shape(foldCalls([call("a", "ListShows"), call("b", "ListShows")]))).toEqual(["a", "b"]);
+  });
+
+  it("folds consecutive calls to one method into a single entry", () => {
+    const entries = foldCalls([call("a", "ListShows"), call("b", "ListShows"), call("c", "ListShows")]);
+
+    expect(shape(entries)).toEqual(["Shows.ListShows×3"]);
+    expect(entries[0].id).toBe("a");
+  });
+
+  it("does not fold across a different method", () => {
+    const items = [call("a", "ListShows"), call("b", "ListShows"), call("c", "ListShows"), call("d", "GetShow"), call("e", "ListShows")];
+
+    expect(shape(foldCalls(items))).toEqual(["Shows.ListShows×3", "d", "e"]);
+  });
+
+  it("breaks a group on anything the script drew between the calls", () => {
+    const items = [call("a", "ListShows"), call("b", "ListShows"), text("t"), call("c", "ListShows"), call("d", "ListShows"), call("e", "ListShows")];
+
+    expect(shape(foldCalls(items))).toEqual(["a", "b", "t", "Shows.ListShows×3"]);
+  });
+
+  it("breaks a group on the log too, so the story keeps its order", () => {
+    const items = [call("a", "ListShows"), call("b", "ListShows"), call("c", "ListShows"), logs("l"), call("d", "ListShows")];
+
+    expect(shape(foldCalls(items))).toEqual(["Shows.ListShows×3", "l", "d"]);
+  });
+
+  it("keeps blocks and calls in emission order", () => {
+    expect(shape(foldCalls([text("t1"), call("a", "GetShow"), text("t2")]))).toEqual(["t1", "a", "t2"]);
+  });
+
+  it("folds nothing when there is nothing", () => {
+    expect(foldCalls([])).toEqual([]);
+  });
+});
+
+describe("groupDuration", () => {
+  it("is the wall time of the group, not the sum of its calls", () => {
+    const concurrent = [
+      call("a", "GetShow", { timestamp: NOW, durationMs: 300 }),
+      call("b", "GetShow", { timestamp: NOW + 10, durationMs: 300 }),
+      call("c", "GetShow", { timestamp: NOW + 20, durationMs: 300 }),
+    ];
+
+    expect(groupDuration(concurrent)).toBe(320);
+  });
+
+  it("adds up when the calls ran one after another", () => {
+    const sequential = [
+      call("a", "GetShow", { timestamp: NOW, durationMs: 100 }),
+      call("b", "GetShow", { timestamp: NOW + 100, durationMs: 100 }),
+      call("c", "GetShow", { timestamp: NOW + 200, durationMs: 100 }),
+    ];
+
+    expect(groupDuration(sequential)).toBe(300);
+  });
+
+  it("has no answer while a call is still in flight", () => {
+    expect(groupDuration([call("a", "GetShow"), call("b", "GetShow", { durationMs: undefined })])).toBeUndefined();
+  });
+});
+
+describe("groupFailures", () => {
+  it("counts the calls that failed, so a fold never hides one", () => {
+    const items = [call("a", "GetShow"), call("b", "GetShow", { error: { code: "NOT_FOUND" } }), call("c", "GetShow")];
+
+    expect(groupFailures(items)).toBe(1);
+  });
+});
+
+describe("groupKeyLabel", () => {
+  it("says nothing when nothing in the requests identifies anything", () => {
+    expect(groupKeyLabel([call("a", "ListShows"), call("b", "ListShows")])).toBeUndefined();
+  });
+
+  it("states a key the whole group shares once", () => {
+    const items = [call("a", "GetShow", { input: { id: "vera-lune" } }), call("b", "GetShow", { input: { id: "vera-lune" } })];
+
+    expect(groupKeyLabel(items)).toBe("vera-lune");
+  });
+
+  it("names the keys until they stop fitting", () => {
+    const items = [
+      call("a", "GetShow", { input: { id: "vera-lune" } }),
+      call("b", "GetShow", { input: { id: "moth-lantern" } }),
+      call("c", "GetShow", { input: { id: "salt-choir" } }),
+      call("d", "GetShow", { input: { id: "amber-hour" } }),
+    ];
+
+    expect(groupKeyLabel(items)).toBe("vera-lune, moth-lantern +2");
+  });
+});

--- a/ui/src/callGroups.ts
+++ b/ui/src/callGroups.ts
@@ -1,0 +1,97 @@
+import { loopKey } from "./loopKey";
+import { ConsoleItem, itemStatus } from "./runs";
+
+/**
+ * How many consecutive calls to one method it takes before the canvas folds them
+ * into a single row. Two is not worth a fold: it saves one line and costs a
+ * click.
+ */
+export const MIN_FOLD = 3;
+
+// How many distinct loop keys a folded row names before it stops listing them.
+const MAX_SHOWN_KEYS = 2;
+
+/**
+ * What the canvas draws, in emission order: a single item, or a run of
+ * consecutive calls to one method folded into one row. Only the canvas folds —
+ * the log is the audit record and stays complete at any length.
+ */
+export type CanvasEntry = { kind: "item"; id: string; item: ConsoleItem } | { kind: "calls"; id: string; name: string; items: ConsoleItem[] };
+
+export function callName(item: ConsoleItem): string | undefined {
+  return item.call && `${item.call.service.name}.${item.call.method.name}`;
+}
+
+/**
+ * Folds consecutive calls to the same method into one entry. Consecutive is the
+ * whole rule: anything the script drew between two calls breaks the group,
+ * because the canvas is the run in the order it happened and gathering calls
+ * that weren't next to each other would rewrite the story to fit the fold.
+ */
+export function foldCalls(items: ConsoleItem[], minimum: number = MIN_FOLD): CanvasEntry[] {
+  const entries: CanvasEntry[] = [];
+  let batch: ConsoleItem[] = [];
+
+  const flush = () => {
+    if (batch.length >= minimum) {
+      entries.push({ kind: "calls", id: batch[0].id, name: callName(batch[0])!, items: batch });
+    } else {
+      for (const item of batch) entries.push({ kind: "item", id: item.id, item });
+    }
+    batch = [];
+  };
+
+  for (const item of items) {
+    const name = callName(item);
+    if (name === undefined) {
+      flush();
+      entries.push({ kind: "item", id: item.id, item });
+      continue;
+    }
+    if (batch.length > 0 && callName(batch[0]) !== name) flush();
+    batch.push(item);
+  }
+  flush();
+
+  return entries;
+}
+
+/**
+ * How long a folded group took end to end — wall time, not the sum of its calls,
+ * so a fan-out reports what it actually cost. Undefined while anything in it is
+ * still in flight, since the group hasn't finished taking as long as it will.
+ */
+export function groupDuration(items: ConsoleItem[]): number | undefined {
+  let start = Infinity;
+  let end = -Infinity;
+  for (const item of items) {
+    const duration = item.call?.durationMs;
+    if (duration === undefined) return undefined;
+    start = Math.min(start, item.timestamp);
+    end = Math.max(end, item.timestamp + duration);
+  }
+  return end < start ? undefined : end - start;
+}
+
+// How many calls in the group failed. A fold must never hide a failure, so this
+// is stated on the row and the failed call keeps a tick of its own.
+export function groupFailures(items: ConsoleItem[]): number {
+  return items.filter((item) => itemStatus(item) === "error").length;
+}
+
+/**
+ * What tells the calls in a folded group apart, read off their requests. The
+ * method name is the same on every one of them by definition, so the loop key is
+ * all that is left to say which pass through the loop is which — one key shared
+ * by all of them is stated once, and many are named until they stop fitting.
+ */
+export function groupKeyLabel(items: ConsoleItem[]): string | undefined {
+  const keys: string[] = [];
+  for (const item of items) {
+    const key = loopKey(item.call?.input);
+    if (key !== undefined && !keys.includes(key)) keys.push(key);
+  }
+  if (keys.length === 0) return undefined;
+  if (keys.length <= MAX_SHOWN_KEYS) return keys.join(", ");
+  return `${keys.slice(0, MAX_SHOWN_KEYS).join(", ")} +${keys.length - MAX_SHOWN_KEYS}`;
+}

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -203,9 +203,13 @@ export function defaultView(group: RunGroup | undefined): ConsoleView {
  * only mean something in a run with calls to compare, so a run of one gets none.
  */
 export function slowestCall(group: RunGroup): number | undefined {
-  const durations = callItems(group)
-    .map((item) => item.call?.durationMs)
-    .filter((duration): duration is number => duration !== undefined);
+  return slowestOf(callItems(group));
+}
+
+// The same measure over any run of calls, which is what the canvas draws a
+// folded group's ticks against.
+export function slowestOf(items: ConsoleItem[]): number | undefined {
+  const durations = items.map((item) => item.call?.durationMs).filter((duration): duration is number => duration !== undefined);
   return durations.length > 1 ? Math.max(...durations) : undefined;
 }
 


### PR DESCRIPTION
Consecutive calls to one method now fold into a single canvas row — the name once, the count, the loop key that tells them apart, and one tick per call drawn against the slowest, each a click into that call's row in the list.

A fold never hides a failure (its tick stays, and the row states the count), and the tick for the currently selected call is lit so the canvas ↔ list link runs both ways.

---
_Generated by [Claude Code](https://claude.ai/code/session_011zPZKK1Dn5H8uem5vTbFGs)_