### PR TITLE
Gave a table rows to page and search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,50 @@ no `kaja.html`, no styling arguments, no layout control.
   part the part you can't watch. Blocks are recorded against their own id
   (`recordBlock`), so a block that fills in stays where it was emitted rather
   than jumping to the end.
+- **A table's rows are an iterable, and that is the whole of static-versus-live.**
+  An array is one; so is an async generator, and one of those only runs when
+  something pulls it — which is what makes paging fetch a page and nothing else.
+  `kaja.table(columns, rows?, { pageSize })` takes either, plus a **function**
+  returning one, and the handle's `.row(...)` is unchanged.
+  - **The pager is over rows, not requests** (`tableView.ts`). Next means "the
+    next page of rows, fetching if I have run out", so a source that yields in
+    batches of 25 fetches twice per page of 50 and one that yields 500 doesn't
+    fetch for ten pages. The script never states a page size and never holds a
+    cursor: the cursor is an ordinary local variable in its own loop, which is
+    what a callback-with-context would have taken away, along with per-row
+    laziness (a row that costs a call only costs it if you page to it).
+  - **No lookahead.** Pulling one row past the page to light Next up would fetch
+    a whole page to answer a question nobody asked, so an open source offers Next
+    until it runs out and a click that yields nothing closes it out. This is also
+    why the page clamp lets **one** page past the loaded rows through — paging
+    into rows that aren't here yet is how they are asked for.
+  - **Declaring the search parameter is what asks for the search text.** A source
+    that takes one is restarted for each new search (a new search is a new result
+    set); one that doesn't is never restarted, and the box filters the rows
+    already loaded and says so. A local filter **never** fetches — searching
+    would otherwise mean pulling an API dry to find three rows. Arity is the
+    switch because it is readable one line from the box, and because the
+    alternative is an option that says what the signature already said.
+  - **Controls appear when there is something to control** — one bar above the
+    rows, holding the search box, the count and the pager. A static table that
+    fits on a page reads exactly as it did before any of this existed, and a
+    pager under a fifty-row table is a control you have to go looking for.
+  - **A live table expires like a payload does.** The source is a closure, so it
+    cannot be stored: read back, the table is the rows it had, saying
+    `run to load the rest` rather than offering a Next that leads nowhere
+    (`storedBlock`). The closures are held on the `Kaja` instance, which outlives
+    any run, and the oldest are let go past `MAX_LIVE_TABLES` — into the same
+    stated state.
+  - **A page fetched later belongs to the run that drew the table**, not to a run
+    of its own: the click happened on that run's canvas, so `openRun` attributes
+    it (`pullRunRef`) and the call is a row in that run's log. The run's duration
+    doesn't move — it is wall time for the script — but the run **does** wait for
+    a live table's first page (`settleTables`), because that page is work the
+    script started. A script running at the same time outranks the attribution;
+    it is definitely the one making the call being reported.
+  - **An agent sees one page.** Nobody is there to press Next, so `run_script`
+    reports `more: true` and the loop that reads the rest is the agent's own to
+    write.
 - **Calls appear as one-line cards.** They can stay minimal because the complete
   record is one click away: clicking a card selects that call's row in the list
   and switches to it. The payload is never unrolled into the flow — that is

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -109,6 +109,28 @@ Rows land one at a time, so the canvas fills as the loop runs rather than after
 it. `run_script` reports what you drew — each block's kind, and a table's columns
 and row count — so you can check the output landed.
 
+**A table can page and search itself.** Hand it the rows instead of pushing
+them, and it gets a search box and a pager for free — an array is drawn as it is,
+and a function is pulled a page at a time, only when the person reading it pages
+past what has been loaded:
+
+```ts
+kaja.table(["id", "title", "seats"], async function* (search) {
+  for (let pageToken = ""; ; ) {
+    const page = await Shows.ListShows({ pageSize: 25, pageToken, query: search });
+    yield* page.items.map((show) => [show.id, show.title, show.seatsAvailable]);
+    if (!(pageToken = page.nextPageToken)) return;
+  }
+});
+```
+
+Declare the `search` parameter and the search box is handed to your source, which
+is started again for each new search; leave it out and the box filters the rows
+already loaded. **Nobody is paging your run**, so `run_script` draws the first
+page and reports `more: true` — if you need the whole set, write the loop and
+read it yourself. Prefer this over `.row(...)` whenever the API pages: the person
+who opens the script gets the rest without running anything.
+
 ## The script runtime
 
 - **No interactive input.** `prompt`, `alert` and `confirm` do nothing and return
@@ -129,7 +151,8 @@ What each member is for:
 - `kaja.text(text)`, `kaja.code(code, language?)` — draw a line or a snippet on
   the canvas.
 - `kaja.table(columns, rows?)` — draw a table; the handle's `.row(...cells)`
-  appends to it.
+  appends to it. `rows` can be an array, or a source (an async generator) the
+  table pulls a page at a time as it is paged through.
 - `kaja.ask(message): Promise<string>` — ask the user; blocks on a human.
 - `kaja.variables.<name>` — the user's configured variables, resolved.
 - `kaja.input?: string` — text supplied when the script is launched from the

--- a/desktop/mcp/tools.go
+++ b/desktop/mcp/tools.go
@@ -15,6 +15,9 @@ const runtimeNote = "Scripts are TypeScript run inside Kaja: top-level await wor
 	"A script is a body of statements, not a function: it has NO return value, and a top-level `return` is an error the app refuses to run. " +
 	"It says what it produced instead - `console.log(...)` writes the transcript, and `kaja.text(...)`, `kaja.code(...)` and " +
 	"`kaja.table(columns).row(...)` draw on the run's canvas, which is how a script renders a table (never build one out of Markdown). " +
+	"A table can also be handed its rows - `kaja.table(columns, rows)` for an array, or an async generator that yields rows, " +
+	"which the table pulls a page at a time as the reader pages through it (declare a `search` parameter and it is restarted for each search). " +
+	"Your run draws its first page and reports `more: true`; nobody is there to page it, so read the rest with an ordinary loop if you need it. " +
 	"Get the runtime's full declaration with describe_type \"kaja\"; it comes from `import { kaja } from \"kaja\";`. " +
 	"There is no interactive input: `prompt`/`alert`/`confirm` do nothing. Use `kaja.ask()` only when a person is at the app."
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,6 +17,7 @@ import {
   clearFile,
   dropFile,
   fileConsole,
+  findBlock,
   hasCallsInFlight,
   putFile,
   recordBlock,
@@ -43,6 +44,7 @@ import { Destination, Finder } from "./Finder";
 import { Gutter } from "./Gutter";
 import { Block, blockLabel } from "./blocks";
 import { AskCancelledError, Kaja, MethodCall } from "./kaja";
+import { TableView } from "./tableView";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
 import { appendCall, createScratch, findUntouched, isUntouched, markRun, pruneScratches, reopen, Scratch, takeOver, withCode } from "./scratches";
@@ -418,6 +420,12 @@ export function App() {
     (title: string): Run => {
       const current = currentRunRef.current;
       if (current) return current;
+      // Paging a live table fetches after its run is over, and those rows belong
+      // to the run whose canvas asked for them rather than to a run of their own.
+      // A script running at the same time outranks it: that one is definitely
+      // making the call being reported.
+      const pulling = pullRunRef.current;
+      if (pulling) return pulling;
       return beginRun(title, lastRunFileIdRef.current);
     },
     [beginRun],
@@ -497,6 +505,45 @@ export function App() {
   if (!kajaRef.current) {
     kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onBlockUpdate);
   }
+
+  /**
+   * Where each table is paged and searched. This is view state rather than
+   * something the run drew, so it is held here instead of in the block — but
+   * above the console, so switching to the log and back finds the table where it
+   * was left.
+   */
+  const [tableViews, setTableViews] = useState<{ [blockId: string]: TableView }>({});
+
+  const onTableView = useCallback((blockId: string, view: TableView) => {
+    setTableViews((current) => ({ ...current, [blockId]: view }));
+  }, []);
+
+  // The run that a table is being filled for, which is what a call made by the
+  // pull is recorded against.
+  const pullRunRef = useRef<Run | null>(null);
+
+  /**
+   * Fill a live table further — the next page, or the first page of a new
+   * search. A source that is no longer held (a run read back from an earlier
+   * session, or one let go to keep the closures bounded) can't be pulled, and
+   * the table says so rather than offering a Next that leads nowhere.
+   */
+  const onTablePull = useCallback(async (blockId: string, search: string, want: number) => {
+    const found = findBlock(historyRef.current, blockId);
+    const table = found?.block;
+    if (!found || table?.kind !== "table") return;
+
+    const previous = pullRunRef.current;
+    pullRunRef.current = found.run;
+    try {
+      const live = await kajaRef.current!.pullTable(blockId, search, want);
+      if (!live) {
+        setHistory((current) => recordBlock(current, found.fileId, found.run.id, blockId, { ...table, live: false, expired: true }, Date.now()));
+      }
+    } finally {
+      pullRunRef.current = previous;
+    }
+  }, []);
 
   // Clearing a file's history clears what is being held of it for next time too;
   // leaving yesterday's run behind would make "cleared" a half-truth.
@@ -1150,9 +1197,9 @@ export function App() {
         const kaja = kajaRef.current!;
         kaja.input = text;
         const run = beginRun(file.name, file.path);
-        runTask(file.content, kaja, apps, onScriptError).finally(() =>
-          setActiveRun((active) => (active?.runId === run.id ? { ...active, settled: true } : active)),
-        );
+        runTask(file.content, kaja, apps, onScriptError)
+          .then(() => kaja.settleTables())
+          .finally(() => setActiveRun((active) => (active?.runId === run.id ? { ...active, settled: true } : active)));
       } catch (err) {
         showFileError(`Run failed: ${err}`);
       }
@@ -1382,6 +1429,9 @@ export function App() {
         const kaja = kajaRef.current!;
         kaja.input = undefined;
         const captured = await runTaskCaptured(source, kaja, appsRef.current);
+        // An agent's table has nobody to page it, so its receipt is the first
+        // page — which is exactly what it says it is.
+        await kaja.settleTables();
         result = { ...captured, methodCalls: collected.map(toMethodCallLog), blocks: [...drawn.values()].map(toBlockLog) };
       } catch (err) {
         result = {
@@ -1675,9 +1725,12 @@ export function App() {
     // speak the same language.
     const title = tab.type === "script" ? tab.script.name : (deriveScratchTitle(code) ?? viewIdentity(tab, scratchesRef.current).name);
     beginRun(title, tab.type === "script" ? tab.script.path : tab.scratchId, controller);
-    runTask(code, kajaRef.current!, apps, onScriptError, controller.signal).finally(() =>
-      setActiveRun((run) => (run?.controller === controller ? { ...run, settled: true } : run)),
-    );
+    // A live table draws its first page itself, and those calls are the run's:
+    // the script is not over until they have landed, or the run would report a
+    // duration that stops before the work it started.
+    runTask(code, kajaRef.current!, apps, onScriptError, controller.signal)
+      .then(() => kajaRef.current!.settleTables())
+      .finally(() => setActiveRun((run) => (run?.controller === controller ? { ...run, settled: true } : run)));
     // A run is the punctuation that settles a scratch: it is when the title is
     // re-read from the code, rather than jittering as you type.
     if (tab.type === "scratch") {
@@ -2285,6 +2338,9 @@ export function App() {
                         onViewChange={onConsoleViewChange}
                         onAnswer={onAnswerAsk}
                         onCancelAsk={onCancelAsk}
+                        tableViews={tableViews}
+                        onTableView={onTableView}
+                        onTablePull={onTablePull}
                         onClear={currentFileId ? () => onClearConsole(currentFileId) : undefined}
                       />
                     </div>
@@ -2517,11 +2573,16 @@ interface McpRunReport {
 // but nobody looking at it, so it is told the shape of what it made rather than
 // the contents, which it produced and already has.
 function toBlockLog(block: Block) {
+  const table = block.kind === "table" ? block : undefined;
   return {
     kind: block.kind,
     label: blockLabel(block),
-    columns: block.kind === "table" ? block.columns : undefined,
-    rows: block.kind === "table" ? block.rows.length : undefined,
+    columns: table?.columns,
+    rows: table?.rows.length,
+    // A live table drew the page it was asked for and left its source open. An
+    // agent has nobody to press Next, so it is told the rows are a page rather
+    // than the set — the loop that would fetch the rest is its own to write.
+    more: table?.live === true && table.exhausted !== true ? true : undefined,
   };
 }
 

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,10 +1,11 @@
-import { ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
 import { CanvasEntry, foldCalls, groupDuration, groupFailures, groupKeyLabel } from "./callGroups";
 import { cn } from "./cn";
 import { Spinner } from "./components/spinner";
 import { isCallInFlight, MethodCall } from "./kaja";
+import { hasControls, NO_TABLE_VIEW, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
 import { loopKey } from "./loopKey";
 import { barFraction, callErrorCode, dotClass, formatDuration } from "./callFormat";
 import { ConsoleItem, itemStatus, RunGroup, slowestOf, worstStatus } from "./runs";
@@ -32,6 +33,11 @@ interface CanvasProps {
   // Clicking a call card takes you to that call's row in the log, which is where
   // its complete record is. The card can stay minimal because of it.
   onSelectCall: (itemId: string) => void;
+  // Where each table is pointed. It is view state rather than something the run
+  // drew, so it is held above the canvas and survives switching views.
+  tableViews: { [blockId: string]: TableView };
+  onTableView: (blockId: string, view: TableView) => void;
+  onTablePull: (blockId: string, search: string, want: number) => void;
 }
 
 /**
@@ -40,7 +46,7 @@ interface CanvasProps {
  * click away in the list — and a run of consecutive calls to one method folds
  * into a single row, which is the whole reason the canvas is not the log.
  */
-export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onSelectCall }: CanvasProps) {
+export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onSelectCall, tableViews, onTableView, onTablePull }: CanvasProps) {
   const entries = useMemo(() => foldCalls(group.items), [group.items]);
 
   if (group.run.payloadsExpired) {
@@ -58,7 +64,16 @@ export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onSelectC
         // rows are still there, which is what makes it look like a rendering
         // bug rather than a layout one.
         <div key={entry.id} className="shrink-0">
-          <Canvas.Entry entry={entry} selectedItemId={selectedItemId} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={onSelectCall} />
+          <Canvas.Entry
+            entry={entry}
+            selectedItemId={selectedItemId}
+            onAnswer={onAnswer}
+            onCancelAsk={onCancelAsk}
+            onSelectCall={onSelectCall}
+            tableViews={tableViews}
+            onTableView={onTableView}
+            onTablePull={onTablePull}
+          />
         </div>
       ))}
     </div>
@@ -75,9 +90,12 @@ interface EntryProps {
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
   onSelectCall: (itemId: string) => void;
+  tableViews: { [blockId: string]: TableView };
+  onTableView: (blockId: string, view: TableView) => void;
+  onTablePull: (blockId: string, search: string, want: number) => void;
 }
 
-Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onSelectCall }: EntryProps) {
+Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onSelectCall, tableViews, onTableView, onTablePull }: EntryProps) {
   if (entry.kind === "calls") {
     return <Canvas.CallGroup name={entry.name} items={entry.items} selectedItemId={selectedItemId} onSelectCall={onSelectCall} />;
   }
@@ -86,7 +104,17 @@ Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onSelec
   if (item.call) return <Canvas.CallCard call={item.call} selected={item.id === selectedItemId} onSelect={() => onSelectCall(item.id)} />;
   if (item.logs) return <Canvas.Logs logs={item.logs} />;
   if (!item.block) return null;
-  return <Canvas.Block id={item.id} block={item.block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
+  return (
+    <Canvas.Block
+      id={item.id}
+      block={item.block}
+      onAnswer={onAnswer}
+      onCancelAsk={onCancelAsk}
+      tableViews={tableViews}
+      onTableView={onTableView}
+      onTablePull={onTablePull}
+    />
+  );
 };
 
 interface BlockProps {
@@ -94,16 +122,19 @@ interface BlockProps {
   block: Block;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
+  tableViews: { [blockId: string]: TableView };
+  onTableView: (blockId: string, view: TableView) => void;
+  onTablePull: (blockId: string, search: string, want: number) => void;
 }
 
-Canvas.Block = function ({ id, block, onAnswer, onCancelAsk }: BlockProps) {
+Canvas.Block = function ({ id, block, onAnswer, onCancelAsk, tableViews, onTableView, onTablePull }: BlockProps) {
   switch (block.kind) {
     case "text":
       return <Canvas.Text block={block} />;
     case "code":
       return <Canvas.Code block={block} />;
     case "table":
-      return <Canvas.Table block={block} />;
+      return <Canvas.Table id={id} block={block} view={tableViews[id] ?? NO_TABLE_VIEW} onView={onTableView} onPull={onTablePull} />;
     case "ask":
       return <Canvas.Ask id={id} block={block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
   }
@@ -122,40 +153,132 @@ Canvas.Code = function ({ block }: { block: CodeBlock }) {
   );
 };
 
-// A wide table scrolls inside itself; the canvas never scrolls sideways as a
-// whole, because everything above and below it would move with it.
-Canvas.Table = function ({ block }: { block: TableBlock }) {
+interface TableProps {
+  id: string;
+  block: TableBlock;
+  view: TableView;
+  onView: (blockId: string, view: TableView) => void;
+  onPull: (blockId: string, search: string, want: number) => void;
+}
+
+/**
+ * A wide table scrolls inside itself; the canvas never scrolls sideways as a
+ * whole, because everything above and below it would move with it.
+ *
+ * The pager is over rows rather than requests: paging past what is loaded is
+ * what pulls the source, and nothing else does. A search that the source takes
+ * restarts it; one it doesn't filters the rows already here, and says so — a
+ * local filter that fetched would pull an API dry to find three rows.
+ */
+Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
+  const shown = tableWindow(block, view);
+  const controls = hasControls(block);
+  // A search bound for the source is debounced; one that filters what is loaded
+  // is not, because it costs nothing and lagging under the keystrokes is worse.
+  const search = useDebounced(view.search, searchesLocally(block) ? 0 : 300);
+  const { needed, want } = pullNeeded(block, { page: shown.page, search });
+
+  useEffect(() => {
+    if (needed) onPull(id, search, want);
+  }, [needed, id, search, want, onPull]);
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse">
-        <thead>
-          <tr>
-            {block.columns.map((column, index) => (
-              <th
-                key={index}
-                className="whitespace-nowrap border-b border-border py-1 pr-4 text-left text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {block.rows.map((row, rowIndex) => (
-            <tr key={rowIndex}>
-              {row.map((cell, cellIndex) => (
-                <td key={cellIndex} className="border-b border-border/50 py-1 pr-4 align-top text-foreground">
-                  {cell}
-                </td>
+    <div className="flex flex-col gap-1.5">
+      {/* One bar, above the rows. A pager under a fifty-row table is a control
+          you have to go looking for, and on a canvas of several blocks it is
+          hard to tell which table it belongs to. */}
+      {controls && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Search size={12} className="shrink-0" />
+          <input
+            data-testid="canvas-table-search"
+            className="min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
+            placeholder={searchesLocally(block) ? "Search loaded rows…" : "Search…"}
+            value={view.search}
+            // A new search is a new set, so it is read from the first page.
+            onChange={(event) => onView(id, { page: 0, search: event.target.value })}
+          />
+          {block.loading && <Spinner className="size-3 shrink-0" />}
+          <span data-testid="canvas-table-summary" className="shrink-0 truncate tabular-nums @max-[420px]:hidden">
+            {tableSummary(block, shown)}
+          </span>
+          <button
+            type="button"
+            className="shrink-0 disabled:opacity-40 enabled:hover:text-foreground"
+            disabled={!shown.hasPrevious}
+            aria-label="Previous page"
+            onClick={() => onView(id, { ...view, page: shown.page - 1 })}
+          >
+            <ChevronLeft size={12} />
+          </button>
+          <button
+            type="button"
+            data-testid="canvas-table-next"
+            className="shrink-0 disabled:opacity-40 enabled:hover:text-foreground"
+            disabled={!shown.hasNext || block.loading === true}
+            aria-label="Next page"
+            onClick={() => onView(id, { ...view, page: shown.page + 1 })}
+          >
+            <ChevronRight size={12} />
+          </button>
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              {block.columns.map((column, index) => (
+                <th
+                  key={index}
+                  className="whitespace-nowrap border-b border-border py-1 pr-4 text-left text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+                >
+                  {column}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-      {block.rows.length === 0 && <div className="py-1.5 text-muted-foreground">No rows yet…</div>}
+          </thead>
+          <tbody>
+            {shown.rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.map((cell, cellIndex) => (
+                  <td key={cellIndex} className="border-b border-border/50 py-1 pr-4 align-top text-foreground">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {shown.rows.length === 0 && (
+          <div className="py-1.5 text-muted-foreground">{block.loading ? "Loading…" : shown.filtered ? "No rows match." : "No rows yet…"}</div>
+        )}
+      </div>
+      {block.error !== undefined && (
+        <div className="flex items-center gap-2 text-destructive">
+          <span className="min-w-0 flex-1 truncate">{block.error}</span>
+          <button type="button" className="shrink-0 hover:text-foreground" onClick={() => onPull(id, search, shown.want)}>
+            Retry
+          </button>
+        </div>
+      )}
     </div>
   );
 };
+
+// A value that settles. Only a search bound for a source needs it — restarting
+// on every keystroke would fetch the same first page five times over.
+function useDebounced<T>(value: T, delay: number): T {
+  const [settled, setSettled] = useState(value);
+  useEffect(() => {
+    if (delay === 0) {
+      setSettled(value);
+      return;
+    }
+    const timer = setTimeout(() => setSettled(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return delay === 0 ? value : settled;
+}
 
 interface AskProps {
   id: string;

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -30,6 +30,7 @@ import {
   slowestCall,
 } from "./runs";
 import { runShortcutLabel } from "./RunButton";
+import { TableView } from "./tableView";
 import { LogLevel } from "./server/api";
 import { unwrapFailure, upstreamRequestLine } from "./upstreamHeaders";
 
@@ -76,6 +77,9 @@ interface ConsoleProps {
   onViewChange: (view: ConsoleView) => void;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
+  tableViews: { [blockId: string]: TableView };
+  onTableView: (blockId: string, view: TableView) => void;
+  onTablePull: (blockId: string, search: string, want: number) => void;
   onClear?: () => void;
 }
 
@@ -97,6 +101,9 @@ export function Console({
   onViewChange,
   onAnswer,
   onCancelAsk,
+  tableViews,
+  onTableView,
+  onTablePull,
   onClear,
 }: ConsoleProps) {
   const [now, setNow] = useState(Date.now());
@@ -299,7 +306,16 @@ export function Console({
       </div>
 
       {selectedGroup && activeView === "canvas" ? (
-        <Canvas group={selectedGroup} selectedItemId={selection?.itemId} onAnswer={onAnswer} onCancelAsk={onCancelAsk} onSelectCall={selectFromCanvas} />
+        <Canvas
+          group={selectedGroup}
+          selectedItemId={selection?.itemId}
+          onAnswer={onAnswer}
+          onCancelAsk={onCancelAsk}
+          onSelectCall={selectFromCanvas}
+          tableViews={tableViews}
+          onTableView={onTableView}
+          onTablePull={onTablePull}
+        />
       ) : selectedGroup ? (
         <Console.ListView
           group={selectedGroup}

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -15,10 +15,37 @@ export interface CodeBlock {
   language?: string;
 }
 
+/**
+ * A table's rows are an iterable, and that is the whole of static-versus-live: an
+ * array is one, and so is a generator the script left open. Everything here is
+ * plain JSON because a block is stored as itself — the source that fills a live
+ * table lives beside it, in the Kaja instance, keyed by the block's id.
+ */
 export interface TableBlock {
   kind: "table";
   columns: string[];
   rows: string[][];
+  // Rows come from a source that is still open, so paging forward pulls more.
+  live?: boolean;
+  // A pull is in flight. The table says so; the run does not, because the run is
+  // over — this is the canvas fetching, not the script running.
+  loading?: boolean;
+  // The source ran out, so the rows are the whole set and a live table has
+  // become an ordinary one.
+  exhausted?: boolean;
+  // The source takes the search text, so a new search restarts it. Without this
+  // the search box filters the rows already loaded and never fetches.
+  serverSearch?: boolean;
+  // Which search the loaded rows answer, for a source that takes one.
+  loadedSearch?: string;
+  // The source is gone — this run was read back from an earlier session, or its
+  // closure was let go. Expiry is a stated state, not a Next that leads nowhere.
+  expired?: boolean;
+  // How many rows a page holds. Absent means the default.
+  pageSize?: number;
+  // What the last pull failed with. The call itself is in the log; this is what
+  // the table says about why it stopped filling.
+  error?: string;
 }
 
 /**
@@ -56,8 +83,12 @@ export function blockLabel(block: Block): string {
       return firstLine(block.text) || "Text";
     case "code":
       return firstLine(block.code) || "Code";
-    case "table":
-      return `${block.rows.length} ${block.rows.length === 1 ? "row" : "rows"}`;
+    case "table": {
+      const rows = `${block.rows.length} ${block.rows.length === 1 ? "row" : "rows"}`;
+      // A live table's count is what it has so far, which is a different claim
+      // from a static table's count and has to read as one.
+      return block.live && !block.exhausted ? `${rows} loaded` : rows;
+    }
     case "ask":
       return block.question;
   }

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,6 +1,7 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
 import { AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
+import { pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
 // Thrown when the user cancels a `kaja.ask(...)` prompt. The task runner
@@ -31,6 +32,70 @@ export interface BlockUpdate {
  */
 export interface Table {
   row(...cells: unknown[]): void;
+}
+
+/**
+ * Rows a table draws. An array is an iterable; so is an async generator, and one
+ * of those only runs when something pulls it — which is what makes paging fetch
+ * a page and nothing else.
+ */
+export type Rows = Iterable<unknown[]> | AsyncIterable<unknown[]>;
+
+/**
+ * …or a source Kaja can start, which is what a server-side search needs: a new
+ * search is a new result set, so the source is restarted with the text in hand.
+ * A source that doesn't declare the parameter never sees it, and the search box
+ * filters the rows already loaded instead.
+ */
+export type RowSource = Rows | ((search: string) => Rows);
+
+export interface TableOptions {
+  pageSize?: number;
+}
+
+// What a live table is filled from. The block is the JSON the console stores;
+// this is the closure beside it, which is why it lives on the Kaja instance —
+// that outlives any one run, and a table stays live after the script is over.
+interface LiveTable {
+  block: TableBlock;
+  open: (search: string) => Rows;
+  iterator?: Iterator<unknown[]> | AsyncIterator<unknown[]>;
+  // Whether the source can be started again. A function can be; an iterable that
+  // is already running cannot, so it has neither a server search nor a retry
+  // that gets anywhere.
+  restartable: boolean;
+  // A generator that threw is finished — JavaScript says so, not us — so a retry
+  // is only a retry if the source can be opened again, from the top.
+  restart?: boolean;
+  search: string;
+  // Bumped when the source is restarted, so a pull that is mid-flight when the
+  // search changes drops what it was doing instead of appending to the new set.
+  generation: number;
+  pulling?: Promise<void>;
+}
+
+// Live sources are closures, so they are held rather than collected. A console
+// that has drawn hundreds of tables lets the oldest go; those tables read as
+// expired, which is a state the canvas already states.
+const MAX_LIVE_TABLES = 24;
+
+function isAsyncIterable(value: any): value is AsyncIterable<unknown[]> {
+  return value != null && typeof value[Symbol.asyncIterator] === "function";
+}
+
+function isIterable(value: any): value is Iterable<unknown[]> {
+  return value != null && typeof value[Symbol.iterator] === "function";
+}
+
+function openIterator(rows: Rows): Iterator<unknown[]> | AsyncIterator<unknown[]> {
+  if (isAsyncIterable(rows)) return rows[Symbol.asyncIterator]();
+  return (rows as Iterable<unknown[]>)[Symbol.iterator]();
+}
+
+// A row is cells. Anything else a source yields is one cell rather than an
+// error, on the same rule formatCell follows: readable beats correct-or-nothing.
+function toCells(row: unknown): string[] {
+  return Array.isArray(row) ? row.map(formatCell) : [formatCell(row)];
 }
 
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
@@ -164,11 +229,47 @@ export class Kaja {
    *
    *   const table = kaja.table(["id", "name", "status"]);
    *   for (const account of accounts) table.row(account.id, account.name, "matched");
+   *
+   * The rows can also be given: an array is drawn as it is, and a source is
+   * pulled a page at a time as the table is paged through.
+   *
+   *   kaja.table(["id", "title"], async function* (search) {
+   *     for (let pageToken = ""; ; ) {
+   *       const page = await Shows.ListShows({ pageSize: 25, pageToken, query: search });
+   *       yield* page.shows.map((show) => [show.id, show.title]);
+   *       if (!(pageToken = page.nextPageToken)) return;
+   *     }
+   *   });
    */
-  table(columns: string[], rows: unknown[][] = []): Table {
+  table(columns: string[], rows?: RowSource, options?: TableOptions): Table {
     const blockId = newBlockId();
-    const block: TableBlock = { kind: "table", columns: columns.map(formatCell), rows: rows.map((row) => row.map(formatCell)) };
-    this.#onBlockUpdate(blockId, block);
+    const block: TableBlock = { kind: "table", columns: columns.map(formatCell), rows: [], pageSize: options?.pageSize };
+
+    if (Array.isArray(rows)) {
+      block.rows = rows.map(toCells);
+    } else if (rows !== undefined) {
+      if (typeof rows !== "function" && !isAsyncIterable(rows) && !isIterable(rows)) {
+        throw new Error("kaja.table: rows must be an array, an iterable of rows, or a function returning one");
+      }
+      // A function can be started again, which is what a search that reaches the
+      // server needs; an iterable that is already running cannot, so its search
+      // stays local. Declaring the parameter is what asks for the text — a
+      // source that ignores it would otherwise be restarted on every keystroke
+      // to fetch the same page back.
+      const restartable = typeof rows === "function";
+      const open = restartable ? rows : () => rows;
+      block.live = true;
+      block.serverSearch = restartable && rows.length > 0;
+      block.loadedSearch = "";
+      this.#openTable(blockId, { block, open, restartable, search: "", generation: 0 });
+    }
+
+    this.#onBlockUpdate(blockId, { ...block });
+    // A live table draws its first page itself rather than waiting to be looked
+    // at: the run is what fetched it, so its calls belong in the run's log — and
+    // a run nobody is watching (an agent's) still reports a page of rows.
+    if (block.live) void this.pullTable(blockId, "", pageSizeOf(block));
+
     return {
       row: (...cells: unknown[]) => {
         // A new array each time: the canvas compares what it was handed against
@@ -177,6 +278,109 @@ export class Kaja {
         this.#onBlockUpdate(blockId, { ...block });
       },
     };
+  }
+
+  #tables = new Map<string, LiveTable>();
+
+  #openTable(blockId: string, table: LiveTable): void {
+    if (this.#tables.size >= MAX_LIVE_TABLES) {
+      const oldest = this.#tables.keys().next();
+      if (!oldest.done) this.#tables.delete(oldest.value);
+    }
+    this.#tables.set(blockId, table);
+  }
+
+  /** Whether this block's source is still held, which is what Next depends on. */
+  hasLiveTable(blockId: string): boolean {
+    return this.#tables.has(blockId);
+  }
+
+  /**
+   * Fill a live table up to `want` rows, restarting its source first if it takes
+   * the search text and the text has changed. Rows are emitted as they arrive,
+   * so a page paints while it fills. Resolves false when the source is gone —
+   * the caller marks the table expired, since it holds the block by then.
+   */
+  async pullTable(blockId: string, search: string, want: number): Promise<boolean> {
+    const table = this.#tables.get(blockId);
+    if (!table) return false;
+
+    const searched = table.block.serverSearch === true && table.search !== search;
+    if (searched || table.restart) {
+      // A new search is a new result set, and a retry is the same source from
+      // the top: either way the rows that are here answer a question nobody is
+      // asking any more.
+      table.search = search;
+      table.restart = false;
+      table.iterator = undefined;
+      table.generation++;
+      table.block.rows = [];
+      table.block.exhausted = false;
+      table.block.loadedSearch = search;
+    } else if (table.pulling) {
+      // Single flight: a pull already under way is filling the same table, and a
+      // second one would interleave its rows with the first's.
+      await table.pulling;
+      return true;
+    }
+
+    const pulling = this.#fill(blockId, table, want, table.generation);
+    table.pulling = pulling;
+    try {
+      await pulling;
+    } finally {
+      // A restart supersedes this pull and puts its own promise here; clearing
+      // it unconditionally would report the new one as finished.
+      if (table.pulling === pulling) table.pulling = undefined;
+    }
+    return true;
+  }
+
+  async #fill(blockId: string, table: LiveTable, want: number, generation: number): Promise<void> {
+    const block = table.block;
+    block.loading = true;
+    block.error = undefined;
+    this.#onBlockUpdate(blockId, { ...block });
+
+    try {
+      if (!table.iterator) table.iterator = openIterator(table.open(table.search));
+      while (block.rows.length < want) {
+        const next = await table.iterator.next();
+        // A restart happened while this was awaiting; its rows answer a search
+        // nobody is looking at any more.
+        if (table.generation !== generation) return;
+        if (next.done) {
+          block.exhausted = true;
+          break;
+        }
+        block.rows = [...block.rows, toCells(next.value)];
+        this.#onBlockUpdate(blockId, { ...block });
+      }
+    } catch (error) {
+      if (table.generation !== generation) return;
+      // The call that failed is already a row in the run's log; this is what the
+      // table says about why it stopped, and what Retry clears.
+      block.error = error instanceof Error ? error.message : String(error);
+      table.restart = table.restartable;
+    } finally {
+      if (table.generation === generation) {
+        block.loading = false;
+        this.#onBlockUpdate(blockId, { ...block });
+      }
+    }
+  }
+
+  /**
+   * Resolves once no table is still filling. A script that draws a live table
+   * and ends is not over until its first page has landed — those calls are the
+   * run's, and the run's duration is what they cost.
+   */
+  async settleTables(): Promise<void> {
+    for (let pass = 0; pass < 8; pass++) {
+      const pulling = [...this.#tables.values()].map((table) => table.pulling).filter((promise): promise is Promise<void> => promise !== undefined);
+      if (pulling.length === 0) return;
+      await Promise.all(pulling);
+    }
   }
 
   // Builders for google.protobuf.Value, Struct and ListValue, so a field of one

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -68,6 +68,21 @@ export interface Table {
   row(...cells: unknown[]): void;
 }
 
+/**
+ * Rows a table draws. An array is an iterable; so is an async generator, and one
+ * of those only runs when something pulls it — which is what makes paging fetch
+ * a page and nothing else.
+ */
+export type Rows = Iterable<unknown[]> | AsyncIterable<unknown[]>;
+
+/**
+ * …or a function returning one, which is what a search that reaches the server
+ * needs: a new search is a new result set, so the source is started again with
+ * the text in hand. Declare the parameter and the search box goes to your
+ * source; leave it out and the box filters the rows already loaded.
+ */
+export type RowSource = Rows | ((search: string) => Rows);
+
 /** The Kaja runtime object. Import it with: import { kaja } from "kaja"; */
 export declare const kaja: {
   /**
@@ -112,8 +127,23 @@ export declare const kaja: {
    *   for (const account of accounts) {
    *     table.row(account.id, account.name, await check(account));
    *   }
+   *
+   * The rows can be given instead — an array, or a source that yields them as
+   * the table is paged through. A source is only pulled when paging asks for
+   * rows it hasn't got, so the second page costs a call and the tenth costs one
+   * only if you go there. The table searches and pages either way.
+   *
+   *   kaja.table(["id", "title"], shows.map((show) => [show.id, show.title]));
+   *
+   *   kaja.table(["id", "title"], async function* (search) {
+   *     for (let pageToken = ""; ; ) {
+   *       const page = await Shows.ListShows({ pageSize: 25, pageToken, query: search });
+   *       yield* page.shows.map((show) => [show.id, show.title]);
+   *       if (!(pageToken = page.nextPageToken)) return;
+   *     }
+   *   });
    */
-  table(columns: string[], rows?: unknown[][]): Table;
+  table(columns: string[], rows?: RowSource, options?: { pageSize?: number }): Table;
   /** UUID helpers. */
   uuid: {
     /**

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+import { Block, TableBlock } from "./blocks";
+import { Kaja } from "./kaja";
+
+// A Kaja with nowhere to draw but a map of what it drew, which is what a table
+// is: a block that keeps being handed back with more in it.
+function draw() {
+  const blocks = new Map<string, Block>();
+  const kaja = new Kaja(
+    () => {},
+    () => Promise.reject(new Error("not asked")),
+    (blockId, block) => void blocks.set(blockId, block),
+  );
+  const only = (): TableBlock => {
+    const block = [...blocks.values()].find((block) => block.kind === "table");
+    if (block?.kind !== "table") throw new Error("no table was drawn");
+    return block;
+  };
+  const id = () => [...blocks.entries()].find(([, block]) => block.kind === "table")![0];
+  return { kaja, only, id };
+}
+
+describe("kaja.table", () => {
+  it("draws an array as it is, and stays static", () => {
+    const { kaja, only } = draw();
+    kaja.table(["id", "title"], [[1, "Vera"]]);
+
+    expect(only().rows).toEqual([["1", "Vera"]]);
+    expect(only().live).toBeUndefined();
+  });
+
+  it("keeps taking rows from the handle", () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id"]);
+    table.row(1);
+    table.row(2);
+
+    expect(only().rows).toEqual([["1"], ["2"]]);
+  });
+
+  /**
+   * The whole claim: a source is pulled for the page that is being looked at and
+   * not one row further. A generator makes that structural — the loop simply
+   * hasn't reached its next fetch.
+   */
+  it("pulls a source only as far as the page being drawn", async () => {
+    const { kaja, only, id } = draw();
+    const fetched: number[] = [];
+    kaja.table(["n"], async function* () {
+      for (let page = 0; page < 100; page++) {
+        fetched.push(page);
+        yield* [0, 1, 2, 3, 4].map((row) => [page * 5 + row]);
+      }
+    });
+    await kaja.settleTables();
+
+    // The first page is drawn by the run itself, so a canvas nobody is watching
+    // still has rows on it.
+    expect(only().rows).toHaveLength(50);
+    expect(fetched).toHaveLength(10);
+
+    await kaja.pullTable(id(), "", 100);
+    expect(only().rows).toHaveLength(100);
+    expect(fetched).toHaveLength(20);
+  });
+
+  it("marks a source that runs out, so the count becomes the total", async () => {
+    const { kaja, only, id } = draw();
+    kaja.table(["n"], async function* () {
+      yield ["one"];
+      yield ["two"];
+    });
+    await kaja.settleTables();
+
+    expect(only().rows).toHaveLength(2);
+    expect(only().exhausted).toBe(true);
+    expect(await kaja.pullTable(id(), "", 100)).toBe(true);
+  });
+
+  // Declaring the parameter is what asks for the search text; the source is
+  // started again with it, because a new search is a new result set.
+  it("restarts a source that takes the search", async () => {
+    const { kaja, only, id } = draw();
+    const searches: string[] = [];
+    kaja.table(["n"], async function* (search: string) {
+      searches.push(search);
+      yield [`${search || "all"}-1`];
+      yield [`${search || "all"}-2`];
+    });
+    await kaja.settleTables();
+
+    expect(only().serverSearch).toBe(true);
+    expect(searches).toEqual([""]);
+
+    await kaja.pullTable(id(), "vera", 50);
+    expect(searches).toEqual(["", "vera"]);
+    expect(only().rows).toEqual([["vera-1"], ["vera-2"]]);
+    expect(only().loadedSearch).toBe("vera");
+  });
+
+  // A source that ignores the text is never restarted for it: it would fetch the
+  // same first page back on every keystroke. The box filters what is loaded.
+  it("leaves a source that doesn't take the search alone", async () => {
+    const { kaja, only, id } = draw();
+    let started = 0;
+    kaja.table(["n"], async function* () {
+      started++;
+      yield ["one"];
+    });
+    await kaja.settleTables();
+    await kaja.pullTable(id(), "vera", 50);
+
+    expect(started).toBe(1);
+    expect(only().serverSearch).toBe(false);
+  });
+
+  it("reports a source that failed, and fills again when it is retried", async () => {
+    const { kaja, only, id } = draw();
+    let attempt = 0;
+    kaja.table(["n"], async function* () {
+      if (attempt++ === 0) throw new Error("upstream is down");
+      yield ["one"];
+    });
+    await kaja.settleTables();
+
+    expect(only().error).toBe("upstream is down");
+    expect(only().loading).toBe(false);
+
+    // A generator that threw is finished, so a retry is the source opened again
+    // from the top rather than the dead one resumed.
+    await kaja.pullTable(id(), "", 50);
+    expect(only().error).toBeUndefined();
+    expect(only().rows).toEqual([["one"]]);
+  });
+
+  // A block read back from the store has no source; Next has to say so rather
+  // than lead nowhere.
+  it("reports a table whose source it no longer holds", async () => {
+    const { kaja } = draw();
+    expect(await kaja.pullTable("block-gone", "", 50)).toBe(false);
+  });
+
+  it("takes a plain array of rows from an iterable source", async () => {
+    const { kaja, only } = draw();
+    kaja.table(["n"], [["a"], ["b"]].values());
+    await kaja.settleTables();
+
+    expect(only().rows).toEqual([["a"], ["b"]]);
+    expect(only().live).toBe(true);
+  });
+});

--- a/ui/src/mcpCatalog.test.ts
+++ b/ui/src/mcpCatalog.test.ts
@@ -186,7 +186,7 @@ describe("buildMcpCatalog", () => {
 
     expect(built.apps).toHaveLength(0);
     expect(built.runtime).toContain("export declare const kaja: {");
-    expect(built.runtime).toContain("table(columns: string[], rows?: unknown[][]): Table;");
+    expect(built.runtime).toContain("table(columns: string[], rows?: RowSource, options?: { pageSize?: number }): Table;");
     expect(built.runtime).toContain('"API_BASE_URL": string;');
     // The rule the type system can't state, said where the declaration is read.
     expect(built.runtime).toContain("a top-level `return` is an error");

--- a/ui/src/runHistory.ts
+++ b/ui/src/runHistory.ts
@@ -139,6 +139,20 @@ export function recordBlock(history: RunHistory, fileId: string | undefined, run
   });
 }
 
+/**
+ * Which run drew a block, wherever it is. A live table is paged long after the
+ * run that drew it is over, and the rows it fetches belong in that run's log —
+ * the click happened on its canvas.
+ */
+export function findBlock(history: RunHistory, blockId: string): { fileId: string; run: Run; block: Block } | undefined {
+  for (const [fileId, file] of Object.entries(history)) {
+    const item = file.items.find((item) => item.id === blockId && item.block !== undefined);
+    const run = item && file.runs.find((run) => run.id === item.runId);
+    if (item?.block && run) return { fileId, run, block: item.block };
+  }
+  return undefined;
+}
+
 export function recordLogs(history: RunHistory, fileId: string | undefined, runId: string, logs: Log[], now: number): RunHistory {
   if (!fileId) return history;
   return withFile(history, fileId, now, (file) => ({ ...file, items: [...file.items, { id: newItemId(), runId, timestamp: now, logs }] }));

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -154,6 +154,12 @@ function toStoredItem(item: ConsoleItem): StoredItem {
 function storedBlock(block: Block | undefined): Block | undefined {
   if (block === undefined) return undefined;
   if (block.kind === "ask" && isAwaitingAnswer(block)) return { ...block, cancelled: true };
+  // A live table's source is a closure, which nothing can store. It reads back
+  // as the rows it had, saying so — the same bargain the payloads make, and for
+  // the same reason: expiry is bearable when it is stated.
+  if (block.kind === "table" && block.live === true && block.exhausted !== true) {
+    return { ...block, live: false, loading: false, error: undefined, expired: true };
+  }
   return block;
 }
 

--- a/ui/src/tableView.test.ts
+++ b/ui/src/tableView.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { TableBlock } from "./blocks";
+import { hasControls, pullNeeded, tableSummary, tableWindow } from "./tableView";
+
+function table(rows: number, extra: Partial<TableBlock> = {}): TableBlock {
+  return {
+    kind: "table",
+    columns: ["id", "title"],
+    rows: Array.from({ length: rows }, (_, index) => [`${index}`, `show ${index}`]),
+    pageSize: 10,
+    ...extra,
+  };
+}
+
+describe("tableWindow", () => {
+  it("pages over the rows it has", () => {
+    const shown = tableWindow(table(25), { page: 1, search: "" });
+
+    expect(shown.rows).toHaveLength(10);
+    expect(shown.rows[0][0]).toBe("10");
+    expect([shown.from, shown.to, shown.total]).toEqual([11, 20, 25]);
+    expect([shown.hasPrevious, shown.hasNext]).toEqual([true, true]);
+  });
+
+  it("has no next page on the last page of a static table", () => {
+    expect(tableWindow(table(25), { page: 2, search: "" }).hasNext).toBe(false);
+  });
+
+  // A search that shrinks the set shows its last page rather than an empty one.
+  it("clamps a page the rows no longer reach", () => {
+    const shown = tableWindow(table(25), { page: 9, search: "" });
+
+    expect(shown.page).toBe(2);
+    expect(shown.rows).toHaveLength(5);
+  });
+
+  // Paging into rows that aren't here yet is how they are asked for, so the
+  // clamp lets a page past the loaded end through — but only one, since that is
+  // as far as a click can get.
+  it("lets one page past the loaded rows through while the source is open", () => {
+    const block = table(20, { live: true });
+
+    expect(tableWindow(block, { page: 2, search: "" }).page).toBe(2);
+    expect(tableWindow(block, { page: 5, search: "" }).page).toBe(2);
+    expect(tableWindow({ ...block, exhausted: true }, { page: 2, search: "" }).page).toBe(1);
+  });
+
+  it("filters on any cell, for a source that doesn't take the search", () => {
+    const shown = tableWindow(table(25), { page: 0, search: "SHOW 2" });
+
+    // show 2, and show 20 through 24.
+    expect(shown.total).toBe(6);
+    expect(shown.filtered).toBe(true);
+    expect(shown.loaded).toBe(25);
+  });
+
+  // A source that takes the search has already answered it; filtering its rows
+  // again would hide what it sent back.
+  it("does not filter the rows of a source that takes the search", () => {
+    const shown = tableWindow(table(25, { live: true, serverSearch: true, loadedSearch: "vera" }), { page: 0, search: "vera" });
+
+    expect(shown.filtered).toBe(false);
+    expect(shown.total).toBe(25);
+  });
+
+  // No lookahead: a live source offers Next until it runs out, because pulling
+  // one row past the page to light the button up is a fetch nobody asked for.
+  it("offers a next page while a source is still open", () => {
+    expect(tableWindow(table(10, { live: true }), { page: 0, search: "" }).hasNext).toBe(true);
+    expect(tableWindow(table(10, { live: true, exhausted: true }), { page: 0, search: "" }).hasNext).toBe(false);
+    expect(tableWindow(table(10, { live: true, expired: true }), { page: 0, search: "" }).hasNext).toBe(false);
+  });
+
+  // A local filter searches what is loaded and never fetches, so it pages only
+  // what it matched.
+  it("does not offer a next page past a local filter's matches", () => {
+    expect(tableWindow(table(25, { live: true }), { page: 0, search: "show 2" }).hasNext).toBe(false);
+  });
+});
+
+describe("pullNeeded", () => {
+  it("asks for rows a page doesn't reach, and only then", () => {
+    expect(pullNeeded(table(10, { live: true }), { page: 0, search: "" })).toEqual({ needed: false, want: 10 });
+    expect(pullNeeded(table(10, { live: true }), { page: 1, search: "" })).toEqual({ needed: true, want: 20 });
+  });
+
+  it("never asks on behalf of a static table", () => {
+    expect(pullNeeded(table(10), { page: 4, search: "" }).needed).toBe(false);
+  });
+
+  it("never asks while one is already in flight, or after one failed", () => {
+    expect(pullNeeded(table(10, { live: true, loading: true }), { page: 1, search: "" }).needed).toBe(false);
+    expect(pullNeeded(table(10, { live: true, error: "unreachable" }), { page: 1, search: "" }).needed).toBe(false);
+  });
+
+  it("asks for a search the source hasn't answered yet", () => {
+    const block = table(30, { live: true, serverSearch: true, loadedSearch: "" });
+
+    expect(pullNeeded(block, { page: 0, search: "vera" }).needed).toBe(true);
+    expect(pullNeeded({ ...block, loadedSearch: "vera" }, { page: 0, search: "vera" }).needed).toBe(false);
+  });
+
+  // Searching what is loaded must not pull an API dry to find three rows.
+  it("never asks on behalf of a local filter", () => {
+    expect(pullNeeded(table(10, { live: true }), { page: 1, search: "show" }).needed).toBe(false);
+  });
+});
+
+describe("hasControls", () => {
+  // Controls appear when there is something to control: a table that fits on a
+  // page reads exactly as it did before any of this existed.
+  it("is false for a static table that fits on one page", () => {
+    expect(hasControls(table(10))).toBe(false);
+    expect(hasControls(table(11))).toBe(true);
+  });
+
+  it("is true for a table that can still grow, or could have", () => {
+    expect(hasControls(table(3, { live: true }))).toBe(true);
+    expect(hasControls(table(3, { expired: true }))).toBe(true);
+  });
+});
+
+describe("tableSummary", () => {
+  it("states a total it knows, and a count it doesn't", () => {
+    const block = table(25);
+    expect(tableSummary(block, tableWindow(block, { page: 0, search: "" }))).toBe("1–10 of 25");
+
+    const live = table(25, { live: true });
+    expect(tableSummary(live, tableWindow(live, { page: 0, search: "" }))).toBe("1–10 · 25 loaded");
+
+    const expired = table(25, { expired: true });
+    expect(tableSummary(expired, tableWindow(expired, { page: 0, search: "" }))).toBe("1–10 of 25 loaded — run to load the rest");
+  });
+
+  it("says a local filter is searching what is loaded", () => {
+    const block = table(25, { live: true });
+    expect(tableSummary(block, tableWindow(block, { page: 0, search: "show 2" }))).toBe("1–6 of 6 matching, of 25 loaded");
+  });
+});

--- a/ui/src/tableView.ts
+++ b/ui/src/tableView.ts
@@ -1,0 +1,132 @@
+import { TableBlock } from "./blocks";
+
+/**
+ * How a table is windowed and searched. The pager is over **rows, not requests**:
+ * Next means "the next page of rows, fetching if I have run out", so a source
+ * that yields in batches of 25 fetches twice per page of 50 and one that yields
+ * 500 does not fetch for ten pages. The script never thinks about it.
+ */
+export const DEFAULT_PAGE_SIZE = 50;
+
+// Where a table is currently pointed. This is view state rather than something
+// the run drew, so it is held beside the console and not in the block.
+export interface TableView {
+  page: number;
+  search: string;
+}
+
+export const NO_TABLE_VIEW: TableView = { page: 0, search: "" };
+
+export function pageSizeOf(block: TableBlock): number {
+  const size = block.pageSize;
+  return size !== undefined && size > 0 ? Math.floor(size) : DEFAULT_PAGE_SIZE;
+}
+
+/**
+ * Whether the search box goes to the source or filters what is on screen. A
+ * source that declares a search parameter is asked; one that doesn't isn't, and
+ * a local filter never fetches — searching would otherwise mean pulling an API
+ * dry to find three rows.
+ */
+export function searchesLocally(block: TableBlock): boolean {
+  return block.serverSearch !== true;
+}
+
+// A row matches if any of its cells contains the text. Cells are already
+// formatted to strings by the time they reach a block, so there is one rule.
+export function matchesSearch(row: string[], search: string): boolean {
+  const needle = search.trim().toLowerCase();
+  if (needle === "") return true;
+  return row.some((cell) => cell.toLowerCase().includes(needle));
+}
+
+// Whether the table shows a search box and a pager at all. Controls appear when
+// there is something to control: a live table can always grow, and a static one
+// that fits on a page reads exactly as it did before any of this existed.
+export function hasControls(block: TableBlock): boolean {
+  return block.live === true || block.expired === true || block.rows.length > pageSizeOf(block);
+}
+
+export interface TableWindow {
+  // The rows to draw, and where they sit in what the table has.
+  rows: string[][];
+  page: number;
+  from: number;
+  to: number;
+  // Rows the window pages over: the loaded rows, or what a local search left.
+  total: number;
+  loaded: number;
+  // A local search is narrowing the loaded rows.
+  filtered: boolean;
+  hasPrevious: boolean;
+  hasNext: boolean;
+  // How many rows the source must hold for this page to be full.
+  want: number;
+}
+
+/**
+ * What to draw for a page. The page is clamped rather than corrected, so a
+ * search that shrinks the set shows its last page instead of an empty one.
+ */
+export function tableWindow(block: TableBlock, view: TableView): TableWindow {
+  const size = pageSizeOf(block);
+  const filtered = searchesLocally(block) && view.search.trim() !== "";
+  const rows = filtered ? block.rows.filter((row) => matchesSearch(row, view.search)) : block.rows;
+  // The last page of what is loaded — plus one while the source is open, since
+  // paging into rows that aren't here yet is exactly how they are asked for.
+  const loadedPages = Math.max(0, Math.ceil(rows.length / size) - 1);
+  const page = Math.max(0, Math.min(view.page, isOpen(block) && !filtered ? loadedPages + 1 : loadedPages));
+  const start = page * size;
+  const shown = rows.slice(start, start + size);
+
+  return {
+    rows: shown,
+    page,
+    from: shown.length === 0 ? 0 : start + 1,
+    to: start + shown.length,
+    total: rows.length,
+    loaded: block.rows.length,
+    filtered,
+    hasPrevious: page > 0,
+    // No lookahead: pulling one row past the page to light the button up would
+    // fetch a whole page to answer a question nobody asked. A live source offers
+    // Next until it runs out, and a click that yields nothing closes it out.
+    hasNext: start + shown.length < rows.length || (isOpen(block) && !filtered),
+    want: (page + 1) * size,
+  };
+}
+
+// Whether more rows can still be had from the source.
+export function isOpen(block: TableBlock): boolean {
+  return block.live === true && block.exhausted !== true && block.expired !== true;
+}
+
+/**
+ * Whether this page needs the source pulled, and for how many rows. Two things
+ * ask for a pull: a page the loaded rows don't reach, and a search a source that
+ * takes one hasn't answered yet. A local filter never does — it searches what is
+ * loaded, which is what the footer says it is doing.
+ */
+export function pullNeeded(block: TableBlock, view: TableView): { needed: boolean; want: number } {
+  const want = (Math.max(0, view.page) + 1) * pageSizeOf(block);
+  if (!isOpen(block) || block.loading === true || block.error !== undefined) return { needed: false, want };
+  if (!searchesLocally(block)) {
+    if ((block.loadedSearch ?? "") !== view.search) return { needed: true, want };
+  } else if (view.search.trim() !== "") {
+    return { needed: false, want };
+  }
+  return { needed: block.rows.length < want, want };
+}
+
+/**
+ * What the footer says about how much there is. A static table knows its total;
+ * a live one only knows what it has, and says so rather than implying the count
+ * is the answer.
+ */
+export function tableSummary(block: TableBlock, window: TableWindow): string {
+  const range = window.total === 0 ? "No rows" : `${window.from}–${window.to} of ${window.total}`;
+  if (window.filtered) return `${range} matching, of ${window.loaded} loaded`;
+  if (block.expired === true) return `${range} loaded — run to load the rest`;
+  if (isOpen(block)) return `${window.from}–${window.to} · ${window.loaded} loaded`;
+  return range;
+}


### PR DESCRIPTION
`kaja.table(columns, rows?)` now takes an array or an async generator — an iterable either way, and a lazy one only runs when paging pulls it, so the next page costs a call and the tenth costs one only if you go there. Declaring a `search` parameter hands the search box to the source; leaving it out filters the rows already loaded, which never fetches.

```ts
kaja.table(["id", "title", "seats"], async function* (search) {
  for (let pageToken = ""; ; ) {
    const page = await Shows.ListShows({ pageSize: 25, pageToken, query: search });
    yield* page.shows.map((show) => [show.id, show.title, show.seatsAvailable]);
    if (!(pageToken = page.nextPageToken)) return;
  }
});
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014Xqh377kAjZiUSXZguharj)_