### PR TITLE
Fixed a table search that stopped working after one search

### DIFF
--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -175,7 +175,9 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   const controls = hasControls(block);
   // A search bound for the source is debounced; one that filters what is loaded
   // is not, because it costs nothing and lagging under the keystrokes is worse.
-  const search = useDebounced(view.search, searchesLocally(block) ? 0 : 300);
+  // The text is settled before it is debounced, so the space after a word is not
+  // a second search — and ⏎ says "now", which is what the wait is for.
+  const [search, searchNow] = useDebounced(view.search.trim(), searchesLocally(block) ? 0 : 300);
   const { needed, want } = pullNeeded(block, { page: shown.page, search });
 
   useEffect(() => {
@@ -197,6 +199,9 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
             value={view.search}
             // A new search is a new set, so it is read from the first page.
             onChange={(event) => onView(id, { page: 0, search: event.target.value })}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") searchNow();
+            }}
           />
           {block.loading && <Spinner className="size-3 shrink-0" />}
           <span data-testid="canvas-table-summary" className="shrink-0 truncate tabular-nums @max-[420px]:hidden">
@@ -265,9 +270,10 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   );
 };
 
-// A value that settles. Only a search bound for a source needs it — restarting
-// on every keystroke would fetch the same first page five times over.
-function useDebounced<T>(value: T, delay: number): T {
+// A value that settles, and the way to settle it now. Only a search bound for a
+// source needs the wait — restarting on every keystroke would fetch the same
+// first page five times over — and anyone who is done typing shouldn't serve it.
+function useDebounced<T>(value: T, delay: number): [T, () => void] {
   const [settled, setSettled] = useState(value);
   useEffect(() => {
     if (delay === 0) {
@@ -277,7 +283,7 @@ function useDebounced<T>(value: T, delay: number): T {
     const timer = setTimeout(() => setSettled(value), delay);
     return () => clearTimeout(timer);
   }, [value, delay]);
-  return delay === 0 ? value : settled;
+  return [delay === 0 ? value : settled, () => setSettled(value)];
 }
 
 interface AskProps {

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -96,6 +96,13 @@ describe("kaja.table", () => {
     expect(searches).toEqual(["", "vera"]);
     expect(only().rows).toEqual([["vera-1"], ["vera-2"]]);
     expect(only().loadedSearch).toBe("vera");
+
+    // A search that runs the source out is still only one search: the next one
+    // opens it again rather than reading the last answer as the end of it.
+    expect(only().exhausted).toBe(true);
+    await kaja.pullTable(id(), "lune", 50);
+    expect(searches).toEqual(["", "vera", "lune"]);
+    expect(only().rows).toEqual([["lune-1"], ["lune-2"]]);
   });
 
   // A source that ignores the text is never restarted for it: it would fetch the

--- a/ui/src/tableView.test.ts
+++ b/ui/src/tableView.test.ts
@@ -100,6 +100,39 @@ describe("pullNeeded", () => {
     expect(pullNeeded({ ...block, loadedSearch: "vera" }, { page: 0, search: "vera" }).needed).toBe(false);
   });
 
+  // A search restarts the source, so the state its last answer left behind is
+  // not a reason to sit still: a narrow search that ran the source out used to
+  // leave the box dead for every search after it.
+  it("asks for a new search however the last one ended", () => {
+    const answered = table(3, { live: true, serverSearch: true, loadedSearch: "vera" });
+
+    expect(pullNeeded({ ...answered, exhausted: true }, { page: 0, search: "lune" }).needed).toBe(true);
+    expect(pullNeeded({ ...answered, loading: true }, { page: 0, search: "lune" }).needed).toBe(true);
+    expect(pullNeeded({ ...answered, error: "unreachable" }, { page: 0, search: "lune" }).needed).toBe(true);
+    // Clearing the box is a new search like any other.
+    expect(pullNeeded({ ...answered, exhausted: true }, { page: 0, search: "" }).needed).toBe(true);
+  });
+
+  it("stops asking once the source has answered a search and run out", () => {
+    const block = table(3, { live: true, serverSearch: true, loadedSearch: "vera", exhausted: true });
+
+    expect(pullNeeded(block, { page: 0, search: "vera" }).needed).toBe(false);
+    expect(pullNeeded(block, { page: 1, search: "vera" }).needed).toBe(false);
+  });
+
+  // The pager is over rows, so a search the source answered still pages forward.
+  it("still asks for a page past what a server search has loaded", () => {
+    const block = table(10, { live: true, serverSearch: true, loadedSearch: "vera" });
+
+    expect(pullNeeded(block, { page: 1, search: "vera" })).toEqual({ needed: true, want: 20 });
+  });
+
+  it("never asks on behalf of a source that is gone", () => {
+    const block = table(3, { live: true, expired: true, serverSearch: true, loadedSearch: "vera" });
+
+    expect(pullNeeded(block, { page: 0, search: "lune" }).needed).toBe(false);
+  });
+
   // Searching what is loaded must not pull an API dry to find three rows.
   it("never asks on behalf of a local filter", () => {
     expect(pullNeeded(table(10, { live: true }), { page: 1, search: "show" }).needed).toBe(false);

--- a/ui/src/tableView.ts
+++ b/ui/src/tableView.ts
@@ -109,12 +109,19 @@ export function isOpen(block: TableBlock): boolean {
  */
 export function pullNeeded(block: TableBlock, view: TableView): { needed: boolean; want: number } {
   const want = (Math.max(0, view.page) + 1) * pageSizeOf(block);
-  if (!isOpen(block) || block.loading === true || block.error !== undefined) return { needed: false, want };
-  if (!searchesLocally(block)) {
-    if ((block.loadedSearch ?? "") !== view.search) return { needed: true, want };
-  } else if (view.search.trim() !== "") {
-    return { needed: false, want };
-  }
+  // A source that was never there or is gone is the one thing nothing gets past.
+  if (block.live !== true || block.expired === true) return { needed: false, want };
+
+  // A search the source takes **restarts** it, so it outranks every state the
+  // current result set is in: rows that ran out, a pull still filling them, and
+  // the error the last one stopped on all belong to a question nobody is asking
+  // any more. Reading them as reasons not to pull is what left the box dead
+  // after one search that happened to exhaust its source.
+  if (!searchesLocally(block) && (block.loadedSearch ?? "") !== view.search) return { needed: true, want };
+
+  if (block.loading === true || block.error !== undefined || block.exhausted === true) return { needed: false, want };
+  // Searching what is loaded must not pull an API dry to find three rows.
+  if (searchesLocally(block) && view.search.trim() !== "") return { needed: false, want };
   return { needed: block.rows.length < want, want };
 }
 


### PR DESCRIPTION
A search that exhausted its source (a few matches — the common case) left the table's search box dead, because `pullNeeded` gated every pull behind `isOpen`, which is false once a source has run out. A search that differs from the one the loaded rows answer now outranks `exhausted`/`loading`/`error`, since a search restarts the source anyway. Also trimmed the text before debouncing it and made Enter settle it now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYue9tFcWBqMcd7P67okcY)_