### PR TITLE
Let a script update a row after it drew it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,27 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
   part the part you can't watch. Blocks are recorded against their own id
   (`recordBlock`), so a block that fills in stays where it was emitted rather
   than jumping to the end.
+- **A row is a handle too, and updating one is writing it again.** `.row(...)`
+  hands back a `Row` with one verb, `.update(...cells)`, taking the same cells in
+  the same order — so a row is declared when its work starts and rewritten when
+  it finishes, which is what a summary table is. Naming the cell instead
+  (`row.update({ status })`) would make the columns keys and buy nothing on a
+  table narrow enough to want this; restating two cells that didn't change is the
+  cheaper of the two, and a patch verb can be added later if wide tables ever ask
+  for it — it can't be an *overload*, since a cell may itself be an object. The
+  block is unchanged by any of it: `rows` is still `string[][]`, an update is the
+  same wholesale re-emit an append is, and a stored run reads back the last
+  values, because the canvas is what the run drew and not how it got there.
+  **A row is as wide as the table** (`padCells`): fewer cells than columns draws
+  blanks rather than a ragged edge — which is what lets a row be written before
+  the work that fills it is done — and `.column(name)` widens the rows already
+  drawn along with the header, so the two can never disagree. Extra cells are
+  left alone, since dropping them would hide what the script had. Renaming a
+  column, removing a row and flashing a changed cell are all **out**: the first
+  two make the canvas rewrite what it drew, and the third is a script asking for
+  how it looks. A handle into a table filled from a **source** goes quiet rather
+  than throwing — a server-side search restarts the source from the top, so the
+  row it pointed at is answering a question nobody is asking any more.
 - **A table's rows are an iterable, and that is the whole of static-versus-live.**
   An array is one; so is an async generator, and one of those only runs when
   something pulls it — which is what makes paging fetch a page and nothing else.

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -109,6 +109,27 @@ Rows land one at a time, so the canvas fills as the loop runs rather than after
 it. `run_script` reports what you drew — each block's kind, and a table's columns
 and row count — so you can check the output landed.
 
+**A row can be rewritten after it is drawn**, which is how a summary table is
+built: `.row(...)` hands back a handle, and `.update(...)` takes the same cells
+in the same order. Write the row when the work starts and update it when it
+finishes, rather than waiting until the end and drawing the table once.
+
+```ts
+const table = kaja.table(["show", "seats", "status"]);
+await Promise.all(
+  shows.map(async (show) => {
+    const row = table.row(show.title, show.seatsAvailable, "checking…");
+    const seating = await Seating.GetAvailability({ showId: show.id });
+    row.update(show.title, seating.available, seating.available > 0 ? "on sale" : "sold out");
+  }),
+);
+```
+
+A row is only ever the whole of itself, so pass every cell, not just the one that
+changed; fewer cells than columns leaves the rest blank. `table.column(name)`
+adds a column if the run turns out to need one, and the rows already drawn grow a
+blank cell for it.
+
 **A table can page and search itself.** Hand it the rows instead of pushing
 them, and it gets a search box and a pager for free — an array is drawn as it is,
 and a function is pulled a page at a time, only when the person reading it pages
@@ -155,8 +176,9 @@ What each member is for:
 - `kaja.text(text)`, `kaja.code(code, language?)` — draw a line or a snippet on
   the canvas.
 - `kaja.table(columns, rows?)` — draw a table; the handle's `.row(...cells)`
-  appends to it. `rows` can be an array, or a source (an async generator) the
-  table pulls a page at a time as it is paged through.
+  appends to it and hands back a row whose `.update(...cells)` rewrites it, and
+  `.column(name)` adds a column. `rows` can be an array, or a source (an async
+  generator) the table pulls a page at a time as it is paged through.
 - `kaja.askStr(question)`, `kaja.askInt(question)`,
   `kaja.askSelect(question, options)` — ask the user for text, a whole number,
   or one of a list; each blocks on a human and hands back the kind of thing it

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -114,7 +114,20 @@ export interface BlockUpdate {
  * the loop to finish would make the interesting part the part you can't watch.
  */
 export interface Table {
-  row(...cells: unknown[]): void;
+  row(...cells: unknown[]): Row;
+  column(name: string): void;
+}
+
+/**
+ * A row that is already on the canvas. **Updating one is writing it again** —
+ * the same cells in the same order `row` took them — because a row is only ever
+ * the whole of itself: naming a cell would need the columns to be keys, and
+ * restating two cells that didn't change is the cheaper of the two. That is what
+ * a summary table is: a row declared when the work starts and rewritten when it
+ * finishes, so the table paints rather than reporting at the end.
+ */
+export interface Row {
+  update(...cells: unknown[]): void;
 }
 
 /**
@@ -179,6 +192,14 @@ function openIterator(rows: Rows): Iterator<unknown[]> | AsyncIterator<unknown[]
 // error, on the same rule formatCell follows: readable beats correct-or-nothing.
 function toCells(row: unknown): string[] {
   return Array.isArray(row) ? row.map(formatCell) : [formatCell(row)];
+}
+
+// A row is as wide as the table. Fewer cells than columns draws blanks rather
+// than a ragged edge, which is what lets a row be written before the work that
+// fills it is done; more are left alone, since dropping them would hide what the
+// script had.
+function padCells(cells: string[], width: number): string[] {
+  return cells.length >= width ? cells : [...cells, ...new Array(width - cells.length).fill("")];
 }
 
 // The request a call is holding, as the approve block shows it. A block is
@@ -373,6 +394,13 @@ export class Kaja {
    *   const table = kaja.table(["id", "name", "status"]);
    *   for (const account of accounts) table.row(account.id, account.name, "matched");
    *
+   * A row hands back a handle, so a table can keep saying what is true as the
+   * script runs: write the row when the work starts and update it when it ends.
+   *
+   *   const row = table.row(account.id, account.name, "checking…");
+   *   const result = await check(account);
+   *   row.update(account.id, account.name, result.status);
+   *
    * The rows can also be given: an array is drawn as it is, and a source is
    * pulled a page at a time as the table is paged through.
    *
@@ -389,7 +417,7 @@ export class Kaja {
     const block: TableBlock = { kind: "table", columns: columns.map(formatCell), rows: [], pageSize: options?.pageSize };
 
     if (Array.isArray(rows)) {
-      block.rows = rows.map(toCells);
+      block.rows = rows.map((row) => padCells(toCells(row), block.columns.length));
     } else if (rows !== undefined) {
       if (typeof rows !== "function" && !isAsyncIterable(rows) && !isIterable(rows)) {
         throw new Error("kaja.table: rows must be an array, an iterable of rows, or a function returning one");
@@ -413,11 +441,36 @@ export class Kaja {
     // a run nobody is watching (an agent's) still reports a page of rows.
     if (block.live) void this.pullTable(blockId, "", pageSizeOf(block));
 
+    // A new array each time, at both levels: the canvas compares what it was
+    // handed against what it holds, and a row pushed or spliced into the same
+    // array is invisible to it.
+    const write = (index: number, cells: unknown[]) => {
+      const row = padCells(cells.map(formatCell), block.columns.length);
+      block.rows = block.rows.map((current, at) => (at === index ? row : current));
+      this.#onBlockUpdate(blockId, { ...block });
+    };
+
     return {
-      row: (...cells: unknown[]) => {
-        // A new array each time: the canvas compares what it was handed against
-        // what it holds, and a row pushed into the same array is invisible to it.
-        block.rows = [...block.rows, cells.map(formatCell)];
+      row: (...cells: unknown[]): Row => {
+        const index = block.rows.length;
+        block.rows = [...block.rows, padCells(cells.map(formatCell), block.columns.length)];
+        this.#onBlockUpdate(blockId, { ...block });
+        return {
+          update: (...cells: unknown[]) => {
+            // The row a handle points at can be gone: a source that takes the
+            // search is restarted from the top, and the rows it had answered a
+            // question nobody is asking any more. There is nothing to rewrite,
+            // so nothing happens — a handle going quiet is better than a script
+            // ending on someone else's search.
+            if (index < block.rows.length) write(index, cells);
+          },
+        };
+      },
+      column: (name: string) => {
+        // Widening the table widens the rows it has already drawn, so the header
+        // and the rows can never disagree about how many columns there are.
+        block.columns = [...block.columns, formatCell(name)];
+        block.rows = block.rows.map((row) => padCells(row, block.columns.length));
         this.#onBlockUpdate(blockId, { ...block });
       },
     };
@@ -496,7 +549,7 @@ export class Kaja {
           block.exhausted = true;
           break;
         }
-        block.rows = [...block.rows, toCells(next.value)];
+        block.rows = [...block.rows, padCells(toCells(next.value), block.columns.length)];
         this.#onBlockUpdate(blockId, { ...block });
       }
     } catch (error) {

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -74,9 +74,29 @@ export interface ListValue {
 export interface Table {
   /**
    * Append a row. It appears at once, so a loop paints as it runs. A cell can be
-   * anything; it is rendered as text.
+   * anything; it is rendered as text. Fewer cells than there are columns leaves
+   * the rest blank, so a row can be written before the work that fills it is
+   * done — the handle it hands back is how you finish it.
    */
-  row(...cells: unknown[]): void;
+  row(...cells: unknown[]): Row;
+  /**
+   * Add a column, once the run knows it needs one. The rows already drawn grow a
+   * blank cell for it.
+   */
+  column(name: string): void;
+}
+
+/** A row already on the canvas, which the run can keep up to date. */
+export interface Row {
+  /**
+   * Rewrite the row: the same cells in the same order row() took them. A row is
+   * only ever the whole of itself, so pass every cell, not just the one that
+   * changed.
+   *
+   *   const row = table.row(account.id, "checking…");
+   *   row.update(account.id, await check(account));
+   */
+  update(...cells: unknown[]): void;
 }
 
 /**
@@ -177,6 +197,18 @@ export declare const kaja: {
    *   const table = kaja.table(["id", "name", "status"]);
    *   for (const account of accounts) {
    *     table.row(account.id, account.name, await check(account));
+   *   }
+   *
+   * A row hands back a handle, so a table can keep saying what is true while the
+   * run goes on: write the row when the work starts, update it when it ends.
+   * This is how a summary table is built — never redraw the whole table.
+   *
+   *   const rows = accounts.map((account) => ({
+   *     account,
+   *     row: table.row(account.id, account.name, "checking…"),
+   *   }));
+   *   for (const { account, row } of rows) {
+   *     row.update(account.id, account.name, await check(account));
    *   }
    *
    * The rows can be given instead — an array, or a source that yields them as

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -39,6 +39,92 @@ describe("kaja.table", () => {
     expect(only().rows).toEqual([["1"], ["2"]]);
   });
 
+  // A row is written when the work starts and rewritten when it finishes, which
+  // is what makes a summary table paint rather than report at the end.
+  it("rewrites a row from its handle", () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id", "status"]);
+    const first = table.row(1, "checking…");
+    const second = table.row(2, "checking…");
+
+    second.update(2, "matched");
+    expect(only().rows).toEqual([
+      ["1", "checking…"],
+      ["2", "matched"],
+    ]);
+
+    first.update(1, "failed");
+    expect(only().rows).toEqual([
+      ["1", "failed"],
+      ["2", "matched"],
+    ]);
+  });
+
+  // The canvas compares what it was handed against what it holds, so a row
+  // rewritten in place would repaint nothing.
+  it("hands the canvas a new array for every update", () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id"]);
+    const row = table.row(1);
+    const before = only().rows;
+
+    row.update(2);
+    expect(only().rows).not.toBe(before);
+    expect(before).toEqual([["1"]]);
+  });
+
+  // A row is as wide as the table, so one written before its values are known
+  // draws blanks rather than a ragged edge — the canvas draws a cell per cell.
+  it("pads a short row to the columns, whether written, updated or pulled", async () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id", "name", "status"]);
+    const row = table.row(1);
+    expect(only().rows).toEqual([["1", "", ""]]);
+
+    row.update(1, "Vera");
+    expect(only().rows).toEqual([["1", "Vera", ""]]);
+
+    const source = draw();
+    source.kaja.table(["id", "name"], [[1], [2, "Lune"]]);
+    expect(source.only().rows).toEqual([
+      ["1", ""],
+      ["2", "Lune"],
+    ]);
+  });
+
+  it("grows every row when a column is added", () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id"]);
+    const row = table.row(1);
+    table.column("status");
+
+    expect(only().columns).toEqual(["id", "status"]);
+    expect(only().rows).toEqual([["1", ""]]);
+
+    row.update(1, "matched");
+    expect(only().rows).toEqual([["1", "matched"]]);
+  });
+
+  // A source that takes the search is restarted from the top, so the rows a
+  // handle pointed into answer a question nobody is asking. Nothing to rewrite,
+  // so nothing happens — better than a script ending on someone else's search.
+  it("goes quiet when the row it points at is gone", async () => {
+    const { kaja, only, id } = draw();
+    const table = kaja.table(["n"], async function* (search: string) {
+      yield [`${search || "all"}-1`];
+    });
+    await kaja.settleTables();
+
+    const row = table.row("written");
+    expect(only().rows).toHaveLength(2);
+
+    await kaja.pullTable(id(), "vera", 50);
+    expect(only().rows).toEqual([["vera-1"]]);
+
+    row.update("rewritten");
+    expect(only().rows).toEqual([["vera-1"]]);
+  });
+
   /**
    * The whole claim: a source is pulled for the page that is being looked at and
    * not one row further. A generator makes that structural — the loop simply


### PR DESCRIPTION
`table.row(...)` now hands back a handle whose `update(...cells)` rewrites the row, so a summary table can be declared when its work starts and kept true as the run goes on; `table.column(name)` adds a column, widening the rows already drawn.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wy69PDHSR1CdRkKR6bdkm)_