### PR TITLE
Added Cursor to the MCP popup and linked each client's configuration file

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -192,6 +192,31 @@ func (a *App) showLogsInFinder() {
 	revealInFinder(dir)
 }
 
+// ShowFileInFinder reveals a file in the system file browser with the file
+// selected, the way Show Config in Finder does for kaja.json. A path that isn't
+// there yet — an MCP client's configuration file before that client has written
+// one — opens the nearest directory that is, so the link always lands somewhere.
+func (a *App) ShowFileInFinder(path string) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	if _, err := os.Stat(path); err == nil {
+		revealFileInFinder(path)
+		return
+	}
+	for dir := filepath.Dir(path); ; {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			revealInFinder(dir)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
 // ScriptFile is the on-disk representation of a Kaja script.
 // For ListScripts only Path and Name are populated; Content is fetched
 // on demand via ReadScriptFile.

--- a/desktop/mcp_bridge.go
+++ b/desktop/mcp_bridge.go
@@ -40,13 +40,39 @@ type MCPInfo struct {
 	URL     string `json:"url"`
 	Token   string `json:"token"`
 	Error   string `json:"error"`
+	// ConfigurationPaths is where each client keeps the file its snippet goes
+	// into, keyed by the client the footer shows it under.
+	ConfigurationPaths map[string]string `json:"configurationPaths"`
 }
 
 // MCPServerInfo returns the current connection details for the UI footer.
 func (a *App) MCPServerInfo() MCPInfo {
 	a.mcpMu.Lock()
 	defer a.mcpMu.Unlock()
-	return MCPInfo{Enabled: a.mcpServer != nil, URL: a.mcpURL, Token: a.mcpToken, Error: a.mcpError}
+	return MCPInfo{
+		Enabled:            a.mcpServer != nil,
+		URL:                a.mcpURL,
+		Token:              a.mcpToken,
+		Error:              a.mcpError,
+		ConfigurationPaths: mcpClientConfigurationPaths(),
+	}
+}
+
+// mcpClientConfigurationPaths is the file each client keeps its MCP servers in,
+// so the footer can link to the one it is telling you to edit rather than only
+// naming it. A client whose path this machine can't answer for is absent, and
+// its snippet is shown with the file named and no link.
+func mcpClientConfigurationPaths() map[string]string {
+	paths := map[string]string{}
+	// The three places os.UserConfigDir reports are the three Claude Desktop
+	// looks in: Application Support, %AppData%, and ~/.config.
+	if dir, err := os.UserConfigDir(); err == nil {
+		paths["claudeDesktop"] = filepath.Join(dir, "Claude", "claude_desktop_config.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths["cursor"] = filepath.Join(home, ".cursor", "mcp.json")
+	}
+	return paths
 }
 
 // MCPSetCatalog receives the live services/methods picture from the UI after

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -6,6 +6,7 @@ import { IconButton } from "./components/icon-button";
 import { Popover, PopoverContent, PopoverTrigger } from "./components/popover";
 import { SegmentedControl } from "./components/segmented-control";
 import { isWailsEnvironment } from "./wails";
+import { ShowFileInFinder } from "./wailsjs/go/main/App";
 import { BrowserOpenURL } from "./wailsjs/runtime/runtime";
 import { FeaturePreview, FeaturePreviews } from "./FeaturePreviews";
 import { CompileStatus } from "./CompileStatus";
@@ -39,7 +40,14 @@ interface StatusBarProps {
 // here and they show up as another tab in the popup.
 interface McpClient {
   label: string;
-  hint: string;
+  // configuration is the file the snippet is pasted into: the key the desktop
+  // resolved a path under, and the name to fall back to when it couldn't. A
+  // client told to run a command instead has none.
+  configuration?: { key: string; name: string };
+  // hint says what to do with the snippet. It is handed the configuration file
+  // it names — a link that reveals it, or its bare name — so the sentence around
+  // it stays with the client it belongs to.
+  hint: (file: React.ReactNode) => React.ReactNode;
   // snippet renders the connection instructions for the running server.
   snippet: (info: main.MCPInfo) => string;
 }
@@ -47,7 +55,7 @@ interface McpClient {
 const mcpClients: McpClient[] = [
   {
     label: "Claude Code",
-    hint: "Run this command to add the server to the CLI:",
+    hint: () => "Run this command to add the server to the CLI:",
     snippet: (info) => `claude mcp add --transport http kaja ${info.url} --header "Authorization: Bearer ${info.token}"`,
   },
   {
@@ -56,7 +64,8 @@ const mcpClients: McpClient[] = [
     // The header is passed via an env var because Claude Desktop splits args on
     // spaces, which would otherwise mangle "Bearer <token>".
     label: "Claude Desktop",
-    hint: "Add this to claude_desktop_config.json (bridges through mcp-remote):",
+    configuration: { key: "claudeDesktop", name: "claude_desktop_config.json" },
+    hint: (file) => <>Add this to {file}, which bridges through mcp-remote:</>,
     snippet: (info) =>
       JSON.stringify(
         {
@@ -72,7 +81,43 @@ const mcpClients: McpClient[] = [
         2,
       ),
   },
+  {
+    // Cursor talks to the server itself, so it takes the endpoint and the token
+    // as they are — no bridge, unlike Claude Desktop.
+    label: "Cursor",
+    configuration: { key: "cursor", name: "mcp.json" },
+    hint: (file) => <>Add this to {file}:</>,
+    snippet: (info) =>
+      JSON.stringify(
+        {
+          mcpServers: {
+            kaja: {
+              type: "http",
+              url: info.url,
+              headers: { Authorization: `Bearer ${info.token}` },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+  },
 ];
+
+// ConfigurationFileLink shows the file a snippet goes into and opens it in the
+// system file browser with the file selected, the way Show Config in Finder does
+// for kaja.json. A file the client hasn't written yet opens its directory.
+function ConfigurationFileLink({ path }: { path: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => ShowFileInFinder(path)}
+      className="cursor-pointer break-all border-0 bg-transparent p-0 text-left font-mono text-[11px] text-foreground underline underline-offset-2 hover:text-foreground/80"
+    >
+      {path}
+    </button>
+  );
+}
 
 // MCPStatus surfaces the localhost MCP endpoint and, per client, the snippet to
 // connect it to an agent. Shown once the server is up, which on the desktop is
@@ -87,6 +132,14 @@ function MCPStatus({ info, active }: { info: main.MCPInfo; active: boolean }) {
   const [copied, setCopied] = useState(false);
   const client = mcpClients[selected];
   const snippet = client.snippet(info);
+  const configurationPath = client.configuration ? info.configurationPaths?.[client.configuration.key] : undefined;
+  const configurationFile = client.configuration ? (
+    configurationPath ? (
+      <ConfigurationFileLink path={configurationPath} />
+    ) : (
+      <span className="font-mono text-[11px] text-foreground">{client.configuration.name}</span>
+    )
+  ) : null;
 
   const select = (index: number) => {
     setSelected(index);
@@ -133,7 +186,7 @@ function MCPStatus({ info, active }: { info: main.MCPInfo; active: boolean }) {
               </SegmentedControl.Button>
             ))}
           </SegmentedControl>
-          <span className="text-[11px] text-muted-foreground">{client.hint}</span>
+          <span className="text-[11px] text-muted-foreground">{client.hint(configurationFile)}</span>
           <pre className="m-0 whitespace-pre-wrap break-all rounded-md bg-muted p-2 font-mono text-[11px] text-foreground">{snippet}</pre>
           <Button variant="outline" size="sm" onClick={copy}>
             {copied ? "Copied" : "Copy"}

--- a/ui/src/wailsjs/go/main/App.d.ts
+++ b/ui/src/wailsjs/go/main/App.d.ts
@@ -28,6 +28,8 @@ export function RenameScript(arg1:string,arg2:string):Promise<main.ScriptFile>;
 
 export function ResolvedVariables():Promise<{[key: string]: string}>;
 
+export function ShowFileInFinder(arg1:string):Promise<void>;
+
 export function Target(arg1:string,arg2:string,arg3:Array<number>,arg4:number,arg5:string):Promise<main.TargetResult>;
 
 export function TargetServerStream(arg1:string,arg2:string,arg3:Array<number>,arg4:string,arg5:string):Promise<void>;

--- a/ui/src/wailsjs/go/main/App.js
+++ b/ui/src/wailsjs/go/main/App.js
@@ -54,6 +54,10 @@ export function ResolvedVariables() {
   return window['go']['main']['App']['ResolvedVariables']();
 }
 
+export function ShowFileInFinder(arg1) {
+  return window['go']['main']['App']['ShowFileInFinder'](arg1);
+}
+
 export function Target(arg1, arg2, arg3, arg4, arg5) {
   return window['go']['main']['App']['Target'](arg1, arg2, arg3, arg4, arg5);
 }

--- a/ui/src/wailsjs/go/models.ts
+++ b/ui/src/wailsjs/go/models.ts
@@ -4,6 +4,7 @@ export namespace main {
     url: string;
     token: string;
     error: string;
+    configurationPaths: { [key: string]: string };
 
     static createFrom(source: any = {}) {
       return new MCPInfo(source);
@@ -15,6 +16,7 @@ export namespace main {
       this.url = source["url"];
       this.token = source["token"];
       this.error = source["error"];
+      this.configurationPaths = source["configurationPaths"];
     }
   }
   export class ScriptFile {


### PR DESCRIPTION
Added a Cursor tab to the MCP popup, which takes the endpoint and token directly (no mcp-remote bridge). The configuration file each snippet is pasted into is now a link that reveals it in the system file browser, the same way Show Config in Finder does for kaja.json.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG6YuGZ3x8dt2h1inGvBLK)_