### PR TITLE
Built every macOS build for the version the app ships for

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -27,5 +27,8 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.13.0
 
       - name: Build desktop app
-        run: wails build
+        run: |
+          source ../scripts/common
+          export_macos_deployment_target
+          wails build
         working-directory: desktop

--- a/desktop/build/darwin/Info.dev.plist
+++ b/desktop/build/darwin/Info.dev.plist
@@ -17,6 +17,8 @@
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
+        <!-- Keep in step with MACOS_DEPLOYMENT_TARGET in scripts/common, which is
+             the version the binary in this bundle is compiled for. -->
         <key>LSMinimumSystemVersion</key>
         <string>12.0</string>
         <key>LSApplicationCategoryType</key>

--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -17,6 +17,8 @@
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
+        <!-- Keep in step with MACOS_DEPLOYMENT_TARGET in scripts/common, which is
+             the version the binary in this bundle is compiled for. -->
         <key>LSMinimumSystemVersion</key>
         <string>12.0</string>
         <key>LSApplicationCategoryType</key>

--- a/scripts/common
+++ b/scripts/common
@@ -21,3 +21,26 @@ install_protoc() {
     mv "$BUILD_DIR/protoc-go" "$BUILD_DIR/protoc"
 }
 
+# The macOS version the desktop app is built for. It is what the shipped bundle
+# declares (LSMinimumSystemVersion in desktop/build/darwin/Info.plist and
+# Info.dev.plist), so keep the three in step.
+MACOS_DEPLOYMENT_TARGET=12.0
+
+# Build the desktop app against that version rather than the one cgo would pick
+# on its own, which is old enough (10.13) that the APIs the app calls warn about
+# their own availability - the data protection keychain is 10.15+. Every build
+# has to say it, not just the store build: a dev build compiled for a different
+# macOS than the one that ships is a dev build that can't report what will
+# happen on it.
+#
+# Usage: export_macos_deployment_target   (a no-op off macOS)
+export_macos_deployment_target() {
+    [ "$(uname -s)" = "Darwin" ] || return 0
+
+    export MACOSX_DEPLOYMENT_TARGET="$MACOS_DEPLOYMENT_TARGET"
+    # Added to what Go would have passed rather than replacing it, so cgo keeps
+    # its own defaults (-O2 -g) and anything the environment already set.
+    export CGO_CFLAGS="$(go env CGO_CFLAGS) -mmacosx-version-min=$MACOS_DEPLOYMENT_TARGET"
+    export CGO_LDFLAGS="$(go env CGO_LDFLAGS) -mmacosx-version-min=$MACOS_DEPLOYMENT_TARGET"
+}
+

--- a/scripts/desktop
+++ b/scripts/desktop
@@ -47,6 +47,10 @@ export PATH=$GOBIN:$PATH
 
 cd ./desktop
 
+# Build for the macOS the store build and the bundle both name, so a dev build
+# compiles the same way the shipped one does.
+export_macos_deployment_target
+
 # Dev mode. wails.json handles the entire frontend pipeline:
 #   - frontend:install runs `bun install` in ../ui
 #   - frontend:build performs the initial bundle into frontend/dist

--- a/scripts/testflight
+++ b/scripts/testflight
@@ -24,6 +24,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=scripts/common
+source "$SCRIPT_DIR/common"
+
 ENV_FILE="$REPO_ROOT/.env"
 if [ -f "$ENV_FILE" ]; then
     echo "Loading environment from $ENV_FILE"
@@ -142,9 +145,7 @@ fi
 
 echo ""
 echo "--- Building desktop app (store)"
-export MACOSX_DEPLOYMENT_TARGET=12.0
-export CGO_LDFLAGS="-mmacosx-version-min=12.0"
-export CGO_CFLAGS="-mmacosx-version-min=12.0"
+export_macos_deployment_target
 (cd "$DESKTOP_DIR" && wails build -ldflags "-X main.GitRef=$PRODUCT_VERSION")
 
 if [ ! -d "$APP_BUNDLE" ]; then


### PR DESCRIPTION
`wails dev` and CI's `wails build` left the macOS deployment target to cgo, which picks 10.13 — older than the data protection keychain the app calls (10.15+, hence the warning on every dev build) and older than the 12.0 the bundle declares and the store build pins.

The version is now stated once in `scripts/common` and exported for the dev, store and CI builds alike.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgVxMe39wsA3WouYFjcMji)_