### PR TITLE
Replaced kaja.ask with typed asks: askStr, askInt and askSelect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ selection, the tab and the view as they were left.
 ## The canvas is what a run drew
 
 **A script says what it made, never how it looks.** The block set is closed and
-tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask` — and
+tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask.*` — and
 that is the guard, not a starting point: the moment a script can paint pixels the
 console is a rendering engine and every block becomes a support surface. There is
 no `kaja.html`, no styling arguments, no layout control.
@@ -440,10 +440,27 @@ no `kaja.html`, no styling arguments, no layout control.
   the above and it is the double-statement problem again — an index of the same
   calls sitting over the content. The fold has to *be* how a call renders in the
   flow, not a summary added over it.
-- **A block that asks is a block that pauses the run.** `kaja.ask` is drawn where
-  it happened and the canvas stops there — the empty space under it *is* the
-  pause. Answering appends the next block. A dialogue is not a fifth block type;
-  it is what a sequence of asks reads as.
+- **A block that asks is a block that pauses the run.** `kaja.ask.*` is drawn
+  where it happened and the canvas stops there — the empty space under it *is*
+  the pause. Answering appends the next block. A dialogue is not a fifth block
+  type; it is what a sequence of asks reads as.
+- **An ask asks for a kind of thing, and hands that kind back.** There is one
+  verb per kind — `kaja.ask.str`, `kaja.ask.int`, `kaja.ask.select(question,
+  options)` — and no general `ask` under them, because a script that asks for
+  text and parses it has moved the parse a line too late to say anything useful
+  about a typo. `str` rather than `string` or `text`: `kaja.text` already means
+  *draw a line*, and `str`/`int` are the same length as each other, which is
+  what makes the pair readable. The kind is on the **block** (`answerType`, plus
+  a select's `choices`), not on the script, because the canvas is what draws the
+  control and checks the answer, and a run read back has to redraw the question
+  it asked. `ask.ts` holds that check, so the canvas, the fallback dialog and
+  the value handed to the script are three readings of one rule. An int field
+  will not submit anything that isn't a whole number — that is the whole point,
+  and `3.5` is refused rather than truncated. A select is a list rather than a
+  field, so there is nothing to validate; its answer travels as the **label**,
+  which is what the canvas showed and what a stored run reads back without its
+  script, and `kaja.ask.select` maps it to the value beside it. Empty text
+  answers a `str`: the script asked for a string and `""` is one.
 - **Splitting the views reintroduces exactly one problem: a run can be waiting on
   the tab you are not looking at.** So a parked run says so three times before
   you can leave it — an amber dot on the Canvas tab, an amber bar at the tail of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ selection, the tab and the view as they were left.
 ## The canvas is what a run drew
 
 **A script says what it made, never how it looks.** The block set is closed and
-tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask.*` — and
+tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask*` — and
 that is the guard, not a starting point: the moment a script can paint pixels the
 console is a rendering engine and every block becomes a support surface. There is
 no `kaja.html`, no styling arguments, no layout control.
@@ -440,16 +440,16 @@ no `kaja.html`, no styling arguments, no layout control.
   the above and it is the double-statement problem again — an index of the same
   calls sitting over the content. The fold has to *be* how a call renders in the
   flow, not a summary added over it.
-- **A block that asks is a block that pauses the run.** `kaja.ask.*` is drawn
+- **A block that asks is a block that pauses the run.** `kaja.ask*` is drawn
   where it happened and the canvas stops there — the empty space under it *is*
   the pause. Answering appends the next block. A dialogue is not a fifth block
   type; it is what a sequence of asks reads as.
 - **An ask asks for a kind of thing, and hands that kind back.** There is one
-  verb per kind — `kaja.ask.str`, `kaja.ask.int`, `kaja.ask.select(question,
-  options)` — and no general `ask` under them, because a script that asks for
+  verb per kind — `kaja.askStr`, `kaja.askInt`, `kaja.askSelect(question,
+  options)` — and no general `ask` beside them, because a script that asks for
   text and parses it has moved the parse a line too late to say anything useful
-  about a typo. `str` rather than `string` or `text`: `kaja.text` already means
-  *draw a line*, and `str`/`int` are the same length as each other, which is
+  about a typo. `Str` rather than `String` or `Text`: `kaja.text` already means
+  *draw a line*, and `Str`/`Int` are the same length as each other, which is
   what makes the pair readable. The kind is on the **block** (`answerType`, plus
   a select's `choices`), not on the script, because the canvas is what draws the
   control and checks the answer, and a run read back has to redraw the question
@@ -459,8 +459,13 @@ no `kaja.html`, no styling arguments, no layout control.
   and `3.5` is refused rather than truncated. A select is a list rather than a
   field, so there is nothing to validate; its answer travels as the **label**,
   which is what the canvas showed and what a stored run reads back without its
-  script, and `kaja.ask.select` maps it to the value beside it. Empty text
+  script, and `kaja.askSelect` maps it to the value beside it. Empty text
   answers a `str`: the script asked for a string and `""` is one.
+- **The `kaja` object is flat.** `askStr`/`askInt`/`askSelect`, `uuidV4` — not
+  `ask.str` or `uuid.v4`. The object is small enough that grouping buys nothing,
+  and it is met through the editor's completion list: one `kaja.` shows every
+  verb there is, where a namespace shows a noun you have to open to find out
+  what is under it. A prefix sorts the related ones together anyway.
 - **Splitting the views reintroduces exactly one problem: a run can be waiting on
   the tab you are not looking at.** So a parked run says so three times before
   you can leave it — an amber dot on the Canvas tab, an amber bar at the tail of

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -134,12 +134,12 @@ who opens the script gets the rest without running anything.
 ## The script runtime
 
 - **No interactive input.** `prompt`, `alert` and `confirm` do nothing and return
-  immediately. `kaja.ask.str/int/select` are how a script asks, and they park the
-  run on a human — only reach for one when a person is at the app.
+  immediately. `kaja.askStr/askInt/askSelect` are how a script asks, and they park
+  the run on a human — only reach for one when a person is at the app.
 - **Top-level `await` works**: the body runs inside an `async` function.
 - There is no DOM and no file system. What a script reaches, it reaches through
   the apps in `list_services`.
-- `crypto.randomUUID()` is available, as is `kaja.uuid.v4()`.
+- `crypto.randomUUID()` is available, as is `kaja.uuidV4()`.
 - The `kaja` object is imported with `import { kaja } from "kaja";`.
 
 ## The `kaja` object
@@ -153,14 +153,14 @@ What each member is for:
 - `kaja.table(columns, rows?)` — draw a table; the handle's `.row(...cells)`
   appends to it. `rows` can be an array, or a source (an async generator) the
   table pulls a page at a time as it is paged through.
-- `kaja.ask.str(question)`, `kaja.ask.int(question)`,
-  `kaja.ask.select(question, options)` — ask the user for text, a whole number,
+- `kaja.askStr(question)`, `kaja.askInt(question)`,
+  `kaja.askSelect(question, options)` — ask the user for text, a whole number,
   or one of a list; each blocks on a human and hands back the kind of thing it
   asked for, so never ask for text and parse it yourself.
 - `kaja.variables.<name>` — the user's configured variables, resolved.
 - `kaja.input?: string` — text supplied when the script is launched from the
   macOS "Run Kaja Script" text service. `undefined` when run any other way.
-- `kaja.uuid.v4(): string` — a random version 4 UUID.
+- `kaja.uuidV4(): string` — a random version 4 UUID.
 - `kaja.value(json)`, `kaja.struct(json)`, `kaja.listValue(json)` — build a field
   typed `Value`, `Struct` or `ListValue`. Those hold **any** JSON, and their wire
   shape is a `kind` oneof you must never write by hand and never re-implement as

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -134,8 +134,8 @@ who opens the script gets the rest without running anything.
 ## The script runtime
 
 - **No interactive input.** `prompt`, `alert` and `confirm` do nothing and return
-  immediately. `kaja.ask()` is how a script asks, and it parks the run on a
-  human — only reach for it when a person is at the app.
+  immediately. `kaja.ask.str/int/select` are how a script asks, and they park the
+  run on a human — only reach for one when a person is at the app.
 - **Top-level `await` works**: the body runs inside an `async` function.
 - There is no DOM and no file system. What a script reaches, it reaches through
   the apps in `list_services`.
@@ -153,7 +153,10 @@ What each member is for:
 - `kaja.table(columns, rows?)` — draw a table; the handle's `.row(...cells)`
   appends to it. `rows` can be an array, or a source (an async generator) the
   table pulls a page at a time as it is paged through.
-- `kaja.ask(message): Promise<string>` — ask the user; blocks on a human.
+- `kaja.ask.str(question)`, `kaja.ask.int(question)`,
+  `kaja.ask.select(question, options)` — ask the user for text, a whole number,
+  or one of a list; each blocks on a human and hands back the kind of thing it
+  asked for, so never ask for text and parse it yourself.
 - `kaja.variables.<name>` — the user's configured variables, resolved.
 - `kaja.input?: string` — text supplied when the script is launched from the
   macOS "Run Kaja Script" text service. `undefined` when run any other way.

--- a/desktop/mcp/tools.go
+++ b/desktop/mcp/tools.go
@@ -19,7 +19,8 @@ const runtimeNote = "Scripts are TypeScript run inside Kaja: top-level await wor
 	"which the table pulls a page at a time as the reader pages through it (declare a `search` parameter and it is restarted for each search). " +
 	"Your run draws its first page and reports `more: true`; nobody is there to page it, so read the rest with an ordinary loop if you need it. " +
 	"Get the runtime's full declaration with describe_type \"kaja\"; it comes from `import { kaja } from \"kaja\";`. " +
-	"There is no interactive input: `prompt`/`alert`/`confirm` do nothing. Use `kaja.ask()` only when a person is at the app."
+	"There is no interactive input: `prompt`/`alert`/`confirm` do nothing. " +
+	"`kaja.ask.str(q)`, `kaja.ask.int(q)` and `kaja.ask.select(q, options)` park the run on a human, so use them only when a person is at the app."
 
 // toolDefinitions is the static tools/list payload. Schemas are hand-written
 // JSON Schema; keep them in sync with handleToolCall below.

--- a/desktop/mcp/tools.go
+++ b/desktop/mcp/tools.go
@@ -20,7 +20,7 @@ const runtimeNote = "Scripts are TypeScript run inside Kaja: top-level await wor
 	"Your run draws its first page and reports `more: true`; nobody is there to page it, so read the rest with an ordinary loop if you need it. " +
 	"Get the runtime's full declaration with describe_type \"kaja\"; it comes from `import { kaja } from \"kaja\";`. " +
 	"There is no interactive input: `prompt`/`alert`/`confirm` do nothing. " +
-	"`kaja.ask.str(q)`, `kaja.ask.int(q)` and `kaja.ask.select(q, options)` park the run on a human, so use them only when a person is at the app."
+	"`kaja.askStr(q)`, `kaja.askInt(q)` and `kaja.askSelect(q, options)` park the run on a human, so use them only when a person is at the app."
 
 // toolDefinitions is the static tools/list payload. Schemas are hand-written
 // JSON Schema; keep them in sync with handleToolCall below.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { Dialog } from "./components/dialog";
 import { FormControl } from "./components/form-control";
 import { IconButton } from "./components/icon-button";
 import { Input } from "./components/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./components/select";
 import { Braces, Code, FileCode, PenLine, Save as SaveIcon, ScrollText, X } from "lucide-react";
 import * as monaco from "monaco-editor";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -42,7 +43,8 @@ import { Compiler } from "./Compiler";
 import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
 import { Gutter } from "./Gutter";
-import { Block, blockLabel } from "./blocks";
+import { answerPlaceholder, answerProblem, normalizeAnswer } from "./ask";
+import { AskBlock, Block, blockLabel } from "./blocks";
 import { AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { TableView } from "./tableView";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
@@ -263,10 +265,13 @@ export function App() {
   // away with it — the same buffer, now on disk.
   const [saveAs, setSaveAs] = useState<{ name: string; content: string; fromScratchId?: string } | null>(null);
   const [saveAsError, setSaveAsError] = useState<string>();
-  // Active `kaja.ask(...)` prompt; null when no script is waiting for input.
+  // Active `kaja.ask.*` prompt; null when no script is waiting for input. The
+  // question travels as its block, because what is being asked for decides what
+  // the dialog draws — the same reading the canvas makes of the same block.
   const [askPrompt, setAskPrompt] = useState<{
-    message: string;
+    question: AskBlock;
     value: string;
+    problem?: string;
     resolve: (value: string) => void;
     reject: (reason: unknown) => void;
   } | null>(null);
@@ -474,17 +479,19 @@ export function App() {
   );
 
   /**
-   * A `kaja.ask(...)` is answered on the canvas of the run that asked it, so the
+   * A `kaja.ask.*` is answered on the canvas of the run that asked it, so the
    * promise waits here keyed by the block the question was drawn as. A run with
    * no console has no canvas to draw on — an agent running code that was never
    * saved — and falls back to the dialog, which needs no surface of its own.
    */
   const pendingAsksRef = useRef(new Map<string, { resolve: (answer: string) => void; reject: (error: unknown) => void }>());
 
-  const onAsk = useCallback((message: string, blockId: string) => {
+  const onAsk = useCallback((question: AskBlock, blockId: string) => {
     return new Promise<string>((resolve, reject) => {
       if (!currentRunRef.current?.fileId) {
-        setAskPrompt({ message, value: "", resolve, reject });
+        // A select opens on its first option, since the dialog has one field and
+        // it has to hold something.
+        setAskPrompt({ question, value: question.answerType === "select" ? (question.choices?.[0] ?? "") : "", resolve, reject });
         return;
       }
       pendingAsksRef.current.set(blockId, { resolve, reject });
@@ -500,6 +507,19 @@ export function App() {
 
   const onAnswerAsk = useCallback((blockId: string, answer: string) => settleAsk(blockId, (pending) => pending.resolve(answer)), [settleAsk]);
   const onCancelAsk = useCallback((blockId: string) => settleAsk(blockId, (pending) => pending.reject(new AskCancelledError())), [settleAsk]);
+
+  // The dialog checks the answer the way the canvas does, so the same question
+  // is as hard to answer wrongly here as it is there.
+  const submitAskPrompt = useCallback(() => {
+    if (!askPrompt) return;
+    const problem = answerProblem(askPrompt.question.answerType, askPrompt.value);
+    if (problem) {
+      setAskPrompt({ ...askPrompt, problem });
+      return;
+    }
+    askPrompt.resolve(normalizeAnswer(askPrompt.question.answerType, askPrompt.value));
+    setAskPrompt(null);
+  }, [askPrompt]);
 
   const kajaRef = useRef<Kaja>(null);
   if (!kajaRef.current) {
@@ -2424,27 +2444,41 @@ export function App() {
             {
               content: "Submit",
               variant: "default",
-              onClick: () => {
-                askPrompt.resolve(askPrompt.value);
-                setAskPrompt(null);
-              },
+              onClick: () => submitAskPrompt(),
             },
           ]}
         >
           <FormControl>
-            <FormControl.Label>{askPrompt.message}</FormControl.Label>
-            <Input
-              autoFocus
-              value={askPrompt.value}
-              onChange={(e) => setAskPrompt((prev) => (prev ? { ...prev, value: e.target.value } : prev))}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  askPrompt.resolve(askPrompt.value);
-                  setAskPrompt(null);
-                }
-              }}
-            />
+            <FormControl.Label>{askPrompt.question.question}</FormControl.Label>
+            {askPrompt.question.answerType === "select" ? (
+              <Select value={askPrompt.value} onValueChange={(value) => setAskPrompt((prev) => (prev ? { ...prev, value: value ?? "" } : prev))}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(askPrompt.question.choices ?? []).map((choice, index) => (
+                    <SelectItem key={index} value={choice}>
+                      {choice}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                autoFocus
+                inputMode={askPrompt.question.answerType === "int" ? "numeric" : undefined}
+                placeholder={answerPlaceholder(askPrompt.question.answerType)}
+                value={askPrompt.value}
+                onChange={(e) => setAskPrompt((prev) => (prev ? { ...prev, value: e.target.value, problem: undefined } : prev))}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    submitAskPrompt();
+                  }
+                }}
+              />
+            )}
+            {askPrompt.problem && <FormControl.Validation variant="error">{askPrompt.problem}</FormControl.Validation>}
           </FormControl>
         </Dialog>
       )}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -265,7 +265,7 @@ export function App() {
   // away with it — the same buffer, now on disk.
   const [saveAs, setSaveAs] = useState<{ name: string; content: string; fromScratchId?: string } | null>(null);
   const [saveAsError, setSaveAsError] = useState<string>();
-  // Active `kaja.ask.*` prompt; null when no script is waiting for input. The
+  // Active `kaja.ask*` prompt; null when no script is waiting for input. The
   // question travels as its block, because what is being asked for decides what
   // the dialog draws — the same reading the canvas makes of the same block.
   const [askPrompt, setAskPrompt] = useState<{
@@ -479,7 +479,7 @@ export function App() {
   );
 
   /**
-   * A `kaja.ask.*` is answered on the canvas of the run that asked it, so the
+   * A `kaja.ask*` is answered on the canvas of the run that asked it, so the
    * promise waits here keyed by the block the question was drawn as. A run with
    * no console has no canvas to draw on — an agent running code that was never
    * saved — and falls back to the dialog, which needs no surface of its own.

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight, Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { answerPlaceholder, answerProblem, AskAnswerType, normalizeAnswer } from "./ask";
 import { AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
 import { CanvasEntry, foldCalls, groupDuration, groupFailures, groupKeyLabel } from "./callGroups";
 import { cn } from "./cn";
@@ -297,45 +298,145 @@ interface AskProps {
  * The question the run is stopped on. Amber is Kaja's "needs you" colour, and it
  * is the whole signal here: the block, the Canvas tab's dot and the run pill all
  * carry it, so a parked run is findable from wherever you happen to be.
+ *
+ * What is drawn under the question is what the script asked for. A select is a
+ * list rather than a field, because an answer that can only be one of five
+ * things should not be typeable as a sixth; anything else is a field that
+ * refuses to submit until the answer is the kind of thing that was asked for.
  */
 Canvas.Ask = function ({ id, block, onAnswer, onCancelAsk }: AskProps) {
-  const [value, setValue] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
   const waiting = block.answer === undefined && !block.cancelled;
-
-  useEffect(() => {
-    if (waiting) inputRef.current?.focus();
-  }, [waiting]);
 
   return (
     <div className={cn("flex flex-col gap-2 rounded-r-md border-l-2 py-2.5 pl-3 pr-3", waiting ? "border-amber-500 bg-amber-500/10" : "border-border bg-card")}>
       <div className={cn("whitespace-pre-wrap break-words", waiting ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground")}>{block.question}</div>
-      {waiting ? (
-        <div className="flex items-center gap-2 rounded-md border border-amber-500 bg-background px-2.5 py-1.5">
-          <input
-            ref={inputRef}
-            data-testid="canvas-ask-input"
-            className="min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
-            placeholder="Answer…"
-            value={value}
-            onChange={(event) => setValue(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                onAnswer(id, value);
-              } else if (event.key === "Escape") {
-                event.preventDefault();
-                onCancelAsk(id);
-              }
-            }}
-          />
-          <span className="shrink-0 text-muted-foreground">⏎</span>
-        </div>
-      ) : (
+      {!waiting ? (
         <div className={cn("break-words", block.cancelled ? "italic text-muted-foreground" : "text-foreground")}>
           {block.cancelled ? "Cancelled" : block.answer}
         </div>
+      ) : block.answerType === "select" ? (
+        <Canvas.AskChoices choices={block.choices ?? []} onAnswer={(answer) => onAnswer(id, answer)} onCancel={() => onCancelAsk(id)} />
+      ) : (
+        <Canvas.AskField answerType={block.answerType} onAnswer={(answer) => onAnswer(id, answer)} onCancel={() => onCancelAsk(id)} />
       )}
+    </div>
+  );
+};
+
+interface AskFieldProps {
+  answerType: AskAnswerType;
+  onAnswer: (answer: string) => void;
+  onCancel: () => void;
+}
+
+// A typed answer is checked here rather than in the script, which is the whole
+// point of asking for one: the problem is stated under the field, while the
+// person who typed it is still looking at it.
+Canvas.AskField = function ({ answerType, onAnswer, onCancel }: AskFieldProps) {
+  const [value, setValue] = useState("");
+  const [problem, setProblem] = useState<string>();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const submit = () => {
+    const said = answerProblem(answerType, value);
+    if (said) {
+      setProblem(said);
+      return;
+    }
+    onAnswer(normalizeAnswer(answerType, value));
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className={cn("flex items-center gap-2 rounded-md border bg-background px-2.5 py-1.5", problem ? "border-destructive" : "border-amber-500")}>
+        <input
+          ref={inputRef}
+          data-testid="canvas-ask-input"
+          className="min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
+          placeholder={answerPlaceholder(answerType)}
+          inputMode={answerType === "int" ? "numeric" : undefined}
+          value={value}
+          onChange={(event) => {
+            setValue(event.target.value);
+            setProblem(undefined);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              submit();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              onCancel();
+            }
+          }}
+        />
+        <span className="shrink-0 text-muted-foreground">⏎</span>
+      </div>
+      {problem && <div className="text-destructive">{problem}</div>}
+    </div>
+  );
+};
+
+interface AskChoicesProps {
+  choices: string[];
+  onAnswer: (answer: string) => void;
+  onCancel: () => void;
+}
+
+// The options, as a list you walk with the arrow keys. It is a listbox rather
+// than a Select popup because the canvas has the room and a question the run is
+// parked on should not need a click to read.
+Canvas.AskChoices = function ({ choices, onAnswer, onCancel }: AskChoicesProps) {
+  const [active, setActive] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    listRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={listRef}
+      role="listbox"
+      tabIndex={0}
+      data-testid="canvas-ask-choices"
+      className="flex flex-col gap-1 outline-none"
+      onKeyDown={(event) => {
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          event.preventDefault();
+          const step = event.key === "ArrowDown" ? 1 : choices.length - 1;
+          setActive((index) => (index + step) % choices.length);
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          if (choices[active] !== undefined) onAnswer(choices[active]);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          onCancel();
+        }
+      }}
+    >
+      {choices.map((choice, index) => (
+        <button
+          key={index}
+          type="button"
+          role="option"
+          aria-selected={index === active}
+          data-testid="canvas-ask-choice"
+          className={cn(
+            "flex items-center gap-2 rounded-md border bg-background px-2.5 py-1.5 text-left",
+            index === active ? "border-amber-500" : "border-border hover:border-amber-500/50",
+          )}
+          onMouseEnter={() => setActive(index)}
+          onClick={() => onAnswer(choice)}
+        >
+          <span className="min-w-0 flex-1 break-words text-foreground">{choice}</span>
+          {index === active && <span className="shrink-0 text-muted-foreground">⏎</span>}
+        </button>
+      ))}
     </div>
   );
 };

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -119,7 +119,7 @@ monaco.languages.registerCompletionItemProvider("typescript", {
           label: { label: "kaja", description: 'import from "kaja"' },
           kind: monaco.languages.CompletionItemKind.Variable,
           detail: 'Add import from "kaja"',
-          documentation: "The Kaja runtime object (kaja.table, kaja.text, kaja.ask.*, kaja.variables, kaja.value).",
+          documentation: "The Kaja runtime object (kaja.table, kaja.text, kaja.askStr, kaja.variables, kaja.value).",
           insertText: "kaja",
           range: new monaco.Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn),
           command: { id: KAJA_IMPORT_COMMAND, title: 'Add import from "kaja"', arguments: [model.uri.toString()] },

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -119,7 +119,7 @@ monaco.languages.registerCompletionItemProvider("typescript", {
           label: { label: "kaja", description: 'import from "kaja"' },
           kind: monaco.languages.CompletionItemKind.Variable,
           detail: 'Add import from "kaja"',
-          documentation: "The Kaja runtime object (kaja.table, kaja.text, kaja.ask, kaja.variables, kaja.value).",
+          documentation: "The Kaja runtime object (kaja.table, kaja.text, kaja.ask.*, kaja.variables, kaja.value).",
           insertText: "kaja",
           range: new monaco.Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn),
           command: { id: KAJA_IMPORT_COMMAND, title: 'Add import from "kaja"', arguments: [model.uri.toString()] },

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -171,7 +171,7 @@ interface SidebarProps {
   runningFileIds?: Set<string>;
   // Of those, the ones an agent started rather than you.
   agentFileIds?: Set<string>;
-  // Files whose run has stopped on a `kaja.ask(...)` and needs an answer.
+  // Files whose run has stopped on a `kaja.ask.*` and needs an answer.
   waitingFileIds?: Set<string>;
   // A read-only configuration doesn't disable the verbs that change apps, it
   // doesn't offer them: New and Delete both go, so there is no way to reach a

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -171,7 +171,7 @@ interface SidebarProps {
   runningFileIds?: Set<string>;
   // Of those, the ones an agent started rather than you.
   agentFileIds?: Set<string>;
-  // Files whose run has stopped on a `kaja.ask.*` and needs an answer.
+  // Files whose run has stopped on a `kaja.ask*` and needs an answer.
   waitingFileIds?: Set<string>;
   // A read-only configuration doesn't disable the verbs that change apps, it
   // doesn't offer them: New and Delete both go, so there is no way to reach a

--- a/ui/src/ask.test.ts
+++ b/ui/src/ask.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { answerPlaceholder, answerProblem, normalizeAnswer, parseInteger } from "./ask";
+
+describe("parseInteger", () => {
+  it("reads a whole number, signed or padded", () => {
+    expect(parseInteger("42")).toBe(42);
+    expect(parseInteger("  42  ")).toBe(42);
+    expect(parseInteger("-7")).toBe(-7);
+    expect(parseInteger("+7")).toBe(7);
+    expect(parseInteger("0")).toBe(0);
+  });
+
+  it("refuses anything that isn't one", () => {
+    expect(parseInteger("")).toBeUndefined();
+    expect(parseInteger("3.5")).toBeUndefined();
+    expect(parseInteger("3 apples")).toBeUndefined();
+    expect(parseInteger("1e3")).toBeUndefined();
+    expect(parseInteger("0x10")).toBeUndefined();
+    expect(parseInteger("NaN")).toBeUndefined();
+  });
+
+  it("refuses a number too big to be exact", () => {
+    expect(parseInteger("9007199254740991")).toBe(9007199254740991);
+    expect(parseInteger("9007199254740993")).toBeUndefined();
+  });
+});
+
+describe("answerProblem", () => {
+  it("takes any text as a string, including none", () => {
+    expect(answerProblem("str", "")).toBeUndefined();
+    expect(answerProblem("str", "  ")).toBeUndefined();
+    expect(answerProblem("str", "june")).toBeUndefined();
+  });
+
+  it("names what is wrong with an int", () => {
+    expect(answerProblem("int", "42")).toBeUndefined();
+    expect(answerProblem("int", "")).toBe("Enter a whole number");
+    expect(answerProblem("int", "3.5")).toBe("Not a whole number");
+  });
+
+  it("has nothing to say about a select, which can only produce a choice", () => {
+    expect(answerProblem("select", "eu")).toBeUndefined();
+  });
+});
+
+describe("normalizeAnswer", () => {
+  it("records the number that was read, not the spacing it was typed with", () => {
+    expect(normalizeAnswer("int", "  +42 ")).toBe("42");
+    expect(normalizeAnswer("str", "  june ")).toBe("  june ");
+  });
+});
+
+describe("answerPlaceholder", () => {
+  it("says what the field is after", () => {
+    expect(answerPlaceholder("int")).toBe("Whole number…");
+    expect(answerPlaceholder("str")).toBe("Answer…");
+  });
+});

--- a/ui/src/ask.ts
+++ b/ui/src/ask.ts
@@ -1,0 +1,51 @@
+// What an ask is asking for, and the one rule its answer has to satisfy.
+//
+// It lives here rather than in the block or in the canvas because three places
+// need the same reading of it: the canvas draws the control, the fallback dialog
+// draws the same control without a canvas, and `kaja.ask.*` hands the script
+// back the kind of thing it asked for. The point of the typed asks is that the
+// parse happens where the person who typed it can still fix it, so the check has
+// to be in front of them rather than in the script a line later.
+
+/** The kinds of thing a script can ask for. */
+export type AskAnswerType = "str" | "int" | "select";
+
+const INTEGER = /^[+-]?\d+$/;
+
+/**
+ * The whole number this text is, or undefined if it isn't one. Strict on
+ * purpose: "3.5" and "3 apples" are not whole numbers, and quietly taking the 3
+ * out of either is the bug the typed ask exists to prevent.
+ */
+export function parseInteger(text: string): number | undefined {
+  const trimmed = text.trim();
+  if (!INTEGER.test(trimmed)) return undefined;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+/**
+ * Why this text doesn't answer the question, or undefined if it does. An empty
+ * answer is a valid string — the script asked for text and got text — so only an
+ * int has anything to reject.
+ */
+export function answerProblem(answerType: AskAnswerType, text: string): string | undefined {
+  if (answerType !== "int") return undefined;
+  if (parseInteger(text) !== undefined) return undefined;
+  return text.trim() === "" ? "Enter a whole number" : "Not a whole number";
+}
+
+/**
+ * The answer as it is recorded, once it passes. An int is normalised, so the run
+ * stores the number that was read rather than the spacing it was typed with.
+ */
+export function normalizeAnswer(answerType: AskAnswerType, text: string): string {
+  if (answerType !== "int") return text;
+  const value = parseInteger(text);
+  return value === undefined ? text : String(value);
+}
+
+/** What the field says before anything is typed into it. */
+export function answerPlaceholder(answerType: AskAnswerType): string {
+  return answerType === "int" ? "Whole number…" : "Answer…";
+}

--- a/ui/src/ask.ts
+++ b/ui/src/ask.ts
@@ -2,7 +2,7 @@
 //
 // It lives here rather than in the block or in the canvas because three places
 // need the same reading of it: the canvas draws the control, the fallback dialog
-// draws the same control without a canvas, and `kaja.ask.*` hands the script
+// draws the same control without a canvas, and `kaja.askStr`/`askInt`/`askSelect` hand the script
 // back the kind of thing it asked for. The point of the typed asks is that the
 // parse happens where the person who typed it can still fix it, so the check has
 // to be in front of them rather than in the script a line later.

--- a/ui/src/blocks.test.ts
+++ b/ui/src/blocks.test.ts
@@ -3,14 +3,14 @@ import { Block, blockLabel, blockText, formatCell, isAwaitingAnswer } from "./bl
 
 describe("isAwaitingAnswer", () => {
   it("is true only for a question nobody has answered", () => {
-    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?" })).toBe(true);
-    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe(false);
+    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", answerType: "str" })).toBe(true);
+    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", answerType: "str", answer: "june" })).toBe(false);
   });
 
   // A cancelled ask stopped the script rather than parking it, so the run is
   // over — showing it as waiting would offer an input nothing is listening to.
   it("is false for a question that was cancelled", () => {
-    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", cancelled: true })).toBe(false);
+    expect(isAwaitingAnswer({ kind: "ask", question: "Which ledger?", answerType: "str", cancelled: true })).toBe(false);
   });
 
   it("is false for anything a run merely drew", () => {
@@ -29,7 +29,7 @@ describe("blockLabel", () => {
   });
 
   it("names an ask by the question it asked", () => {
-    expect(blockLabel({ kind: "ask", question: "Which ledger?" })).toBe("Which ledger?");
+    expect(blockLabel({ kind: "ask", question: "Which ledger?", answerType: "str" })).toBe("Which ledger?");
   });
 });
 
@@ -42,7 +42,7 @@ describe("blockText", () => {
   });
 
   it("copies a question with what it was answered", () => {
-    expect(blockText({ kind: "ask", question: "Which ledger?", answer: "june" })).toBe("Which ledger?\njune");
+    expect(blockText({ kind: "ask", question: "Which ledger?", answerType: "str", answer: "june" })).toBe("Which ledger?\njune");
   });
 });
 

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -1,3 +1,5 @@
+import { AskAnswerType } from "./ask";
+
 /**
  * What a run drew. A script says what it made, never how it looks, so the set is
  * closed and small — the canvas renders these four and nothing else. The moment
@@ -56,6 +58,15 @@ export interface TableBlock {
 export interface AskBlock {
   kind: "ask";
   question: string;
+  // What is being asked for. The block carries it rather than the script,
+  // because the canvas is what has to draw the control and check the answer, and
+  // a run read back has to draw the same question it asked.
+  answerType: AskAnswerType;
+  // The labels a select offered, in the order it offered them. The answer is one
+  // of these, which is what makes a stored select readable without its script.
+  choices?: string[];
+  // Always text, whatever was asked for — a block is stored as itself, and the
+  // typed value is the script's copy rather than the run's record.
   answer?: string;
   cancelled?: boolean;
 }

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,10 +1,11 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
+import { parseInteger } from "./ask";
 import { AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
 import { pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
-// Thrown when the user cancels a `kaja.ask(...)` prompt. The task runner
+// Thrown when the user cancels a `kaja.ask.*` prompt. The task runner
 // swallows it so a cancelled prompt quietly stops the script.
 export class AskCancelledError extends Error {
   constructor() {
@@ -14,10 +15,29 @@ export class AskCancelledError extends Error {
 }
 
 // The question is asked by the block; this is what waits for it to be answered.
-// The id is what the answer comes back against, so an ask on a canvas nobody is
-// looking at is still the one that resolves.
+// The whole block goes, not just its text, because what is being asked for
+// decides what is drawn. The id is what the answer comes back against, so an ask
+// on a canvas nobody is looking at is still the one that resolves.
 export interface AskRequest {
-  (message: string, blockId: string): Promise<string>;
+  (question: AskBlock, blockId: string): Promise<string>;
+}
+
+/** An option a select offers when the label isn't the value. */
+export interface Choice<V> {
+  label: string;
+  value: V;
+}
+
+/**
+ * Ask the user something and park the run on the answer. One verb per kind of
+ * thing, because the alternative is every script parsing what it just asked for
+ * — and parsing it a line too late to say anything useful about a typo.
+ */
+export interface Ask {
+  str(question: string): Promise<string>;
+  int(question: string): Promise<number>;
+  select(question: string, options: readonly string[]): Promise<string>;
+  select<V>(question: string, options: readonly Choice<V>[]): Promise<V>;
 }
 
 // A block arriving, or the same block again with more in it.
@@ -185,19 +205,41 @@ export class Kaja {
   }
 
   /**
-   * Pause the script and ask the user for input. The question is drawn on the
-   * run's canvas where it happened, and the canvas stops there until it is
-   * answered — the empty space under it is the pause. Resolves with the
-   * submitted text; rejects (aborting the script) if the user cancels.
+   * Pause the script and ask the user for something. The question is drawn on
+   * the run's canvas where it happened, and the canvas stops there until it is
+   * answered — the empty space under it is the pause. Each verb hands back the
+   * kind of thing it asked for, so a bad answer is rejected in front of the
+   * person who typed it; a cancel aborts the script.
    */
-  async ask(message: string): Promise<string> {
+  readonly ask: Ask = {
+    str: (question: string): Promise<string> => this.#ask({ kind: "ask", question, answerType: "str" }, (answer) => answer),
+
+    // The answer has already been checked against parseInteger on the way in —
+    // the canvas will not submit anything else — so this is a re-read, not a
+    // second parse with its own opinion.
+    int: (question: string): Promise<number> => this.#ask({ kind: "ask", question, answerType: "int" }, (answer) => parseInteger(answer) ?? Number.NaN),
+
+    select: (question: string, options: readonly (string | Choice<any>)[]): Promise<any> => {
+      if (options.length === 0) throw new Error("kaja.ask.select: options must not be empty");
+      const choices = options.map((option) => (typeof option === "string" ? option : formatCell(option.label)));
+      return this.#ask({ kind: "ask", question, answerType: "select", choices }, (answer) => {
+        // The answer comes back as the label, because that is what was on the
+        // canvas and what a stored run reads back without its script. Two
+        // options under one label are one option to whoever picked it, so the
+        // first is the honest reading rather than an error nobody can act on.
+        const picked = options[choices.indexOf(answer)] ?? options[0];
+        return typeof picked === "string" ? picked : picked.value;
+      });
+    },
+  };
+
+  async #ask<T>(question: AskBlock, take: (answer: string) => T): Promise<T> {
     const blockId = newBlockId();
-    const question: AskBlock = { kind: "ask", question: message };
     this.#onBlockUpdate(blockId, question);
     try {
-      const answer = await this.#onAsk(message, blockId);
+      const answer = await this.#onAsk(question, blockId);
       this.#onBlockUpdate(blockId, { ...question, answer });
-      return answer;
+      return take(answer);
     } catch (error) {
       this.#onBlockUpdate(blockId, { ...question, cancelled: true });
       throw error;

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -5,7 +5,7 @@ import { AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlo
 import { pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
-// Thrown when the user cancels a `kaja.ask.*` prompt. The task runner
+// Thrown when the user cancels a `kaja.ask*` prompt. The task runner
 // swallows it so a cancelled prompt quietly stops the script.
 export class AskCancelledError extends Error {
   constructor() {
@@ -22,22 +22,10 @@ export interface AskRequest {
   (question: AskBlock, blockId: string): Promise<string>;
 }
 
-/** An option a select offers when the label isn't the value. */
+/** An option askSelect offers when the label isn't the value. */
 export interface Choice<V> {
   label: string;
   value: V;
-}
-
-/**
- * Ask the user something and park the run on the answer. One verb per kind of
- * thing, because the alternative is every script parsing what it just asked for
- * — and parsing it a line too late to say anything useful about a typo.
- */
-export interface Ask {
-  str(question: string): Promise<string>;
-  int(question: string): Promise<number>;
-  select(question: string, options: readonly string[]): Promise<string>;
-  select<V>(question: string, options: readonly Choice<V>[]): Promise<V>;
 }
 
 // A block arriving, or the same block again with more in it.
@@ -180,21 +168,6 @@ export class Kaja {
   // holds - scripts are the desktop only, where there is no remote browser
   // being handed a value it shouldn't have.
   variables: { [key: string]: string } = {};
-  // UUID helpers for scripts, e.g. `kaja.uuid.v4()`.
-  readonly uuid = {
-    v4(): string {
-      if (typeof crypto.randomUUID === "function") {
-        return crypto.randomUUID();
-      }
-      // crypto.randomUUID is only available in secure contexts; fall back to
-      // building a v4 UUID from random bytes.
-      const bytes = crypto.getRandomValues(new Uint8Array(16));
-      bytes[6] = (bytes[6] & 0x0f) | 0x40;
-      bytes[8] = (bytes[8] & 0x3f) | 0x80;
-      const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
-    },
-  };
   #onAsk: AskRequest;
   #onBlockUpdate: BlockUpdate;
 
@@ -205,33 +178,42 @@ export class Kaja {
   }
 
   /**
-   * Pause the script and ask the user for something. The question is drawn on
-   * the run's canvas where it happened, and the canvas stops there until it is
-   * answered — the empty space under it is the pause. Each verb hands back the
-   * kind of thing it asked for, so a bad answer is rejected in front of the
-   * person who typed it; a cancel aborts the script.
+   * Ask the user for text. The question is drawn on the run's canvas where it
+   * happened, and the canvas stops there until it is answered — the empty space
+   * under it is the pause. A cancel aborts the script.
    */
-  readonly ask: Ask = {
-    str: (question: string): Promise<string> => this.#ask({ kind: "ask", question, answerType: "str" }, (answer) => answer),
+  askStr(question: string): Promise<string> {
+    return this.#ask({ kind: "ask", question, answerType: "str" }, (answer) => answer);
+  }
 
-    // The answer has already been checked against parseInteger on the way in —
-    // the canvas will not submit anything else — so this is a re-read, not a
-    // second parse with its own opinion.
-    int: (question: string): Promise<number> => this.#ask({ kind: "ask", question, answerType: "int" }, (answer) => parseInteger(answer) ?? Number.NaN),
+  /**
+   * Ask the user for a whole number. The field will not submit anything else,
+   * so this always resolves with a number — the answer has been checked against
+   * parseInteger on the way in, and this is a re-read rather than a second parse
+   * with its own opinion.
+   */
+  askInt(question: string): Promise<number> {
+    return this.#ask({ kind: "ask", question, answerType: "int" }, (answer) => parseInteger(answer) ?? Number.NaN);
+  }
 
-    select: (question: string, options: readonly (string | Choice<any>)[]): Promise<any> => {
-      if (options.length === 0) throw new Error("kaja.ask.select: options must not be empty");
-      const choices = options.map((option) => (typeof option === "string" ? option : formatCell(option.label)));
-      return this.#ask({ kind: "ask", question, answerType: "select", choices }, (answer) => {
-        // The answer comes back as the label, because that is what was on the
-        // canvas and what a stored run reads back without its script. Two
-        // options under one label are one option to whoever picked it, so the
-        // first is the honest reading rather than an error nobody can act on.
-        const picked = options[choices.indexOf(answer)] ?? options[0];
-        return typeof picked === "string" ? picked : picked.value;
-      });
-    },
-  };
+  /**
+   * Ask the user to pick one of a fixed list. Strings resolve as themselves;
+   * { label, value } pairs resolve as the value.
+   */
+  askSelect(question: string, options: readonly string[]): Promise<string>;
+  askSelect<V>(question: string, options: readonly Choice<V>[]): Promise<V>;
+  askSelect(question: string, options: readonly (string | Choice<any>)[]): Promise<any> {
+    if (options.length === 0) throw new Error("kaja.askSelect: options must not be empty");
+    const choices = options.map((option) => (typeof option === "string" ? option : formatCell(option.label)));
+    return this.#ask({ kind: "ask", question, answerType: "select", choices }, (answer) => {
+      // The answer comes back as the label, because that is what was on the
+      // canvas and what a stored run reads back without its script. Two options
+      // under one label are one option to whoever picked it, so the first is the
+      // honest reading rather than an error nobody can act on.
+      const picked = options[choices.indexOf(answer)] ?? options[0];
+      return typeof picked === "string" ? picked : picked.value;
+    });
+  }
 
   async #ask<T>(question: AskBlock, take: (answer: string) => T): Promise<T> {
     const blockId = newBlockId();
@@ -437,6 +419,20 @@ export class Kaja {
 
   listValue(input: JsonValue[]): ListValue {
     return toListValue(input);
+  }
+
+  /** A random version 4 UUID. */
+  uuidV4(): string {
+    if (typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    // crypto.randomUUID is only available in secure contexts; fall back to
+    // building a v4 UUID from random bytes.
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
   }
 }
 

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -83,46 +83,10 @@ export type Rows = Iterable<unknown[]> | AsyncIterable<unknown[]>;
  */
 export type RowSource = Rows | ((search: string) => Rows);
 
-/** An option kaja.ask.select offers when the label isn't the value. */
+/** An option kaja.askSelect offers when the label isn't the value. */
 export interface Choice<V> {
   label: string;
   value: V;
-}
-
-/**
- * Ask the user something and park the run on the answer. One verb per kind of
- * thing, so a script never parses what it just asked for — an answer that isn't
- * a whole number is rejected in front of the person who typed it, rather than
- * turning into NaN a line later.
- */
-export interface Ask {
-  /**
-   * Ask for text.
-   *
-   *   const name = await kaja.ask.str("Which customer?");
-   */
-  str(question: string): Promise<string>;
-  /**
-   * Ask for a whole number. The field will not submit anything else, so this
-   * always resolves with a number.
-   *
-   *   const limit = await kaja.ask.int("How many rows?");
-   */
-  int(question: string): Promise<number>;
-  /**
-   * Ask the user to pick one of a fixed list. Strings resolve as themselves;
-   * give { label, value } pairs and the value comes back, so picking from a list
-   * of records hands you the record.
-   *
-   *   const region = await kaja.ask.select("Which region?", ["eu", "us"]);
-   *
-   *   const show = await kaja.ask.select(
-   *     "Which show?",
-   *     shows.map((show) => ({ label: show.title, value: show })),
-   *   );
-   */
-  select(question: string, options: readonly string[]): Promise<string>;
-  select<V>(question: string, options: readonly Choice<V>[]): Promise<V>;
 }
 
 /** The Kaja runtime object. Import it with: import { kaja } from "kaja"; */
@@ -140,12 +104,35 @@ export declare const kaja: {
    */
   variables: ${kajaVariablesType(variableNames)};
   /**
-   * Pause the script and ask the user for something. The question is drawn on
-   * the run's canvas and the run stops there until it is answered; if the user
-   * cancels, the script stops. Each verb hands back the kind of thing it asked
-   * for, so never ask for text and parse it yourself.
+   * Ask the user for text, and park the run on the answer. The question is
+   * drawn on the run's canvas and the run stops there until it is answered; if
+   * the user cancels, the script stops.
+   *
+   *   const name = await kaja.askStr("Which customer?");
    */
-  ask: Ask;
+  askStr(question: string): Promise<string>;
+  /**
+   * Ask the user for a whole number. The field will not submit anything else,
+   * so this always resolves with a number — never ask for text and parse it
+   * yourself.
+   *
+   *   const limit = await kaja.askInt("How many rows?");
+   */
+  askInt(question: string): Promise<number>;
+  /**
+   * Ask the user to pick one of a fixed list. Strings resolve as themselves;
+   * give { label, value } pairs and the value comes back, so picking from a list
+   * of records hands you the record.
+   *
+   *   const region = await kaja.askSelect("Which region?", ["eu", "us"]);
+   *
+   *   const show = await kaja.askSelect(
+   *     "Which show?",
+   *     shows.map((show) => ({ label: show.title, value: show })),
+   *   );
+   */
+  askSelect(question: string, options: readonly string[]): Promise<string>;
+  askSelect<V>(question: string, options: readonly Choice<V>[]): Promise<V>;
   /**
    * Write a line onto the run's canvas.
    *
@@ -185,15 +172,12 @@ export declare const kaja: {
    *   });
    */
   table(columns: string[], rows?: RowSource, options?: { pageSize?: number }): Table;
-  /** UUID helpers. */
-  uuid: {
-    /**
-     * Generate a random version 4 UUID, e.g. "9b2b1a94-3c6e-4f6e-9d2a-0f6b7c8d9e0f".
-     *
-     *   const id = kaja.uuid.v4();
-     */
-    v4(): string;
-  };
+  /**
+   * Generate a random version 4 UUID, e.g. "9b2b1a94-3c6e-4f6e-9d2a-0f6b7c8d9e0f".
+   *
+   *   const id = kaja.uuidV4();
+   */
+  uuidV4(): string;
   /**
    * Build a google.protobuf.Value from a plain JSON value, instead of writing
    * its oneof out by hand. Objects and arrays are converted all the way down.

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -83,6 +83,48 @@ export type Rows = Iterable<unknown[]> | AsyncIterable<unknown[]>;
  */
 export type RowSource = Rows | ((search: string) => Rows);
 
+/** An option kaja.ask.select offers when the label isn't the value. */
+export interface Choice<V> {
+  label: string;
+  value: V;
+}
+
+/**
+ * Ask the user something and park the run on the answer. One verb per kind of
+ * thing, so a script never parses what it just asked for — an answer that isn't
+ * a whole number is rejected in front of the person who typed it, rather than
+ * turning into NaN a line later.
+ */
+export interface Ask {
+  /**
+   * Ask for text.
+   *
+   *   const name = await kaja.ask.str("Which customer?");
+   */
+  str(question: string): Promise<string>;
+  /**
+   * Ask for a whole number. The field will not submit anything else, so this
+   * always resolves with a number.
+   *
+   *   const limit = await kaja.ask.int("How many rows?");
+   */
+  int(question: string): Promise<number>;
+  /**
+   * Ask the user to pick one of a fixed list. Strings resolve as themselves;
+   * give { label, value } pairs and the value comes back, so picking from a list
+   * of records hands you the record.
+   *
+   *   const region = await kaja.ask.select("Which region?", ["eu", "us"]);
+   *
+   *   const show = await kaja.ask.select(
+   *     "Which show?",
+   *     shows.map((show) => ({ label: show.title, value: show })),
+   *   );
+   */
+  select(question: string, options: readonly string[]): Promise<string>;
+  select<V>(question: string, options: readonly Choice<V>[]): Promise<V>;
+}
+
 /** The Kaja runtime object. Import it with: import { kaja } from "kaja"; */
 export declare const kaja: {
   /**
@@ -98,13 +140,12 @@ export declare const kaja: {
    */
   variables: ${kajaVariablesType(variableNames)};
   /**
-   * Pause the script and ask the user for input. The question is drawn on the
-   * run's canvas and the run stops there until it is answered. Resolves with
-   * the submitted text; if the user cancels, the script stops.
-   *
-   *   const name = await kaja.ask("What's your name?");
+   * Pause the script and ask the user for something. The question is drawn on
+   * the run's canvas and the run stops there until it is answered; if the user
+   * cancels, the script stops. Each verb hands back the kind of thing it asked
+   * for, so never ask for text and parse it yourself.
    */
-  ask(message: string): Promise<string>;
+  ask: Ask;
   /**
    * Write a line onto the run's canvas.
    *

--- a/ui/src/runHistory.test.ts
+++ b/ui/src/runHistory.test.ts
@@ -204,7 +204,7 @@ describe("hasCallsInFlight", () => {
 });
 
 describe("recordBlock", () => {
-  const asked = { kind: "ask", question: "Which ledger?" } as const;
+  const asked = { kind: "ask", question: "Which ledger?", answerType: "str" } as const;
 
   it("keeps a block where it was emitted as it fills in", () => {
     let history: RunHistory = startRun({}, run("r1", "f1"), NOW);

--- a/ui/src/runStore.test.ts
+++ b/ui/src/runStore.test.ts
@@ -111,20 +111,20 @@ describe("blocks in the store", () => {
   it("brings back what a run drew", () => {
     const items: ConsoleItem[] = [
       { id: "b1", runId: "r1", timestamp: NOW, block: { kind: "table", columns: ["id"], rows: [["ac_1"]] } },
-      { id: "b2", runId: "r1", timestamp: NOW, block: { kind: "ask", question: "Which ledger?", answer: "june" } },
+      { id: "b2", runId: "r1", timestamp: NOW, block: { kind: "ask", question: "Which ledger?", answerType: "str", answer: "june" } },
     ];
     const loaded = deserializeFile(serializeFile([run], items, NOW));
     expect(loaded.items.map((item) => item.block)).toEqual([
       { kind: "table", columns: ["id"], rows: [["ac_1"]] },
-      { kind: "ask", question: "Which ledger?", answer: "june" },
+      { kind: "ask", question: "Which ledger?", answerType: "str", answer: "june" },
     ]);
   });
 
   // The promise the question was blocking died with the session, so reading it
   // back as still waiting would offer an input nothing is listening to.
   it("stores a question nobody answered as one that was abandoned", () => {
-    const items: ConsoleItem[] = [{ id: "b1", runId: "r1", timestamp: NOW, block: { kind: "ask", question: "Which ledger?" } }];
+    const items: ConsoleItem[] = [{ id: "b1", runId: "r1", timestamp: NOW, block: { kind: "ask", question: "Which ledger?", answerType: "str" } }];
     const loaded = deserializeFile(serializeFile([run], items, NOW));
-    expect(loaded.items[0].block).toEqual({ kind: "ask", question: "Which ledger?", cancelled: true });
+    expect(loaded.items[0].block).toEqual({ kind: "ask", question: "Which ledger?", answerType: "str", cancelled: true });
   });
 });

--- a/ui/src/runs.test.ts
+++ b/ui/src/runs.test.ts
@@ -155,8 +155,8 @@ describe("the two views", () => {
 });
 
 describe("a run parked on a question", () => {
-  const asked: Block = { kind: "ask", question: "Which ledger?" };
-  const answered: Block = { kind: "ask", question: "Which ledger?", answer: "june" };
+  const asked: Block = { kind: "ask", question: "Which ledger?", answerType: "str" };
+  const answered: Block = { kind: "ask", question: "Which ledger?", answerType: "str", answer: "june" };
 
   it("is still in flight, though nothing is in the air", () => {
     const [group] = groupRuns([run("r1")], [call("a", "r1"), block("b", "r1", asked)]);

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "bun:test";
+import { AskBlock } from "./blocks";
 import { Kaja } from "./kaja";
 import { runTaskCaptured } from "./taskRunner";
 
-function makeKaja(): Kaja {
+function makeKaja(answer: (question: AskBlock) => string = () => ""): Kaja {
   return new Kaja(
     () => {},
-    async () => "",
+    async (question) => answer(question),
     () => {},
   );
 }
@@ -93,11 +94,57 @@ describe("orphaned imports", () => {
   });
 });
 
-describe("kaja.uuid", () => {
+describe("the ask verbs", () => {
+  it("hands back the kind of thing it asked for", async () => {
+    const asked: AskBlock[] = [];
+    const kaja = makeKaja((question) => {
+      asked.push(question);
+      return question.answerType === "int" ? "42" : "june";
+    });
+
+    const run = await runTaskCaptured(
+      `import { kaja } from "kaja";\nconst name = await kaja.askStr("Which ledger?");\nconst count = await kaja.askInt("How many?");\nreturn [name, count, typeof count].join(" ");`,
+      kaja,
+      [],
+    );
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe("june 42 number");
+    expect(asked.map((question) => question.answerType)).toEqual(["str", "int"]);
+  });
+
+  it("offers a select's labels and resolves to the value beside the one picked", async () => {
+    const asked: AskBlock[] = [];
+    const kaja = makeKaja((question) => {
+      asked.push(question);
+      return "Europe";
+    });
+
+    const run = await runTaskCaptured(
+      `import { kaja } from "kaja";\nconst region = await kaja.askSelect("Where?", [{ label: "US", value: "us" }, { label: "Europe", value: "eu" }]);\nreturn region;`,
+      kaja,
+      [],
+    );
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe("eu");
+    expect(asked[0].choices).toEqual(["US", "Europe"]);
+  });
+
+  it("refuses a select with nothing to pick", async () => {
+    const kaja = makeKaja();
+
+    const run = await runTaskCaptured(`import { kaja } from "kaja";\nreturn await kaja.askSelect("Where?", []);`, kaja, []);
+
+    expect(run.error).toContain("options must not be empty");
+  });
+});
+
+describe("kaja.uuidV4", () => {
   it("generates a version 4 UUID from scripts", async () => {
     const kaja = makeKaja();
 
-    const run = await runTaskCaptured(`import { kaja } from "kaja";\nreturn kaja.uuid.v4();`, kaja, []);
+    const run = await runTaskCaptured(`import { kaja } from "kaja";\nreturn kaja.uuidV4();`, kaja, []);
 
     expect(run.error).toBeUndefined();
     expect(run.result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
@@ -105,7 +152,7 @@ describe("kaja.uuid", () => {
 
   it("generates unique values", () => {
     const kaja = makeKaja();
-    expect(kaja.uuid.v4()).not.toBe(kaja.uuid.v4());
+    expect(kaja.uuidV4()).not.toBe(kaja.uuidV4());
   });
 });
 


### PR DESCRIPTION
`kaja.ask` is gone; there is now one verb per kind of thing — `kaja.askStr(question)`, `kaja.askInt(question)` and `kaja.askSelect(question, options)` — so a script never parses what it just asked for, and a bad answer is refused in front of the person who typed it rather than turning into `NaN` a line later.

`askSelect` takes strings or `{ label, value }` pairs, so picking from a list of records hands you the record; the kind lives on the block (`answerType`) because the canvas is what draws the control, and `ask.ts` holds the one check the canvas, the fallback dialog and the script's value all read. `kaja.uuid.v4()` became `kaja.uuidV4()` on the same rule — the object is flat, so one `kaja.` in the editor shows every verb there is.