### PR TITLE
Held a call for approval on the canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,10 +346,10 @@ selection, the tab and the view as they were left.
 ## The canvas is what a run drew
 
 **A script says what it made, never how it looks.** The block set is closed and
-tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask` — and
-that is the guard, not a starting point: the moment a script can paint pixels the
-console is a rendering engine and every block becomes a support surface. There is
-no `kaja.html`, no styling arguments, no layout control.
+tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask`,
+`kaja.approve` — and that is the guard, not a starting point: the moment a script
+can paint pixels the console is a rendering engine and every block becomes a
+support surface. There is no `kaja.html`, no styling arguments, no layout control.
 
 - **Ordered, never placed.** Blocks stack in the order they were emitted, like
   calls do. "Canvas" is the name; the thing is a document. Free 2D positioning is
@@ -442,8 +442,36 @@ no `kaja.html`, no styling arguments, no layout control.
   flow, not a summary added over it.
 - **A block that asks is a block that pauses the run.** `kaja.ask` is drawn where
   it happened and the canvas stops there — the empty space under it *is* the
-  pause. Answering appends the next block. A dialogue is not a fifth block type;
+  pause. Answering appends the next block. A dialogue is not a sixth block type;
   it is what a sequence of asks reads as.
+- **A block that approves is one of those, about a call that hasn't happened.**
+  `kaja.approve(Shows.CreateShow({ … }))` draws the call and the request it is
+  about to send, and parks the run in front of it: **Approve** sends it and hands
+  back the response, **Stop** ends the script there. It reads exactly like the
+  ask it is modelled on — same amber, same pause, `isAwaitingUser` covers both,
+  and an undecided one is stored as not approved on the same rule a hanging ask
+  is stored as cancelled. It carries the request rather than a summary of it,
+  because what makes a call worth approving is what is in it, and a click away is
+  too far for the one block you are meant to read before deciding. Neither button
+  takes focus: an ask focuses its input for free, but here Enter would send the
+  request, which is the thing this block exists to prevent. There is no "approve
+  all" and no policy — one call, one decision.
+- **Which is only possible because a method hands back a `Call`, not a promise**
+  (`Call` in `kaja.ts`, returned by every method `client.ts` builds). **A call
+  starts when it is awaited — or at the end of the tick, if nothing has claimed
+  it.** So every script that was ever written still reads as what it does:
+  `await Shows.ListShows({})` sends immediately, a bare `Shows.Ping({})` still
+  goes out, and `Promise.all([a(), b()])` still runs both at once (starting is
+  idempotent, so it doesn't matter which of the two gets there). The generated
+  service stubs say `Call<Response>` and import the type from `kaja`, so the
+  editor and `describe_method` state the same thing the runtime does. Claiming is
+  a real operation rather than a matter of being first — `approve` calls
+  `call.claim()` before its own first `await`, because otherwise the tick would
+  end while the question was still on screen and send the call itself. A call
+  that has already gone out is refused rather than approved: nothing could take
+  it back, so pretending to ask would be the one dishonest thing this could do.
+  Everything a call does happens when it starts, the row it puts in the run's
+  log included — so a call that was never approved was never anywhere.
 - **Splitting the views reintroduces exactly one problem: a run can be waiting on
   the tab you are not looking at.** So a parked run says so three times before
   you can leave it — an amber dot on the Canvas tab, an amber bar at the tail of

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -134,8 +134,12 @@ who opens the script gets the rest without running anything.
 ## The script runtime
 
 - **No interactive input.** `prompt`, `alert` and `confirm` do nothing and return
-  immediately. `kaja.ask()` is how a script asks, and it parks the run on a
-  human — only reach for it when a person is at the app.
+  immediately. `kaja.ask()` is how a script asks, and `kaja.approve()` how it
+  holds a call back until someone says yes; both park the run on a human — only
+  reach for them when a person is at the app.
+- **A method hands back a `Call`, not a promise.** It is sent when you await it,
+  so `await Shows.ListShows({})` is exactly what it always was. The gap is what
+  lets `kaja.approve` hold a call back before it goes out.
 - **Top-level `await` works**: the body runs inside an `async` function.
 - There is no DOM and no file system. What a script reaches, it reaches through
   the apps in `list_services`.
@@ -154,6 +158,9 @@ What each member is for:
   appends to it. `rows` can be an array, or a source (an async generator) the
   table pulls a page at a time as it is paged through.
 - `kaja.ask(message): Promise<string>` — ask the user; blocks on a human.
+- `kaja.approve(call): Promise<T>` — hold a call until the user approves it, e.g.
+  `await kaja.approve(Shows.CreateShow({ … }))`. The call goes inside the
+  parentheses, and not approving stops the script. Blocks on a human.
 - `kaja.variables.<name>` — the user's configured variables, resolved.
 - `kaja.input?: string` — text supplied when the script is launched from the
   macOS "Run Kaja Script" text service. `undefined` when run any other way.

--- a/desktop/mcp/tools.go
+++ b/desktop/mcp/tools.go
@@ -19,7 +19,9 @@ const runtimeNote = "Scripts are TypeScript run inside Kaja: top-level await wor
 	"which the table pulls a page at a time as the reader pages through it (declare a `search` parameter and it is restarted for each search). " +
 	"Your run draws its first page and reports `more: true`; nobody is there to page it, so read the rest with an ordinary loop if you need it. " +
 	"Get the runtime's full declaration with describe_type \"kaja\"; it comes from `import { kaja } from \"kaja\";`. " +
-	"There is no interactive input: `prompt`/`alert`/`confirm` do nothing. Use `kaja.ask()` only when a person is at the app."
+	"A method hands back a `Call`, not a promise: it is sent when you await it, and `await Service.Method({…})` is unchanged by that. " +
+	"There is no interactive input: `prompt`/`alert`/`confirm` do nothing. Use `kaja.ask()`, and `kaja.approve(Service.Method({…}))` " +
+	"which holds a call back until a person approves it, only when a person is at the app."
 
 // toolDefinitions is the static tools/list payload. Schemas are hand-written
 // JSON Schema; keep them in sync with handleToolCall below.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,7 +19,7 @@ import {
   dropFile,
   fileConsole,
   findBlock,
-  hasCallsInFlight,
+  hasWorkInFlight,
   putFile,
   recordBlock,
   recordCall,
@@ -1779,13 +1779,13 @@ export function App() {
 
   // A generated method-call script issues its call without awaiting it, so the
   // script's own promise settles well before the response lands. The run is over
-  // once the script has settled and nothing it started is still in flight — and
-  // that is when its wall duration is known and it is worth keeping for the next
-  // time the file is opened.
+  // once the script has settled and nothing it started is still in flight — a
+  // call, or a question it is parked on — and that is when its wall duration is
+  // known and it is worth keeping for the next time the file is opened.
   useEffect(() => {
     if (!activeRun?.settled) return;
     const file = fileConsole(historyRef.current, activeRun.fileId);
-    if (hasCallsInFlight(file, activeRun.runId)) return;
+    if (hasWorkInFlight(file, activeRun.runId)) return;
 
     if (activeRun.fileId) {
       const now = Date.now();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -43,7 +43,7 @@ import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
 import { Gutter } from "./Gutter";
 import { Block, blockLabel } from "./blocks";
-import { AskCancelledError, Kaja, MethodCall } from "./kaja";
+import { ApprovalRejectedError, AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { TableView } from "./tableView";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
@@ -270,6 +270,14 @@ export function App() {
     resolve: (value: string) => void;
     reject: (reason: unknown) => void;
   } | null>(null);
+  // Active `kaja.approve(...)` call, for a run with no canvas to draw it on;
+  // null when nothing is waiting to be approved.
+  const [approvePrompt, setApprovePrompt] = useState<{
+    method: string;
+    request: string;
+    resolve: () => void;
+    reject: (reason: unknown) => void;
+  } | null>(null);
   // Whether the New app dialog is open.
   const [newAppOpen, setNewAppOpen] = useState(false);
   // Whether the active tab's JSON parses. It gates switching back to the form or
@@ -474,12 +482,14 @@ export function App() {
   );
 
   /**
-   * A `kaja.ask(...)` is answered on the canvas of the run that asked it, so the
-   * promise waits here keyed by the block the question was drawn as. A run with
-   * no console has no canvas to draw on — an agent running code that was never
-   * saved — and falls back to the dialog, which needs no surface of its own.
+   * A `kaja.ask(...)` is answered, and a `kaja.approve(...)` decided, on the
+   * canvas of the run it came from — so both promises wait here keyed by the
+   * block they were drawn as. One map, because both are the same thing to the
+   * run: it is parked until someone says something. A run with no console has no
+   * canvas to draw on — an agent running code that was never saved — and falls
+   * back to a dialog, which needs no surface of its own.
    */
-  const pendingAsksRef = useRef(new Map<string, { resolve: (answer: string) => void; reject: (error: unknown) => void }>());
+  const pendingPromptsRef = useRef(new Map<string, { resolve: (answer: string) => void; reject: (error: unknown) => void }>());
 
   const onAsk = useCallback((message: string, blockId: string) => {
     return new Promise<string>((resolve, reject) => {
@@ -487,23 +497,41 @@ export function App() {
         setAskPrompt({ message, value: "", resolve, reject });
         return;
       }
-      pendingAsksRef.current.set(blockId, { resolve, reject });
+      pendingPromptsRef.current.set(blockId, { resolve, reject });
     });
   }, []);
 
-  const settleAsk = useCallback((blockId: string, settle: (pending: { resolve: (answer: string) => void; reject: (error: unknown) => void }) => void) => {
-    const pending = pendingAsksRef.current.get(blockId);
+  const onApprove = useCallback((method: string, request: string, blockId: string) => {
+    return new Promise<void>((resolve, reject) => {
+      if (!currentRunRef.current?.fileId) {
+        setApprovePrompt({ method, request, resolve, reject });
+        return;
+      }
+      pendingPromptsRef.current.set(blockId, { resolve: () => resolve(), reject });
+    });
+  }, []);
+
+  const settlePrompt = useCallback((blockId: string, settle: (pending: { resolve: (answer: string) => void; reject: (error: unknown) => void }) => void) => {
+    const pending = pendingPromptsRef.current.get(blockId);
     if (!pending) return;
-    pendingAsksRef.current.delete(blockId);
+    pendingPromptsRef.current.delete(blockId);
     settle(pending);
   }, []);
 
-  const onAnswerAsk = useCallback((blockId: string, answer: string) => settleAsk(blockId, (pending) => pending.resolve(answer)), [settleAsk]);
-  const onCancelAsk = useCallback((blockId: string) => settleAsk(blockId, (pending) => pending.reject(new AskCancelledError())), [settleAsk]);
+  const onAnswerAsk = useCallback((blockId: string, answer: string) => settlePrompt(blockId, (pending) => pending.resolve(answer)), [settlePrompt]);
+  const onCancelAsk = useCallback((blockId: string) => settlePrompt(blockId, (pending) => pending.reject(new AskCancelledError())), [settlePrompt]);
+
+  // Approve sends the call; Stop rejects it, which stops the script where it
+  // stands. The block records which of the two happened either way.
+  const onDecideApproval = useCallback(
+    (blockId: string, decision: "approved" | "rejected") =>
+      settlePrompt(blockId, (pending) => (decision === "approved" ? pending.resolve("") : pending.reject(new ApprovalRejectedError()))),
+    [settlePrompt],
+  );
 
   const kajaRef = useRef<Kaja>(null);
   if (!kajaRef.current) {
-    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onBlockUpdate);
+    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onApprove, onBlockUpdate);
   }
 
   /**
@@ -1774,10 +1802,11 @@ export function App() {
   }, [currentFileId]);
 
   // Stop aborts the calls the run has in flight; the script itself stops at the
-  // call it was awaiting. A run parked on a question is awaiting an answer
-  // rather than a call, so Stop has to end that too or the script never returns.
+  // call it was awaiting. A run parked on a question — or on a call waiting to
+  // be approved — is awaiting the user rather than a call, so Stop has to end
+  // that too or the script never returns.
   const onStopActiveRun = useCallback(() => {
-    for (const blockId of [...pendingAsksRef.current.keys()]) onCancelAsk(blockId);
+    for (const blockId of [...pendingPromptsRef.current.keys()]) onCancelAsk(blockId);
     setActiveRun((run) => {
       run?.controller?.abort();
       return null;
@@ -2338,6 +2367,7 @@ export function App() {
                         onViewChange={onConsoleViewChange}
                         onAnswer={onAnswerAsk}
                         onCancelAsk={onCancelAsk}
+                        onDecide={onDecideApproval}
                         tableViews={tableViews}
                         onTableView={onTableView}
                         onTablePull={onTablePull}
@@ -2447,6 +2477,25 @@ export function App() {
             />
           </FormControl>
         </Dialog>
+      )}
+      {approvePrompt && (
+        <ConfirmationDialog
+          title="Approve call"
+          confirmButtonContent="Approve"
+          cancelButtonContent="Stop"
+          onClose={(gesture) => {
+            if (gesture === "confirm") approvePrompt.resolve();
+            else approvePrompt.reject(new ApprovalRejectedError());
+            setApprovePrompt(null);
+          }}
+        >
+          <div className="flex flex-col gap-2 font-mono text-xs">
+            <div className="text-foreground">{approvePrompt.method}</div>
+            <pre className="max-h-64 overflow-auto rounded-md border border-border bg-background px-2.5 py-2 leading-relaxed text-foreground">
+              {approvePrompt.request}
+            </pre>
+          </div>
+        </ConfirmationDialog>
       )}
       {newAppOpen && <NewAppDialog appsPreviewEnabled={previewApps} onClose={() => setNewAppOpen(false)} onSelect={onSelectAppType} />}
       {renameScript && (

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,8 +1,9 @@
-import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { ChevronLeft, ChevronRight, Search, ShieldQuestionMark } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
+import { ApproveBlock, AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
 import { CanvasEntry, foldCalls, groupDuration, groupFailures, groupKeyLabel } from "./callGroups";
 import { cn } from "./cn";
+import { Button } from "./components/button";
 import { Spinner } from "./components/spinner";
 import { isCallInFlight, MethodCall } from "./kaja";
 import { hasControls, NO_TABLE_VIEW, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
@@ -30,6 +31,9 @@ interface CanvasProps {
   selectedItemId?: string;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
+  // One prop for both buttons of an approve block, because there is one decision
+  // to make and the block records it under this name.
+  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
   // Clicking a call card takes you to that call's row in the log, which is where
   // its complete record is. The card can stay minimal because of it.
   onSelectCall: (itemId: string) => void;
@@ -46,7 +50,7 @@ interface CanvasProps {
  * click away in the list — and a run of consecutive calls to one method folds
  * into a single row, which is the whole reason the canvas is not the log.
  */
-export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onSelectCall, tableViews, onTableView, onTablePull }: CanvasProps) {
+export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onDecide, onSelectCall, tableViews, onTableView, onTablePull }: CanvasProps) {
   const entries = useMemo(() => foldCalls(group.items), [group.items]);
 
   if (group.run.payloadsExpired) {
@@ -69,6 +73,7 @@ export function Canvas({ group, selectedItemId, onAnswer, onCancelAsk, onSelectC
             selectedItemId={selectedItemId}
             onAnswer={onAnswer}
             onCancelAsk={onCancelAsk}
+            onDecide={onDecide}
             onSelectCall={onSelectCall}
             tableViews={tableViews}
             onTableView={onTableView}
@@ -89,13 +94,16 @@ interface EntryProps {
   selectedItemId?: string;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
+  // One prop for both buttons of an approve block, because there is one decision
+  // to make and the block records it under this name.
+  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
   onSelectCall: (itemId: string) => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
 }
 
-Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onSelectCall, tableViews, onTableView, onTablePull }: EntryProps) {
+Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onDecide, onSelectCall, tableViews, onTableView, onTablePull }: EntryProps) {
   if (entry.kind === "calls") {
     return <Canvas.CallGroup name={entry.name} items={entry.items} selectedItemId={selectedItemId} onSelectCall={onSelectCall} />;
   }
@@ -110,6 +118,7 @@ Canvas.Entry = function ({ entry, selectedItemId, onAnswer, onCancelAsk, onSelec
       block={item.block}
       onAnswer={onAnswer}
       onCancelAsk={onCancelAsk}
+      onDecide={onDecide}
       tableViews={tableViews}
       onTableView={onTableView}
       onTablePull={onTablePull}
@@ -122,12 +131,15 @@ interface BlockProps {
   block: Block;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
+  // One prop for both buttons of an approve block, because there is one decision
+  // to make and the block records it under this name.
+  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
 }
 
-Canvas.Block = function ({ id, block, onAnswer, onCancelAsk, tableViews, onTableView, onTablePull }: BlockProps) {
+Canvas.Block = function ({ id, block, onAnswer, onCancelAsk, onDecide, tableViews, onTableView, onTablePull }: BlockProps) {
   switch (block.kind) {
     case "text":
       return <Canvas.Text block={block} />;
@@ -137,6 +149,8 @@ Canvas.Block = function ({ id, block, onAnswer, onCancelAsk, tableViews, onTable
       return <Canvas.Table id={id} block={block} view={tableViews[id] ?? NO_TABLE_VIEW} onView={onTableView} onPull={onTablePull} />;
     case "ask":
       return <Canvas.Ask id={id} block={block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
+    case "approve":
+      return <Canvas.Approve id={id} block={block} onDecide={onDecide} />;
   }
 };
 
@@ -328,6 +342,53 @@ Canvas.Ask = function ({ id, block, onAnswer, onCancelAsk }: AskProps) {
       ) : (
         <div className={cn("break-words", block.cancelled ? "italic text-muted-foreground" : "text-foreground")}>
           {block.cancelled ? "Cancelled" : block.answer}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ApproveProps {
+  id: string;
+  block: ApproveBlock;
+  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
+}
+
+/**
+ * The call the run is stopped in front of, drawn where it would have happened
+ * and holding the request it is about to send — a call is worth approving
+ * because of what is in it, so the payload is the block rather than a click
+ * away. It wears the same amber as an ask, since it parks the run the same way.
+ *
+ * Neither button takes focus. An ask focuses its input, which costs nothing;
+ * here Enter would send the request, and a key pressed at the wrong moment is
+ * exactly what this block exists to prevent.
+ */
+Canvas.Approve = function ({ id, block, onDecide }: ApproveProps) {
+  const waiting = block.decision === undefined;
+
+  return (
+    <div
+      data-testid="canvas-approve"
+      className={cn("flex flex-col gap-2 rounded-r-md border-l-2 py-2.5 pl-3 pr-3", waiting ? "border-amber-500 bg-amber-500/10" : "border-border bg-card")}
+    >
+      <div className={cn("flex items-center gap-2", waiting ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground")}>
+        <ShieldQuestionMark size={12} className="shrink-0" />
+        <span className="min-w-0 truncate">{block.method}</span>
+      </div>
+      <pre className="max-h-64 overflow-auto rounded-md border border-border bg-background px-2.5 py-2 leading-relaxed text-foreground">{block.request}</pre>
+      {waiting ? (
+        <div className="flex items-center gap-2">
+          <Button size="sm" data-testid="canvas-approve-send" onClick={() => onDecide(id, "approved")}>
+            Approve
+          </Button>
+          <Button size="sm" variant="outline" data-testid="canvas-approve-stop" onClick={() => onDecide(id, "rejected")}>
+            Stop
+          </Button>
+        </div>
+      ) : (
+        <div className={cn(block.decision === "rejected" ? "italic text-muted-foreground" : "text-foreground")}>
+          {block.decision === "approved" ? "Approved" : "Not approved — the script stopped here"}
         </div>
       )}
     </div>

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -77,6 +77,7 @@ interface ConsoleProps {
   onViewChange: (view: ConsoleView) => void;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
+  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
@@ -101,6 +102,7 @@ export function Console({
   onViewChange,
   onAnswer,
   onCancelAsk,
+  onDecide,
   tableViews,
   onTableView,
   onTablePull,
@@ -311,6 +313,7 @@ export function Console({
           selectedItemId={selection?.itemId}
           onAnswer={onAnswer}
           onCancelAsk={onCancelAsk}
+          onDecide={onDecide}
           onSelectCall={selectFromCanvas}
           tableViews={tableViews}
           onTableView={onTableView}

--- a/ui/src/appLoader.docs.test.ts
+++ b/ui/src/appLoader.docs.test.ts
@@ -52,9 +52,11 @@ describe("proto doc comments in service model", () => {
     const text = serviceSource!.file.text;
 
     expect(text).toContain("Sums two integers.");
-    expect(text).toContain("Sum: async (input: SumRequest)");
+    // A method hands back a Call, and the source says where that type comes from.
+    expect(text).toContain('import type { Call } from "kaja";');
+    expect(text).toContain("Sum: (input: SumRequest): Call<SumResponse>");
     // JSDoc must be attached to the method, not floating elsewhere.
-    const idx = text.indexOf("Sum: async");
+    const idx = text.indexOf("Sum: (input");
     const before = text.slice(Math.max(0, idx - 200), idx);
     expect(before).toContain("Sums two integers.");
   });

--- a/ui/src/appLoader.ts
+++ b/ui/src/appLoader.ts
@@ -98,7 +98,11 @@ export async function loadApp(apiSources: ApiSource[], stubCode: string, configu
         source.file.fileName,
         // If service source, replace the service class (last statement) with the service interface definitions
         // TODO: This is bad. Won't work if there are multiple services in the source file.
-        printStatements([...kajaStatements, ...serviceInterfaceDefinitions]),
+        // A method hands back a Call rather than a Promise, so the source that
+        // declares one says where the type comes from — the same module a script
+        // imports `kaja` from, which is where the rule about when a call starts
+        // is written down.
+        printStatements([...(serviceInterfaceDefinitions.length > 0 ? [callTypeImport()] : []), ...kajaStatements, ...serviceInterfaceDefinitions]),
         ts.ScriptTarget.Latest,
       ),
       serviceNames: source.serviceNames,
@@ -276,6 +280,20 @@ function readSignatures(
   return signatures;
 }
 
+// `import type { Call } from "kaja";` — what a generated service's methods
+// return. Type-only, so nothing about it survives into what a script runs.
+function callTypeImport(): ts.ImportDeclaration {
+  return ts.factory.createImportDeclaration(
+    undefined,
+    ts.factory.createImportClause(
+      true,
+      undefined,
+      ts.factory.createNamedImports([ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("Call"))]),
+    ),
+    ts.factory.createStringLiteral("kaja"),
+  );
+}
+
 // createServiceInterfaceDefinition synthesizes the `export const <Service> = {…}`
 // the editor checks a script against, from the signatures already read.
 function createServiceInterfaceDefinition(
@@ -297,7 +315,10 @@ function createServiceInterfaceDefinition(
     const func = ts.factory.createPropertyAssignment(
       protoMethodName,
       ts.factory.createArrowFunction(
-        [ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword)],
+        // Not async: a method hands back a Call, which is not a promise the
+        // language would let an async function return. The call inside it is
+        // still awaited the same way — that is what a Call is for.
+        undefined,
         undefined,
         [
           ts.factory.createParameterDeclaration(
@@ -308,7 +329,7 @@ function createServiceInterfaceDefinition(
             ts.factory.createTypeReferenceNode(ts.factory.createIdentifier(signature.input), undefined),
           ),
         ],
-        ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Promise"), [
+        ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Call"), [
           ts.factory.createTypeReferenceNode(ts.factory.createIdentifier(signature.output), undefined),
         ]),
         ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),

--- a/ui/src/approve.test.ts
+++ b/ui/src/approve.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { ApproveBlock, Block } from "./blocks";
+import { ApprovalRejectedError, Call, Kaja } from "./kaja";
+
+// A Kaja whose canvas is a map, and whose approvals are decided by the test.
+function held(decide: (method: string, request: string) => Promise<void>) {
+  const blocks = new Map<string, Block>();
+  const kaja = new Kaja(
+    () => {},
+    () => Promise.reject(new Error("not asked")),
+    (method, request) => decide(method, request),
+    (blockId, block) => void blocks.set(blockId, block),
+  );
+  const only = (): ApproveBlock => {
+    const block = [...blocks.values()].find((block) => block.kind === "approve");
+    if (block?.kind !== "approve") throw new Error("nothing was held for approval");
+    return block;
+  };
+  return { kaja, only };
+}
+
+function stub(): { call: Call<string>; sends: number } {
+  const state = { sends: 0 };
+  const call = new Call("Shows.CreateShow", { title: "Vera Lune" }, async () => {
+    state.sends++;
+    return "show-1";
+  });
+  return {
+    call,
+    get sends() {
+      return state.sends;
+    },
+  };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("kaja.approve", () => {
+  it("holds the call until it is approved, then sends it and hands back the response", async () => {
+    const { kaja, only } = held(async () => {});
+    const stubbed = stub();
+
+    const response = await kaja.approve(stubbed.call);
+
+    expect(response).toBe("show-1");
+    expect(stubbed.sends).toBe(1);
+    expect(only()).toEqual({ kind: "approve", method: "Shows.CreateShow", request: '{\n  "title": "Vera Lune"\n}', decision: "approved" });
+  });
+
+  it("never sends the call when it is not approved", async () => {
+    const { kaja, only } = held(async () => {
+      throw new ApprovalRejectedError();
+    });
+    const stubbed = stub();
+
+    await expect(kaja.approve(stubbed.call)).rejects.toBeInstanceOf(ApprovalRejectedError);
+    // The tick that would have started an unclaimed call has been and gone.
+    await tick();
+    expect(stubbed.sends).toBe(0);
+    expect(only().decision).toBe("rejected");
+  });
+
+  it("holds the call for as long as the question is on screen", async () => {
+    let decide = () => {};
+    const { kaja } = held(() => new Promise<void>((resolve) => (decide = resolve)));
+    const stubbed = stub();
+
+    const approving = kaja.approve(stubbed.call);
+    // Several ticks with the question unanswered. A call that was only first in
+    // line rather than claimed would have gone out in the first of them.
+    await tick();
+    await tick();
+    expect(stubbed.sends).toBe(0);
+
+    decide();
+    await approving;
+    expect(stubbed.sends).toBe(1);
+  });
+
+  it("draws the call before it asks, so the canvas parks on it", async () => {
+    let drawn: ApproveBlock | undefined;
+    const { kaja, only } = held(async (method, request) => {
+      drawn = only();
+      expect(method).toBe("Shows.CreateShow");
+      expect(request).toContain("Vera Lune");
+    });
+
+    await kaja.approve(stub().call);
+
+    expect(drawn).toEqual({ kind: "approve", method: "Shows.CreateShow", request: '{\n  "title": "Vera Lune"\n}' });
+  });
+
+  it("refuses a call that has already gone out, which nothing could take back", async () => {
+    const { kaja } = held(async () => {});
+    const stubbed = stub();
+    await tick();
+
+    await expect(kaja.approve(stubbed.call)).rejects.toThrow(/already been sent/);
+    expect(stubbed.sends).toBe(1);
+  });
+});

--- a/ui/src/apps.ts
+++ b/ui/src/apps.ts
@@ -1,4 +1,4 @@
-import { Kaja } from "./kaja";
+import { Call, Kaja } from "./kaja";
 import { Sources, Stub } from "./sources";
 import { ConfigurationApp, Log } from "./server/api";
 
@@ -116,7 +116,7 @@ export interface Clients {
 
 export interface Client {
   kaja?: Kaja;
-  methods: { [key: string]: (input: any) => {} };
+  methods: { [key: string]: (input: any) => Call<any> };
 }
 
 export function serviceId(service: Service): string {

--- a/ui/src/blocks.test.ts
+++ b/ui/src/blocks.test.ts
@@ -1,20 +1,27 @@
 import { describe, expect, it } from "bun:test";
-import { Block, blockLabel, blockText, formatCell, isAwaitingAnswer } from "./blocks";
+import { Block, blockLabel, blockText, formatCell, isAwaitingUser } from "./blocks";
 
-describe("isAwaitingAnswer", () => {
+describe("isAwaitingUser", () => {
   it("is true only for a question nobody has answered", () => {
-    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?" })).toBe(true);
-    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe(false);
+    expect(isAwaitingUser({ kind: "ask", question: "Which ledger?" })).toBe(true);
+    expect(isAwaitingUser({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe(false);
   });
 
   // A cancelled ask stopped the script rather than parking it, so the run is
   // over — showing it as waiting would offer an input nothing is listening to.
   it("is false for a question that was cancelled", () => {
-    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", cancelled: true })).toBe(false);
+    expect(isAwaitingUser({ kind: "ask", question: "Which ledger?", cancelled: true })).toBe(false);
+  });
+
+  it("is true for a call nobody has approved, and false once they have", () => {
+    const held: Block = { kind: "approve", method: "Shows.CreateShow", request: "{}" };
+    expect(isAwaitingUser(held)).toBe(true);
+    expect(isAwaitingUser({ ...held, decision: "approved" })).toBe(false);
+    expect(isAwaitingUser({ ...held, decision: "rejected" })).toBe(false);
   });
 
   it("is false for anything a run merely drew", () => {
-    expect(isAwaitingAnswer({ kind: "text", text: "Reconciling" })).toBe(false);
+    expect(isAwaitingUser({ kind: "text", text: "Reconciling" })).toBe(false);
   });
 });
 
@@ -31,6 +38,14 @@ describe("blockLabel", () => {
   it("names an ask by the question it asked", () => {
     expect(blockLabel({ kind: "ask", question: "Which ledger?" })).toBe("Which ledger?");
   });
+
+  // The verb is a question only while it still is one.
+  it("names a held call by what became of it", () => {
+    const held: Block = { kind: "approve", method: "Shows.CreateShow", request: "{}" };
+    expect(blockLabel(held)).toBe("Approve Shows.CreateShow");
+    expect(blockLabel({ ...held, decision: "approved" })).toBe("Shows.CreateShow approved");
+    expect(blockLabel({ ...held, decision: "rejected" })).toBe("Shows.CreateShow not approved");
+  });
 });
 
 describe("blockText", () => {
@@ -43,6 +58,11 @@ describe("blockText", () => {
 
   it("copies a question with what it was answered", () => {
     expect(blockText({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe("Which ledger?\njune");
+  });
+
+  it("copies a held call with the request it was holding", () => {
+    const held: Block = { kind: "approve", method: "Shows.CreateShow", request: '{ "title": "Vera Lune" }', decision: "approved" };
+    expect(blockText(held)).toBe('Shows.CreateShow approved\n{ "title": "Vera Lune" }');
   });
 });
 

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -60,7 +60,22 @@ export interface AskBlock {
   cancelled?: boolean;
 }
 
-export type Block = TextBlock | CodeBlock | TableBlock | AskBlock;
+/**
+ * A call the script is holding back until it is approved. The other block that
+ * stops the run — and the only one that decides something rather than showing
+ * it: not approving stops the script where it stands, so the call it names is
+ * one that never happened.
+ */
+export interface ApproveBlock {
+  kind: "approve";
+  // The call, as "Service.Method".
+  method: string;
+  // The request it is about to send, already text.
+  request: string;
+  decision?: "approved" | "rejected";
+}
+
+export type Block = TextBlock | CodeBlock | TableBlock | AskBlock | ApproveBlock;
 
 let sequence = 0;
 
@@ -69,10 +84,13 @@ export function newBlockId(): string {
   return `block-${Date.now().toString(36)}-${sequence}`;
 }
 
-// The run is stopped here until this is answered. A cancelled ask stopped the
-// script instead, so it is settled rather than waiting.
-export function isAwaitingAnswer(block: Block): boolean {
-  return block.kind === "ask" && block.answer === undefined && block.cancelled !== true;
+// The run is stopped here until the user says something. A cancelled ask and a
+// rejected call both stopped the script instead, so they are settled rather than
+// waiting.
+export function isAwaitingUser(block: Block): boolean {
+  if (block.kind === "ask") return block.answer === undefined && block.cancelled !== true;
+  if (block.kind === "approve") return block.decision === undefined;
+  return false;
 }
 
 // How a block is named where only one line fits. A table is described by its
@@ -91,6 +109,16 @@ export function blockLabel(block: Block): string {
     }
     case "ask":
       return block.question;
+    case "approve":
+      // The verb is in the present tense only while it is still a question.
+      switch (block.decision) {
+        case "approved":
+          return `${block.method} approved`;
+        case "rejected":
+          return `${block.method} not approved`;
+        default:
+          return `Approve ${block.method}`;
+      }
   }
 }
 
@@ -106,6 +134,8 @@ export function blockText(block: Block): string {
       return [block.columns, ...block.rows].map((cells) => cells.join("\t")).join("\n");
     case "ask":
       return block.cancelled ? `${block.question}\n(cancelled)` : `${block.question}\n${block.answer ?? ""}`;
+    case "approve":
+      return `${blockLabel(block)}\n${block.request}`;
   }
 }
 

--- a/ui/src/call.test.ts
+++ b/ui/src/call.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { Call } from "./kaja";
+
+// A call that records when it was sent, so the tests can ask the only question
+// that matters about a Call: has the request gone out yet?
+function stub<T>(value: T): { call: Call<T>; sends: number } {
+  const state = { sends: 0 };
+  const call = new Call("Shows.ListShows", { pageSize: 25 }, async () => {
+    state.sends++;
+    return value;
+  });
+  return {
+    call,
+    get sends() {
+      return state.sends;
+    },
+  };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("Call", () => {
+  it("doesn't send while the tick it was written in is still running", () => {
+    const stubbed = stub("shows");
+    expect(stubbed.sends).toBe(0);
+    expect(stubbed.call.started).toBe(false);
+  });
+
+  it("sends when it is awaited", async () => {
+    const stubbed = stub("shows");
+    expect(await stubbed.call).toBe("shows");
+    expect(stubbed.sends).toBe(1);
+  });
+
+  it("sends at the end of the tick when nothing claims it", async () => {
+    const stubbed = stub("shows");
+    await tick();
+    expect(stubbed.sends).toBe(1);
+    expect(stubbed.call.started).toBe(true);
+  });
+
+  it("sends once however many times it is read", async () => {
+    const stubbed = stub("shows");
+    const [first, second] = await Promise.all([stubbed.call, stubbed.call]);
+    await tick();
+    expect([first, second]).toEqual(["shows", "shows"]);
+    expect(stubbed.sends).toBe(1);
+  });
+
+  it("runs concurrently under Promise.all, which is what a fan-out is", async () => {
+    const first = stub("a");
+    const second = stub("b");
+    expect(await Promise.all([first.call, second.call])).toEqual(["a", "b"]);
+    expect(first.sends + second.sends).toBe(2);
+  });
+
+  it("stays unsent once claimed, and goes out when it is started", async () => {
+    const stubbed = stub("shows");
+    stubbed.call.claim();
+    await tick();
+    expect(stubbed.sends).toBe(0);
+
+    expect(await stubbed.call.start()).toBe("shows");
+    expect(stubbed.sends).toBe(1);
+  });
+
+  it("carries what it is, so a canvas can name it before it happens", () => {
+    const { call } = stub("shows");
+    expect(call.label).toBe("Shows.ListShows");
+    expect(call.input).toEqual({ pageSize: 25 });
+  });
+});

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -3,7 +3,7 @@ import type { IMessageType } from "@protobuf-ts/runtime";
 import type { MethodInfo, RpcMetadata, RpcOptions, ServerStreamingCall, UnaryCall } from "@protobuf-ts/runtime-rpc";
 import { TwirpFetchTransport } from "@protobuf-ts/twirp-transport";
 import { appHeaders, transportHeaders } from "./appTypes";
-import { MethodCall, MethodCallHeaders } from "./kaja";
+import { Call, MethodCall, MethodCallHeaders } from "./kaja";
 import {
   UPSTREAM_ERROR_TRAILER,
   UPSTREAM_REQUEST_HEADERS_TRAILER,
@@ -128,7 +128,7 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
     const isServerStreaming = method.serverStreaming && !method.clientStreaming;
     const inputType: IMessageType<any> | undefined = (clientStub.methods as MethodInfo[] | undefined)?.find((m) => m.name === method.name)?.I;
 
-    client.methods[method.name] = async (input: any) => {
+    const send = async (input: any) => {
       // Capture request headers from appRef at request time. They are shown as
       // configured, with their ${NAME} references intact - the Headers view
       // reads better that way, and the values behind them stay outside the
@@ -203,6 +203,13 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
 
       return methodCall.output;
     };
+
+    // A call is handed back rather than made: it goes out when the script awaits
+    // it, or at the end of the tick if nothing has claimed it. `kaja.approve` is
+    // what claims one, and holding it back is the only reason the gap exists —
+    // everything above happens when the call starts, including the row it puts
+    // in the log, so a call that was never approved was never anywhere.
+    client.methods[method.name] = (input: any) => new Call(`${service.name}.${method.name}`, input, () => send(input));
   }
 
   return client;

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -141,6 +141,7 @@ test("defaultInput generates a request that serializes", () => {
     new Kaja(
       () => {},
       async () => "",
+      async () => {},
       () => {},
     ),
   );

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,6 +1,6 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
-import { AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
+import { ApproveBlock, AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
 import { pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
@@ -13,11 +13,86 @@ export class AskCancelledError extends Error {
   }
 }
 
+// Thrown when the user doesn't approve a `kaja.approve(...)` call. The task
+// runner swallows it too: not approving stops the script rather than failing it.
+export class ApprovalRejectedError extends Error {
+  constructor() {
+    super("The call was not approved");
+    this.name = "ApprovalRejectedError";
+  }
+}
+
+/**
+ * A call that hasn't been made yet.
+ *
+ * **A call starts when it is awaited — or at the end of the tick, if nothing has
+ * claimed it.** So `await Shows.ListShows({})` and a bare `Shows.Ping({})` both
+ * do what they read as, and `Promise.all([A(), B()])` still runs both at once;
+ * starting is idempotent, so it doesn't matter which of the two gets there.
+ *
+ * That gap of one tick is the whole of what `kaja.approve(...)` needs: the call
+ * is written inside its parentheses, so approve is handed it in the same
+ * synchronous turn and claims it before the tick can end.
+ */
+export class Call<T> implements PromiseLike<T> {
+  // What the call is, for a canvas that has to name it before it happens.
+  readonly label: string;
+  readonly input: unknown;
+  #send: () => Promise<T>;
+  #sent?: Promise<T>;
+  #claimed = false;
+
+  constructor(label: string, input: unknown, send: () => Promise<T>) {
+    this.label = label;
+    this.input = input;
+    this.#send = send;
+    queueMicrotask(() => {
+      if (!this.#claimed) this.start();
+    });
+  }
+
+  /** Whether the request has gone out. Approving one that has is too late. */
+  get started(): boolean {
+    return this.#sent !== undefined;
+  }
+
+  /**
+   * Take the call out of the tick's hands: from here it goes out only when
+   * something starts it, however long that takes. `kaja.approve` claims a call
+   * before its own first await — the same synchronous turn the call was written
+   * in — which is the whole of how it can hold one back.
+   */
+  claim(): void {
+    this.#claimed = true;
+  }
+
+  /** Send the request, or hand back the one already in flight. */
+  start(): Promise<T> {
+    if (!this.#sent) this.#sent = this.#send();
+    return this.#sent;
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.start().then(onfulfilled, onrejected);
+  }
+}
+
 // The question is asked by the block; this is what waits for it to be answered.
 // The id is what the answer comes back against, so an ask on a canvas nobody is
 // looking at is still the one that resolves.
 export interface AskRequest {
   (message: string, blockId: string): Promise<string>;
+}
+
+// The same, for a call held back until it is approved: it resolves when the call
+// may go out, and rejects when the script is to stop instead. The call and its
+// request travel with it for the same reason the question does — a run with no
+// canvas asks in a dialog, which has nothing but what it is handed.
+export interface ApproveRequest {
+  (method: string, request: string, blockId: string): Promise<void>;
 }
 
 // A block arriving, or the same block again with more in it.
@@ -98,6 +173,17 @@ function toCells(row: unknown): string[] {
   return Array.isArray(row) ? row.map(formatCell) : [formatCell(row)];
 }
 
+// The request a call is holding, as the approve block shows it. A block is
+// stored as JSON, so it is text by the time it is one — and text is what the
+// canvas draws either way.
+function formatRequest(input: unknown): string {
+  try {
+    return JSON.stringify(input, (_key, value) => (typeof value === "bigint" ? value.toString() : value), 2) ?? String(input);
+  } catch {
+    return String(input);
+  }
+}
+
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
 // google.protobuf.Value and friends, declared structurally so they match the
@@ -176,11 +262,13 @@ export class Kaja {
     },
   };
   #onAsk: AskRequest;
+  #onApprove: ApproveRequest;
   #onBlockUpdate: BlockUpdate;
 
-  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest, onBlockUpdate: BlockUpdate) {
+  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest, onApprove: ApproveRequest, onBlockUpdate: BlockUpdate) {
     this._internal = new KajaInternal(onMethodCallUpdate);
     this.#onAsk = onAsk;
+    this.#onApprove = onApprove;
     this.#onBlockUpdate = onBlockUpdate;
   }
 
@@ -202,6 +290,37 @@ export class Kaja {
       this.#onBlockUpdate(blockId, { ...question, cancelled: true });
       throw error;
     }
+  }
+
+  /**
+   * Hold a call until it is approved. The call and the request it is about to
+   * send are drawn on the run's canvas and the run stops there; approving sends
+   * it and hands back the response, and not approving stops the script.
+   *
+   *   const show = await kaja.approve(Shows.CreateShow({ title: "Vera Lune" }));
+   *
+   * The call goes inside the parentheses — that is what makes it a call that
+   * hasn't happened yet rather than one to be sorry about.
+   */
+  async approve<T>(call: Call<T>): Promise<T> {
+    if (call.started) {
+      throw new Error(`kaja.approve: ${call.label} has already been sent. Write the call inside it — kaja.approve(${call.label}({ … })).`);
+    }
+    // Before anything is awaited, or the tick this was written in would end
+    // while the question was still on screen and send the call itself.
+    call.claim();
+
+    const blockId = newBlockId();
+    const block: ApproveBlock = { kind: "approve", method: call.label, request: formatRequest(call.input) };
+    this.#onBlockUpdate(blockId, block);
+    try {
+      await this.#onApprove(block.method, block.request, blockId);
+    } catch (error) {
+      this.#onBlockUpdate(blockId, { ...block, decision: "rejected" });
+      throw error;
+    }
+    this.#onBlockUpdate(blockId, { ...block, decision: "approved" });
+    return call.start();
   }
 
   /**

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -35,6 +35,17 @@ const header = `// The Kaja runtime, imported as: import { kaja } from "kaja";
 export function kajaModuleDeclaration(variableNames: string[]): string {
   return `${header}
 
+/**
+ * A call that hasn't been made yet, which is what every service method hands
+ * back: \`Shows.ListShows({})\` is the call, and awaiting it is what sends it.
+ *
+ * A call starts when it is awaited — or at the end of the tick, if nothing has
+ * claimed it — so a bare \`Shows.Ping({})\` still goes out, and
+ * \`Promise.all([a(), b()])\` still runs both at once. The gap of one tick is
+ * what kaja.approve holds a call in.
+ */
+export interface Call<T> extends PromiseLike<T> {}
+
 /** A plain JSON value, as accepted by kaja.value and friends. */
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
@@ -105,6 +116,18 @@ export declare const kaja: {
    *   const name = await kaja.ask("What's your name?");
    */
   ask(message: string): Promise<string>;
+  /**
+   * Hold a call until it is approved. The call and the request it is about to
+   * send are drawn on the run's canvas and the run stops there; approving sends
+   * it and hands back the response, and not approving stops the script.
+   *
+   *   const show = await kaja.approve(Shows.CreateShow({ title: "Vera Lune" }));
+   *
+   * Write the call inside the parentheses. That is what makes it a call that
+   * hasn't happened yet: a call kept in a variable and awaited elsewhere has
+   * already gone out, and approving one is then too late to mean anything.
+   */
+  approve<T>(call: Call<T>): Promise<T>;
   /**
    * Write a line onto the run's canvas.
    *

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -9,6 +9,7 @@ function draw() {
   const kaja = new Kaja(
     () => {},
     () => Promise.reject(new Error("not asked")),
+    () => Promise.reject(new Error("not approved")),
     (blockId, block) => void blocks.set(blockId, block),
   );
   const only = (): TableBlock => {

--- a/ui/src/mcpCatalog.test.ts
+++ b/ui/src/mcpCatalog.test.ts
@@ -121,7 +121,7 @@ describe("buildMcpCatalog", () => {
 
     const method = service.methods[0];
     expect(method.name).toBe("ListShows");
-    expect(method.signature).toBe("ListShows(input: ListShowsRequest): Promise<ListShowsResponse>");
+    expect(method.signature).toBe("ListShows(input: ListShowsRequest): Call<ListShowsResponse>");
     expect(method.input).toBe("ListShowsRequest");
     expect(method.output).toBe("ListShowsResponse");
     expect(method.doc).toBe("Lists the shows on sale.");

--- a/ui/src/mcpCatalog.ts
+++ b/ui/src/mcpCatalog.ts
@@ -37,7 +37,8 @@ export interface McpService {
 export interface McpMethod {
   name: string;
   // The TypeScript a script writes, e.g.
-  // "ListShows(input: ListShowsRequest): Promise<ListShowsResponse>".
+  // "ListShows(input: ListShowsRequest): Call<ListShowsResponse>" — a Call is
+  // awaited like a promise, and is what kaja.approve holds back.
   signature: string;
   input: string;
   output: string;
@@ -89,7 +90,7 @@ function describeMethod(app: App, service: Service, method: Method): McpMethod {
   const output = method.output ?? "unknown";
   const described: McpMethod = {
     name: method.name,
-    signature: `${method.name}(input: ${input}): Promise<${output}>`,
+    signature: `${method.name}(input: ${input}): Call<${output}>`,
     input,
     output,
     example: generateMethodEditorCode(app, service, method),

--- a/ui/src/runHistory.test.ts
+++ b/ui/src/runHistory.test.ts
@@ -5,7 +5,7 @@ import {
   clearFile,
   dropFile,
   fileConsole,
-  hasCallsInFlight,
+  hasWorkInFlight,
   putFile,
   recordBlock,
   recordCall,
@@ -193,13 +193,34 @@ describe("running files", () => {
   });
 });
 
-describe("hasCallsInFlight", () => {
+describe("hasWorkInFlight", () => {
   it("is what the settle check waits on", () => {
     let history = startRun({}, run("r1", "a"), NOW);
     history = recordCall(history, "a", "r1", call("c1"), NOW);
-    expect(hasCallsInFlight(fileConsole(history, "a"), "r1")).toBe(true);
+    expect(hasWorkInFlight(fileConsole(history, "a"), "r1")).toBe(true);
     history = recordCall(history, "a", "r1", call("c1", { shows: [] }), NOW);
-    expect(hasCallsInFlight(fileConsole(history, "a"), "r1")).toBe(false);
+    expect(hasWorkInFlight(fileConsole(history, "a"), "r1")).toBe(false);
+  });
+
+  // A script that doesn't await its own question returns while the block is
+  // still on screen. Settling there leaves the answer with no run to land in,
+  // which opens one that nothing will ever finish.
+  it("keeps a run parked on the user open, however its script returned", () => {
+    const held = { kind: "approve", method: "Shows.CreateShow", request: "{}" } as const;
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = recordBlock(history, "a", "r1", "b1", held, NOW);
+    expect(hasWorkInFlight(fileConsole(history, "a"), "r1")).toBe(true);
+    history = recordBlock(history, "a", "r1", "b1", { ...held, decision: "rejected" }, NOW);
+    expect(hasWorkInFlight(fileConsole(history, "a"), "r1")).toBe(false);
+  });
+
+  it("waits on a question the same way", () => {
+    const asked = { kind: "ask", question: "Which ledger?", answerType: "str" } as const;
+    let history = startRun({}, run("r1", "a"), NOW);
+    history = recordBlock(history, "a", "r1", "b1", asked, NOW);
+    expect(hasWorkInFlight(fileConsole(history, "a"), "r1")).toBe(true);
+    history = recordBlock(history, "a", "r1", "b1", { ...asked, answer: "june" }, NOW);
+    expect(hasWorkInFlight(fileConsole(history, "a"), "r1")).toBe(false);
   });
 });
 

--- a/ui/src/runHistory.ts
+++ b/ui/src/runHistory.ts
@@ -1,4 +1,4 @@
-import { Block, isAwaitingAnswer } from "./blocks";
+import { Block, isAwaitingUser } from "./blocks";
 import { isCallInFlight, MethodCall } from "./kaja";
 import { ConsoleItem, ConsoleTab, ConsoleView, newItemId, Run, RunSelection } from "./runs";
 import { Log } from "./server/api";
@@ -208,7 +208,7 @@ export function setView(history: RunHistory, fileId: string | undefined, view: C
 // away from it, so the sidebar reads this to say so on a script whose canvas is
 // no longer on screen to.
 export function isWaitingForAnswer(file: FileConsole): boolean {
-  return file.items.some((item) => item.block !== undefined && isAwaitingAnswer(item.block));
+  return file.items.some((item) => item.block !== undefined && isAwaitingUser(item.block));
 }
 
 export function waitingFileIds(history: RunHistory): Set<string> {

--- a/ui/src/runHistory.ts
+++ b/ui/src/runHistory.ts
@@ -281,7 +281,13 @@ export function agentFileIds(history: RunHistory): Set<string> {
 }
 
 // Whether anything the run started is still in the air, which is what the settle
-// check waits on.
-export function hasCallsInFlight(file: FileConsole, runId: string): boolean {
-  return file.items.some((item) => item.runId === runId && item.call !== undefined && isCallInFlight(item.call));
+// check waits on. A question the user hasn't answered — or a call held for
+// approval — counts: a run parked on the user is not over, however the script
+// that started it returned. A script that doesn't await its own question is
+// exactly the case this covers, and settling under it is worse than a delay —
+// the answer would arrive with no run open and start one that never ends.
+export function hasWorkInFlight(file: FileConsole, runId: string): boolean {
+  return file.items.some(
+    (item) => item.runId === runId && ((item.call !== undefined && isCallInFlight(item.call)) || (item.block !== undefined && isAwaitingUser(item.block))),
+  );
 }

--- a/ui/src/runStore.test.ts
+++ b/ui/src/runStore.test.ts
@@ -127,4 +127,11 @@ describe("blocks in the store", () => {
     const loaded = deserializeFile(serializeFile([run], items, NOW));
     expect(loaded.items[0].block).toEqual({ kind: "ask", question: "Which ledger?", cancelled: true });
   });
+
+  // And that is the truth about the call, too: nothing ever sent it.
+  it("stores a call nobody approved as one that was not approved", () => {
+    const items: ConsoleItem[] = [{ id: "b1", runId: "r1", timestamp: NOW, block: { kind: "approve", method: "Shows.CreateShow", request: "{}" } }];
+    const loaded = deserializeFile(serializeFile([run], items, NOW));
+    expect(loaded.items[0].block).toEqual({ kind: "approve", method: "Shows.CreateShow", request: "{}", decision: "rejected" });
+  });
 });

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -1,5 +1,5 @@
 import { Method, Service } from "./apps";
-import { Block, isAwaitingAnswer } from "./blocks";
+import { Block, isAwaitingUser } from "./blocks";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { MethodCall } from "./kaja";
 import { ConsoleItem, Run } from "./runs";
@@ -150,10 +150,13 @@ function toStoredItem(item: ConsoleItem): StoredItem {
 
 // A question that was never answered is stored as one that was abandoned: the
 // promise it was blocking died with the session, so reading it back as still
-// waiting would show a run parked on an input nothing is listening to.
+// waiting would show a run parked on an input nothing is listening to. A call
+// that was never approved reads back the same way, and it is the truth about it
+// too — nothing sent it.
 function storedBlock(block: Block | undefined): Block | undefined {
   if (block === undefined) return undefined;
-  if (block.kind === "ask" && isAwaitingAnswer(block)) return { ...block, cancelled: true };
+  if (block.kind === "ask" && isAwaitingUser(block)) return { ...block, cancelled: true };
+  if (block.kind === "approve" && isAwaitingUser(block)) return { ...block, decision: "rejected" };
   // A live table's source is a closure, which nothing can store. It reads back
   // as the rows it had, saying so — the same bargain the payloads make, and for
   // the same reason: expiry is bearable when it is stated.

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -1,4 +1,4 @@
-import { Block, blockLabel, isAwaitingAnswer } from "./blocks";
+import { Block, blockLabel, isAwaitingUser } from "./blocks";
 import { isCallInFlight, MethodCall } from "./kaja";
 import { Log, LogLevel } from "./server/api";
 
@@ -104,7 +104,7 @@ export function logsStatus(logs: Log[]): RunStatus {
 // A drawn block has already happened, so it is settled — except an ask, which is
 // the run stopped mid-flight waiting to be answered.
 export function blockStatus(block: Block): RunStatus {
-  return isAwaitingAnswer(block) ? "pending" : "success";
+  return isAwaitingUser(block) ? "pending" : "success";
 }
 
 export function itemStatus(item: ConsoleItem): RunStatus {
@@ -158,7 +158,7 @@ export function groupRuns(runs: Run[], items: ConsoleItem[]): RunGroup[] {
         // either — the script is stopped inside it waiting to be answered.
         inFlight:
           !run.stale &&
-          runItems.some((item) => (item.call !== undefined && isCallInFlight(item.call)) || (item.block !== undefined && isAwaitingAnswer(item.block))),
+          runItems.some((item) => (item.call !== undefined && isCallInFlight(item.call)) || (item.block !== undefined && isAwaitingUser(item.block))),
         failures: runItems.filter((item) => itemStatus(item) === "error").length,
       };
     });
@@ -178,7 +178,7 @@ export function callCount(group: RunGroup): number {
 // The question the run is stopped on, if it is stopped on one. This is what puts
 // a dot on the Canvas tab and an amber bar at the tail of the log.
 export function awaitingItem(group: RunGroup): ConsoleItem | undefined {
-  return group.items.find((item) => item.block !== undefined && isAwaitingAnswer(item.block));
+  return group.items.find((item) => item.block !== undefined && isAwaitingUser(item.block));
 }
 
 // Whether the run drew anything of its own. A run that only made calls has a

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -6,6 +6,7 @@ function makeKaja(): Kaja {
   return new Kaja(
     () => {},
     async () => "",
+    async () => {},
     () => {},
   );
 }

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { AskCancelledError, Kaja } from "./kaja";
+import { ApprovalRejectedError, AskCancelledError, Kaja } from "./kaja";
 import { Client, App, serviceId } from "./apps";
 import { printStatements } from "./appLoader";
 
@@ -134,9 +134,9 @@ export function runTask(code: string, kaja: Kaja, apps: App[], onError: (error: 
     .then(
       () => {},
       (err: unknown) => {
-        // A cancelled prompt or an aborted run simply stops the script; surface
-        // everything else.
-        if (err instanceof AskCancelledError || signal?.aborted) return;
+        // A cancelled prompt, a call that wasn't approved, or an aborted run
+        // simply stops the script; surface everything else.
+        if (err instanceof AskCancelledError || err instanceof ApprovalRejectedError || signal?.aborted) return;
         onError(err);
       },
     )
@@ -184,6 +184,9 @@ export async function runTaskCaptured(code: string, kaja: Kaja, apps: App[]): Pr
   } catch (err) {
     if (err instanceof AskCancelledError) {
       return { console: lines, error: "Script cancelled by user." };
+    }
+    if (err instanceof ApprovalRejectedError) {
+      return { console: lines, error: `Script stopped: ${err.message}.` };
     }
     return { console: lines, error: err instanceof Error ? err.message : String(err) };
   }


### PR DESCRIPTION
`kaja.approve(Shows.CreateShow({ … }))` draws the call and its request on the run's canvas and parks the run there — Approve sends it and hands back the response, Stop ends the script.

That needs a call that hasn't happened yet, so a method now hands back a `Call` rather than a `Promise`: a call starts when it is awaited, or at the end of the tick if nothing has claimed it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLPPmSypbGvEgNzUdiKK5)_