### PR TITLE
Added "Approve all" to the approve block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,10 +452,30 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
   and an undecided one is stored as not approved on the same rule a hanging ask
   is stored as cancelled. It carries the request rather than a summary of it,
   because what makes a call worth approving is what is in it, and a click away is
-  too far for the one block you are meant to read before deciding. Neither button
+  too far for the one block you are meant to read before deciding. No button
   takes focus: an ask focuses its input for free, but here Enter would send the
-  request, which is the thing this block exists to prevent. There is no "approve
-  all" and no policy — one call, one decision.
+  request, which is the thing this block exists to prevent.
+- **The third button is "Approve all", and what it covers is in its name.** A
+  loop is read a couple of times and then let go, so **Approve all
+  `Shows.CreateShow`** settles this call and every later one to that method; the
+  ones that ride on it draw no block, since a canvas of decisions nobody made is
+  what pressing it was meant to be rid of — they are already cards on the canvas
+  and rows in the log. It is secondary, because reading the next one is still the
+  expected thing to do.
+  - **The scope is the method because that is what the button can honestly say.**
+    A script that also writes somewhere else asks again for that method, which is
+    a click, not a wall. All-methods was the alternative and it cannot be named:
+    it would cover calls you have not seen.
+  - **The lifetime is the run, because anything longer is a policy.**
+    `runTask` clears `_internal.approvedMethods` at the top of every run — both
+    doors, the editor's and the MCP server's — so the guard is back the next time
+    Run is pressed, and nothing about it is ever written to disk. The key is the
+    call's own `Service.Method` label, the same identity the block names.
+  - **The script never learns of it.** `kaja.approve` is unchanged and takes no
+    options: which calls are worth reading one by one is decided in front of
+    them, not written into the loop. The one place it is recorded is `standing`
+    on the block that granted it, which is what a run read back has to say
+    instead of falling silent about a decision made once and used ten times.
 - **Which is only possible because a method hands back a `Call`, not a promise**
   (`Call` in `kaja.ts`, returned by every method `client.ts` builds). **A call
   starts when it is awaited — or at the end of the tick, if nothing has claimed

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -163,7 +163,10 @@ What each member is for:
   asked for, so never ask for text and parse it yourself.
 - `kaja.approve(call): Promise<T>` — hold a call until the user approves it, e.g.
   `await kaja.approve(Shows.CreateShow({ … }))`. The call goes inside the
-  parentheses, and not approving stops the script. Blocks on a human.
+  parentheses, and not approving stops the script. Blocks on a human — though
+  they can press **Approve all**, which settles every later call to the same
+  method in that run without asking again. So wrapping each call of a loop is
+  right: the reader decides where to stop reading, not the script.
 - `kaja.variables.<name>` — the user's configured variables, resolved.
 - `kaja.input?: string` — text supplied when the script is launched from the
   macOS "Run Kaja Script" text service. `undefined` when run any other way.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -44,8 +44,8 @@ import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
 import { Gutter } from "./Gutter";
 import { answerPlaceholder, answerProblem, normalizeAnswer } from "./ask";
-import { ApproveBlock, AskBlock, Block, blockLabel } from "./blocks";
-import { ApprovalRejectedError, AskCancelledError, Kaja, MethodCall } from "./kaja";
+import { ApproveBlock, ApproveGesture, AskBlock, Block, blockLabel } from "./blocks";
+import { ApprovalRejectedError, ApproveDecision, AskCancelledError, Kaja, MethodCall } from "./kaja";
 import { TableView } from "./tableView";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
@@ -278,7 +278,7 @@ export function App() {
   // null when nothing is waiting to be approved.
   const [approvePrompt, setApprovePrompt] = useState<{
     call: ApproveBlock;
-    resolve: () => void;
+    resolve: (decision: ApproveDecision) => void;
     reject: (reason: unknown) => void;
   } | null>(null);
   // Whether the New app dialog is open.
@@ -507,12 +507,14 @@ export function App() {
   }, []);
 
   const onApprove = useCallback((call: ApproveBlock, blockId: string) => {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<ApproveDecision>((resolve, reject) => {
       if (!currentRunRef.current?.fileId) {
         setApprovePrompt({ call, resolve, reject });
         return;
       }
-      pendingPromptsRef.current.set(blockId, { resolve: () => resolve(), reject });
+      // The gesture rides back on the same map an answer does — there is one
+      // thing to say, and which of the two approvals it was is the whole of it.
+      pendingPromptsRef.current.set(blockId, { resolve: (gesture) => resolve(gesture === "all" ? "all" : "approved"), reject });
     });
   }, []);
 
@@ -526,11 +528,12 @@ export function App() {
   const onAnswerAsk = useCallback((blockId: string, answer: string) => settlePrompt(blockId, (pending) => pending.resolve(answer)), [settlePrompt]);
   const onCancelAsk = useCallback((blockId: string) => settlePrompt(blockId, (pending) => pending.reject(new AskCancelledError())), [settlePrompt]);
 
-  // Approve sends the call; Stop rejects it, which stops the script where it
-  // stands. The block records which of the two happened either way.
+  // Approve sends the call, Approve all sends it and every later one to the same
+  // method, and Stop rejects it, which stops the script where it stands. The
+  // block records which of the three happened either way.
   const onDecideApproval = useCallback(
-    (blockId: string, decision: "approved" | "rejected") =>
-      settlePrompt(blockId, (pending) => (decision === "approved" ? pending.resolve("") : pending.reject(new ApprovalRejectedError()))),
+    (blockId: string, gesture: ApproveGesture) =>
+      settlePrompt(blockId, (pending) => (gesture === "rejected" ? pending.reject(new ApprovalRejectedError()) : pending.resolve(gesture))),
     [settlePrompt],
   );
 
@@ -2504,15 +2507,40 @@ export function App() {
         </Dialog>
       )}
       {approvePrompt && (
-        <ConfirmationDialog
+        // The same three decisions the canvas offers, for a run that has no
+        // canvas to draw them on. Dismissing the dialog is not approving, which
+        // is the safe reading of a gesture that said nothing.
+        <Dialog
           title="Approve call"
-          confirmButtonContent="Approve"
-          cancelButtonContent="Stop"
-          onClose={(gesture) => {
-            if (gesture === "confirm") approvePrompt.resolve();
-            else approvePrompt.reject(new ApprovalRejectedError());
+          onClose={() => {
+            approvePrompt.reject(new ApprovalRejectedError());
             setApprovePrompt(null);
           }}
+          footerButtons={[
+            {
+              content: "Stop",
+              onClick: () => {
+                approvePrompt.reject(new ApprovalRejectedError());
+                setApprovePrompt(null);
+              },
+            },
+            {
+              content: `Approve all ${approvePrompt.call.method}`,
+              variant: "secondary",
+              onClick: () => {
+                approvePrompt.resolve("all");
+                setApprovePrompt(null);
+              },
+            },
+            {
+              content: "Approve",
+              variant: "default",
+              onClick: () => {
+                approvePrompt.resolve("approved");
+                setApprovePrompt(null);
+              },
+            },
+          ]}
         >
           <div className="flex flex-col gap-2 font-mono text-xs">
             <div className="text-foreground">{approvePrompt.call.method}</div>
@@ -2520,7 +2548,7 @@ export function App() {
               {approvePrompt.call.request}
             </pre>
           </div>
-        </ConfirmationDialog>
+        </Dialog>
       )}
       {newAppOpen && <NewAppDialog appsPreviewEnabled={previewApps} onClose={() => setNewAppOpen(false)} onSelect={onSelectAppType} />}
       {renameScript && (

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,7 +1,7 @@
 import { ChevronLeft, ChevronRight, Search, ShieldQuestionMark } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { answerPlaceholder, answerProblem, AskAnswerType, normalizeAnswer } from "./ask";
-import { ApproveBlock, AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
+import { ApproveBlock, ApproveGesture, AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
 import { CanvasEntry, foldCalls, groupDuration, groupFailures, groupKeyLabel } from "./callGroups";
 import { cn } from "./cn";
 import { Button } from "./components/button";
@@ -32,9 +32,9 @@ interface CanvasProps {
   selectedItemId?: string;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
-  // One prop for both buttons of an approve block, because there is one decision
+  // One prop for every button of an approve block, because there is one decision
   // to make and the block records it under this name.
-  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
+  onDecide: (blockId: string, gesture: ApproveGesture) => void;
   // Clicking a call card takes you to that call's row in the log, which is where
   // its complete record is. The card can stay minimal because of it.
   onSelectCall: (itemId: string) => void;
@@ -95,9 +95,9 @@ interface EntryProps {
   selectedItemId?: string;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
-  // One prop for both buttons of an approve block, because there is one decision
+  // One prop for every button of an approve block, because there is one decision
   // to make and the block records it under this name.
-  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
+  onDecide: (blockId: string, gesture: ApproveGesture) => void;
   onSelectCall: (itemId: string) => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
@@ -132,9 +132,9 @@ interface BlockProps {
   block: Block;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
-  // One prop for both buttons of an approve block, because there is one decision
+  // One prop for every button of an approve block, because there is one decision
   // to make and the block records it under this name.
-  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
+  onDecide: (blockId: string, gesture: ApproveGesture) => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
@@ -340,7 +340,7 @@ Canvas.Ask = function ({ id, block, onAnswer, onCancelAsk }: AskProps) {
 interface ApproveProps {
   id: string;
   block: ApproveBlock;
-  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
+  onDecide: (blockId: string, gesture: ApproveGesture) => void;
 }
 
 /**
@@ -349,9 +349,15 @@ interface ApproveProps {
  * because of what is in it, so the payload is the block rather than a click
  * away. It wears the same amber as an ask, since it parks the run the same way.
  *
- * Neither button takes focus. An ask focuses its input, which costs nothing;
- * here Enter would send the request, and a key pressed at the wrong moment is
- * exactly what this block exists to prevent.
+ * **Approve all names the method it covers**, because that is the whole question
+ * anyone hesitates over before pressing it, and a button that says "all" and
+ * means "all Shows.CreateShow" is one that has to be learned by being surprised
+ * by it. It is secondary rather than primary: reading the next one is still the
+ * expected thing to do.
+ *
+ * No button takes focus. An ask focuses its input, which costs nothing; here
+ * Enter would send the request, and a key pressed at the wrong moment is exactly
+ * what this block exists to prevent.
  */
 Canvas.Approve = function ({ id, block, onDecide }: ApproveProps) {
   const waiting = block.decision === undefined;
@@ -367,9 +373,12 @@ Canvas.Approve = function ({ id, block, onDecide }: ApproveProps) {
       </div>
       <pre className="max-h-64 overflow-auto rounded-md border border-border bg-background px-2.5 py-2 leading-relaxed text-foreground">{block.request}</pre>
       {waiting ? (
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button size="sm" data-testid="canvas-approve-send" onClick={() => onDecide(id, "approved")}>
             Approve
+          </Button>
+          <Button size="sm" variant="secondary" data-testid="canvas-approve-all" onClick={() => onDecide(id, "all")}>
+            <span className="min-w-0 max-w-[16rem] truncate">Approve all {block.method}</span>
           </Button>
           <Button size="sm" variant="outline" data-testid="canvas-approve-stop" onClick={() => onDecide(id, "rejected")}>
             Stop
@@ -377,7 +386,11 @@ Canvas.Approve = function ({ id, block, onDecide }: ApproveProps) {
         </div>
       ) : (
         <div className={cn(block.decision === "rejected" ? "italic text-muted-foreground" : "text-foreground")}>
-          {block.decision === "approved" ? "Approved" : "Not approved — the script stopped here"}
+          {block.decision === "rejected"
+            ? "Not approved — the script stopped here"
+            : block.standing
+              ? `Approved — and every ${block.method} after it`
+              : "Approved"}
         </div>
       )}
     </div>

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -1,6 +1,6 @@
 import { Bot, Check, ChevronDown, ChevronsUpDown, ChevronUp, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
 import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { blockText } from "./blocks";
+import { ApproveGesture, blockText } from "./blocks";
 import { barFraction, callErrorCode, dotClass, formatBytes, formatDuration, payloadBytes, statusClass } from "./callFormat";
 import { formatClockTime, formatDayLabel, formatElapsed, isSameDay } from "./callTime";
 import { Canvas } from "./Canvas";
@@ -77,7 +77,7 @@ interface ConsoleProps {
   onViewChange: (view: ConsoleView) => void;
   onAnswer: (blockId: string, answer: string) => void;
   onCancelAsk: (blockId: string) => void;
-  onDecide: (blockId: string, decision: "approved" | "rejected") => void;
+  onDecide: (blockId: string, gesture: ApproveGesture) => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;

--- a/ui/src/approve.test.ts
+++ b/ui/src/approve.test.ts
@@ -1,27 +1,34 @@
 import { describe, expect, it } from "bun:test";
 import { ApproveBlock, Block } from "./blocks";
-import { ApprovalRejectedError, Call, Kaja } from "./kaja";
+import { ApprovalRejectedError, ApproveDecision, Call, Kaja } from "./kaja";
 
-// A Kaja whose canvas is a map, and whose approvals are decided by the test.
-function held(decide: (call: ApproveBlock) => Promise<void>) {
+// A Kaja whose canvas is a map, and whose approvals are decided by the test. The
+// asks are counted, because "how many times was I asked" is the whole of what a
+// standing approval changes.
+function held(decide: (call: ApproveBlock) => Promise<ApproveDecision>) {
   const blocks = new Map<string, Block>();
+  const asked: string[] = [];
   const kaja = new Kaja(
     () => {},
     () => Promise.reject(new Error("not asked")),
-    (call) => decide(call),
+    (call) => {
+      asked.push(call.method);
+      return decide(call);
+    },
     (blockId, block) => void blocks.set(blockId, block),
   );
+  const approvals = (): ApproveBlock[] => [...blocks.values()].filter((block): block is ApproveBlock => block.kind === "approve");
   const only = (): ApproveBlock => {
-    const block = [...blocks.values()].find((block) => block.kind === "approve");
-    if (block?.kind !== "approve") throw new Error("nothing was held for approval");
+    const block = approvals()[0];
+    if (!block) throw new Error("nothing was held for approval");
     return block;
   };
-  return { kaja, only };
+  return { kaja, only, approvals, asked };
 }
 
-function stub(): { call: Call<string>; sends: number } {
+function stub(method = "Shows.CreateShow"): { call: Call<string>; sends: number } {
   const state = { sends: 0 };
-  const call = new Call("Shows.CreateShow", { title: "Vera Lune" }, async () => {
+  const call = new Call(method, { title: "Vera Lune" }, async () => {
     state.sends++;
     return "show-1";
   });
@@ -37,7 +44,7 @@ const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe("kaja.approve", () => {
   it("holds the call until it is approved, then sends it and hands back the response", async () => {
-    const { kaja, only } = held(async () => {});
+    const { kaja, only } = held(async () => "approved");
     const stubbed = stub();
 
     const response = await kaja.approve(stubbed.call);
@@ -62,7 +69,7 @@ describe("kaja.approve", () => {
 
   it("holds the call for as long as the question is on screen", async () => {
     let decide = () => {};
-    const { kaja } = held(() => new Promise<void>((resolve) => (decide = resolve)));
+    const { kaja } = held(() => new Promise<ApproveDecision>((resolve) => (decide = () => resolve("approved"))));
     const stubbed = stub();
 
     const approving = kaja.approve(stubbed.call);
@@ -83,6 +90,7 @@ describe("kaja.approve", () => {
       drawn = only();
       expect(call.method).toBe("Shows.CreateShow");
       expect(call.request).toContain("Vera Lune");
+      return "approved";
     });
 
     await kaja.approve(stub().call);
@@ -91,11 +99,75 @@ describe("kaja.approve", () => {
   });
 
   it("refuses a call that has already gone out, which nothing could take back", async () => {
-    const { kaja } = held(async () => {});
+    const { kaja } = held(async () => "approved");
     const stubbed = stub();
     await tick();
 
     await expect(kaja.approve(stubbed.call)).rejects.toThrow(/already been sent/);
+    expect(stubbed.sends).toBe(1);
+  });
+});
+
+describe("kaja.approve — approve all", () => {
+  it("asks once, then sends every later call to the same method", async () => {
+    const { kaja, asked } = held(async () => "all");
+
+    const first = stub();
+    expect(await kaja.approve(first.call)).toBe("show-1");
+    const second = stub();
+    expect(await kaja.approve(second.call)).toBe("show-1");
+
+    expect(first.sends).toBe(1);
+    expect(second.sends).toBe(1);
+    expect(asked).toEqual(["Shows.CreateShow"]);
+  });
+
+  it("draws nothing for the calls that ride on it — they are cards and rows already", async () => {
+    const { kaja, approvals } = held(async () => "all");
+
+    await kaja.approve(stub().call);
+    await kaja.approve(stub().call);
+
+    expect(approvals()).toEqual([
+      { kind: "approve", method: "Shows.CreateShow", request: '{\n  "title": "Vera Lune"\n}', decision: "approved", standing: true },
+    ]);
+  });
+
+  it("does not reach another method", async () => {
+    const { kaja, asked } = held(async () => "all");
+
+    await kaja.approve(stub("Shows.CreateShow").call);
+    await kaja.approve(stub("Shows.DeleteShow").call);
+    await kaja.approve(stub("Shows.CreateShow").call);
+
+    expect(asked).toEqual(["Shows.CreateShow", "Shows.DeleteShow"]);
+  });
+
+  it("covers the run it was given in and no further", async () => {
+    const { kaja, asked } = held(async () => "all");
+
+    await kaja.approve(stub().call);
+    // What runTask does at the top of every run: the guard is back the next time
+    // Run is pressed.
+    kaja._internal.approvedMethods.clear();
+    await kaja.approve(stub().call);
+
+    expect(asked).toEqual(["Shows.CreateShow", "Shows.CreateShow"]);
+  });
+
+  it("sends a standing call at once and only once", async () => {
+    const { kaja } = held(async () => "all");
+    await kaja.approve(stub().call);
+
+    const stubbed = stub();
+    const approving = kaja.approve(stubbed.call);
+    // Nothing is waited on, so the call goes out in the turn it was written in —
+    // which is what "let it run" asked for. It is still claimed, so the tick that
+    // starts an unclaimed call has nothing left to start.
+    expect(stubbed.sends).toBe(1);
+
+    await approving;
+    await tick();
     expect(stubbed.sends).toBe(1);
   });
 });

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -84,7 +84,21 @@ export interface ApproveBlock {
   // The request it is about to send, already text.
   request: string;
   decision?: "approved" | "rejected";
+  // The approval covered every later call to this method too. The calls that
+  // ride on it draw no block of their own — they are already cards on the canvas
+  // and rows in the log — so this is the one place a standing approval is
+  // recorded, and it is what a run read back has to say instead of falling
+  // silent about a decision that was made once and used ten times.
+  standing?: boolean;
 }
+
+/**
+ * How a held call is settled. Two of the three approve it: this call, or this
+ * call and every later one to the same method. Nothing here reaches past the
+ * run — a standing approval is a decision about what is in front of you, not a
+ * policy the workspace keeps.
+ */
+export type ApproveGesture = "approved" | "all" | "rejected";
 
 export type Block = TextBlock | CodeBlock | TableBlock | AskBlock | ApproveBlock;
 
@@ -124,7 +138,7 @@ export function blockLabel(block: Block): string {
       // The verb is in the present tense only while it is still a question.
       switch (block.decision) {
         case "approved":
-          return `${block.method} approved`;
+          return block.standing ? `All ${block.method} approved` : `${block.method} approved`;
         case "rejected":
           return `${block.method} not approved`;
         default:

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -141,7 +141,7 @@ test("defaultInput generates a request that serializes", () => {
     new Kaja(
       () => {},
       async () => "",
-      async () => {},
+      async () => "approved" as const,
       () => {},
     ),
   );

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,7 +1,7 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
 import { parseInteger } from "./ask";
-import { ApproveBlock, AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
+import { ApproveBlock, ApproveGesture, AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
 import { pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
@@ -95,12 +95,16 @@ export interface Choice<V> {
   value: V;
 }
 
+// Which of the two approving gestures was made: this call, or this call and
+// every later one to the same method.
+export type ApproveDecision = Exclude<ApproveGesture, "rejected">;
+
 // The same, for a call held back until it is approved: it resolves when the call
 // may go out, and rejects when the script is to stop instead. The block travels
 // with it for the same reason a question's does — a run with no canvas asks in a
 // dialog, which has nothing but what it is handed.
 export interface ApproveRequest {
-  (call: ApproveBlock, blockId: string): Promise<void>;
+  (call: ApproveBlock, blockId: string): Promise<ApproveDecision>;
 }
 
 // A block arriving, or the same block again with more in it.
@@ -325,6 +329,11 @@ export class Kaja {
    *
    * The call goes inside the parentheses — that is what makes it a call that
    * hasn't happened yet rather than one to be sorry about.
+   *
+   * The canvas also offers **Approve all**, which settles this call and every
+   * later one to the same method in this run. The script never asks for that and
+   * never learns of it: which calls are worth reading one by one is a decision
+   * made in front of them, not written into the loop.
    */
   async approve<T>(call: Call<T>): Promise<T> {
     if (call.started) {
@@ -334,16 +343,28 @@ export class Kaja {
     // while the question was still on screen and send the call itself.
     call.claim();
 
+    // A standing approval was given for this method earlier in the run, so this
+    // call goes out without asking — and draws nothing, since a canvas of
+    // decisions nobody made is what "let it run" was pressed to be rid of. The
+    // call is still a card on the canvas and a row in the log, as every call is.
+    if (this._internal.approvedMethods.has(call.label)) return call.start();
+
     const blockId = newBlockId();
     const block: ApproveBlock = { kind: "approve", method: call.label, request: formatRequest(call.input) };
     this.#onBlockUpdate(blockId, block);
+    let decision: ApproveDecision;
     try {
-      await this.#onApprove(block, blockId);
+      decision = await this.#onApprove(block, blockId);
     } catch (error) {
       this.#onBlockUpdate(blockId, { ...block, decision: "rejected" });
       throw error;
     }
-    this.#onBlockUpdate(blockId, { ...block, decision: "approved" });
+    if (decision === "all") {
+      this._internal.approvedMethods.add(call.label);
+      this.#onBlockUpdate(blockId, { ...block, decision: "approved", standing: true });
+    } else {
+      this.#onBlockUpdate(blockId, { ...block, decision: "approved" });
+    }
     return call.start();
   }
 
@@ -603,6 +624,18 @@ class KajaInternal {
   // Signal of the run currently in flight, so the calls a script makes can be
   // aborted from the editor's Stop button. Undefined when nothing is running.
   abortSignal?: AbortSignal;
+  /**
+   * Methods that were approved for the rest of the run, by their "Service.Method"
+   * label — the same identity the block names and the button offers, so what was
+   * pressed and what it covers are one thing.
+   *
+   * The scope is the method rather than the run because that is what the button
+   * can honestly say: a script that loops over one call is the case this exists
+   * for, and one that also writes somewhere else asks again for that. And the
+   * lifetime is the run because anything longer is a policy — cleared by
+   * `runTask`, so the guard is back the next time Run is pressed.
+   */
+  readonly approvedMethods = new Set<string>();
   #onMethodCallUpdate: MethodCallUpdate;
 
   constructor(onMethodCallUpdate: MethodCallUpdate) {

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -154,6 +154,12 @@ export declare const kaja: {
    * Write the call inside the parentheses. That is what makes it a call that
    * hasn't happened yet: a call kept in a variable and awaited elsewhere has
    * already gone out, and approving one is then too late to mean anything.
+   *
+   * Beside Approve the canvas offers **Approve all**, which settles this call
+   * and every later one to the same method in this run — so a loop can be read
+   * a couple of times and then let go. Nothing about that is the script's to
+   * decide: write kaja.approve around every call worth a decision, and which of
+   * them are read one by one is settled in front of them.
    */
   approve<T>(call: Call<T>): Promise<T>;
   /**

--- a/ui/src/taskRunner.test.ts
+++ b/ui/src/taskRunner.test.ts
@@ -7,7 +7,7 @@ function makeKaja(answer: (question: AskBlock) => string = () => ""): Kaja {
   return new Kaja(
     () => {},
     async (question) => answer(question),
-    async () => {},
+    async () => "approved" as const,
     () => {},
   );
 }

--- a/ui/src/taskRunner.ts
+++ b/ui/src/taskRunner.ts
@@ -109,6 +109,8 @@ export function runTask(code: string, kaja: Kaja, apps: App[], onError: (error: 
     }
   };
   kaja._internal.abortSignal = signal;
+  // A standing approval covers the run it was given in and nothing further.
+  kaja._internal.approvedMethods.clear();
 
   let result: any;
   try {
@@ -166,6 +168,8 @@ export async function runTaskCaptured(code: string, kaja: Kaja, apps: App[]): Pr
     error: (...parts: unknown[]) => record("error", parts),
     debug: (...parts: unknown[]) => record("debug", parts),
   };
+
+  kaja._internal.approvedMethods.clear();
 
   try {
     const { args, runCode } = prepareTask(code, kaja, apps);


### PR DESCRIPTION
Adds a third button to `kaja.approve`: **Approve all `Service.Method`**, which settles this call and every later call to that method in the same run — so a loop can be read a couple of times and then let go. The scope is the method (that's what the button can honestly name), the lifetime is the run, and the script never learns of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P83p2PWECF7k6wdJr1soa3)_