### PR TITLE
Surfaced what a script printed in the console, and renamed the log to Calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,17 +268,73 @@ reader who found one had no reason to expect the other where it is. Each now has
 its own file and its own parts: `RunLog.CallRow` / `TailBar` / `PayloadPane`
 belong to the log, `Console.RunSelect` / `RunRow` to the frame, and flat against
 one another they read as the same kind of thing. `Log` alone is taken (the
-script's own log messages), and `RunList` would be read as a list of runs, which
-is what the run picker beside it actually is — so the log is `RunLog`. The
-segmented control says **Log** and **Canvas**, and `ConsoleView` is
-`"log" | "canvas"` to match; it is in-memory only, so nothing had to migrate.
+script's own log messages, which the calls view now mixes in), and `RunList` would
+be read as a list of runs, which is what the run picker beside it actually is — so
+the component is `RunLog`, the run's log. The segmented control says **Calls** and
+**Canvas**, and `ConsoleView` is `"calls" | "canvas"` to match; it is in-memory
+only, so nothing had to migrate.
 
-**A row is a call and only a call.** No disclosure triangles, no block rows, no
-run row. Splitting the views is what deletes the double-statement problem — an
+**A row is a call and only a call** — no disclosure triangles, no block rows, no
+run row — which is why the view is called **Calls** rather than Log: "log" is what
+anyone means by what a script printed, and that is a separate thing this view can
+*mix in*. Splitting the views is what deletes the double-statement problem — an
 index of "table · 42 rows" rows sitting above the same tables rendered below —
 and it is why Request/Response/Headers moved **down onto the payload pane**: the
 header no longer rearranges itself as the selection moves, and the pane never
 reflows as you step through the log.
+
+**What a script printed is a channel, and the Calls view is where it is read.**
+`console.log` and friends are the logging API — there is no `kaja.log`, because the
+`kaja` object holds the verbs that are Kaja's own and logging is not one of them:
+a second spelling would add a decision without adding a capability, and the value
+of a log line is that it costs nothing to write and nothing to delete.
+
+- **The scope is what tells a script's lines from Kaja's own** (`scriptConsole.ts`).
+  The script body is wrapped in a function taking `console` as a parameter, so
+  inside it the name resolves to the run's console and everywhere else in the app
+  to the real one — app code a script calls into keeps the real console, and a
+  closure the script defines keeps this one however late it fires. No origin
+  tagging, no allowlist, nothing to drift. **Kaja's own `console.log` never
+  appears in a run**, which is right and not a limitation: what fires during a run
+  is transport tracing that duplicates the request and response the payload pane
+  already shows properly, eight lines to a call. When the system does have
+  something to say in a run it says it in the console's own vocabulary — a row, a
+  status, a tail-bar statement — never as a text stream. If a log line is the only
+  way to say it, it didn't need saying.
+- **The wrapper is built from the console, not declared as five methods.** The
+  five-method stand-in it replaced made `console.table(rows)` throw
+  "console.table is not a function" inside an agent's snippet. Everything that
+  isn't a level — `table`, `time`, `group`, `dir`, and whatever a runtime adds
+  next — passes straight through to devtools, which is where instrumentation
+  belongs and where it stays. The five levels map onto the proto's own ordered
+  enum (`LEVEL_DEBUG` 0 … `LEVEL_ERROR` 3), with `log` and `info` sharing `INFO`.
+- **A printed line is not a verdict** (`printed` on `ConsoleItem`). It never
+  colours the run's dot and never counts as something drawn — a script that prints
+  `console.error("retry 2")` in a loop and finishes is not a failed run, and one
+  whose only output is `console.log` must not open on an empty canvas. The
+  script-error item, which is a verdict Kaja wrote, goes on being one.
+- **Off by default, and a floor rather than four checkboxes.** `LogFloor` is
+  `off` / `error` / `warn` / `all`: the levels are ordered, so "warnings but not
+  errors" is not a question anyone asks, and one control beats four switches over
+  a list that is usually empty. It lives on `FileConsole` beside `view`, on the
+  same rule — debugging is a mode, not a click — and its control only exists while
+  the run printed something.
+- **Off is only bearable because the tail bar says what is missing.** A clean list
+  over a run that printed an error is a log that is silently incomplete, so the
+  bar states `4 log lines · 1 error` and is the way to turn the floor on.
+- **A log row is the same fixed 24px and truncates; the pane holds the line.** The
+  windowing is arithmetic only because every row is that height, and the payload
+  pane had nothing to show for a row that isn't a call anyway — so selecting one
+  shows the whole message, which is what makes `console.log(someObject)` worth
+  doing.
+- **A line lands where it was printed and a call where it was issued**
+  (`callRows`), so a line printed while a call is in flight sits after that call's
+  row rather than after its response. Both lists are already ordered, so the mix
+  is a merge rather than a sort.
+- **kaja.log gets the lines with their origin attached** — `[ui] [INFO] [script] …`
+  via `logScriptLine`, so the level column stays greppable. The script's console
+  forwards to `deviceConsole`, the console as it was before `installUiLog` patched
+  it, so a script error isn't written to the file twice.
 
 **A response is printed, not formatted** (`payloadText.ts`). The pane follows the
 selection, which follows a run as it happens, so this runs as often as the

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -86,12 +86,18 @@ script is a file someone opens and presses Run on, so everything it has to say
 belongs where they will see it. Never build a table out of Markdown, ASCII or
 `console.table`; `kaja.table` is the table.
 
-`console.log(...)` is not that channel. It is the transcript, which `run_script`
-hands back to you and nobody else reads, so it is **for you while you are
-working** — a count, a filtered id, a shape worth checking before you write the
-real thing. Leave it out of a script you keep. You do not need it to see what a
-call did, either: `run_script` already reports every call's request and
-response.
+`console.log(...)` is not that channel. It is the log, which `run_script` hands
+back to you, so it is **for you while you are working** — a count, a filtered id,
+a shape worth checking before you write the real thing. Leave it out of a script
+you keep. You do not need it to see what a call did, either: `run_script` already
+reports every call's request and response.
+
+Every level works and is recorded as the level it was printed at —
+`console.debug`, `console.log`, `console.info`, `console.warn`, `console.error` —
+and so does every other console method (`table`, `time`, `group`, …), which goes
+to devtools and is not reported back. There is no `kaja.log`: the standard
+console is the logging API. The person whose Kaja this is can mix your lines into
+the run's Calls view, so they are not private — but they are not output either.
 
 ```ts
 import { kaja } from "kaja";

--- a/desktop/mcp/tools.go
+++ b/desktop/mcp/tools.go
@@ -15,8 +15,9 @@ const runtimeNote = "Scripts are TypeScript run inside Kaja: top-level await wor
 	"A script is a body of statements, not a function: it has NO return value, and a top-level `return` is an error the app refuses to run. " +
 	"It draws what it produced instead: `kaja.text(...)`, `kaja.code(...)` and `kaja.table(columns).row(...)` draw on the run's canvas, " +
 	"which is the output the person who opens the script sees, and is how a script renders a table (never build one out of Markdown). " +
-	"`console.log(...)` writes the transcript back to you and nobody else - use it to probe while you work, and leave it out of a script " +
-	"you keep; every call's request and response is reported to you without it. " +
+	"`console.log(...)` writes the log back to you - use it to probe while you work, and leave it out of a script " +
+	"you keep; every call's request and response is reported to you without it. Every level is recorded as itself (debug/log/info/warn/error), " +
+	"every other console method goes to devtools only, and there is no `kaja.log` - the standard console is the logging API. " +
 	"A table can also be handed its rows - `kaja.table(columns, rows)` for an array, or an async generator that yields rows, " +
 	"which the table pulls a page at a time as the reader pages through it (declare a `search` parameter and it is restarted for each search). " +
 	"Your run draws its first page and reports `more: true`; nobody is there to page it, so read the rest with an ordinary loop if you need it. " +

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -43,6 +43,8 @@ import { Editor, registerKajaModule, setValueCompletionApps } from "./Editor";
 import { formatTypeScript } from "./formatter";
 import { monacoTheme, surfaceColor } from "./monacoTheme";
 import { remapEditorCode, remapSourcesToNewName } from "./sources";
+import { logFileLevel } from "./scriptConsole";
+import { logScriptLine } from "./uiLog";
 import { Configuration, ConfigurationApp, LogLevel, Runtime, VariableStatus } from "./server/api";
 import { getApiClient } from "./server/connection";
 import {
@@ -447,6 +449,24 @@ export function App() {
     [openRun],
   );
 
+  /**
+   * A line the script printed. It lands in the run it was printed in, so it can
+   * be read against the calls around it, and in kaja.log with its origin
+   * attached — the file is what a TestFlight user can actually send back.
+   *
+   * It is not a verdict: an error-level line says something went wrong in the
+   * script's own reckoning, not that the run failed, so it never colours the
+   * run's dot. Only `onScriptError` below does that.
+   */
+  const onScriptLog = useCallback(
+    (level: LogLevel, message: string) => {
+      logScriptLine(logFileLevel(level), message);
+      const run = openRun("Script output");
+      consoles.recordPrinted(run.fileId, run.id, level, message, Date.now());
+    },
+    [openRun],
+  );
+
   // Show a failed script run in the console; a script that dies silently looks
   // like it succeeded. Mirrored to console.error so it also lands in kaja.log.
   const onScriptError = useCallback(
@@ -540,7 +560,7 @@ export function App() {
 
   const kajaRef = useRef<Kaja>(null);
   if (!kajaRef.current) {
-    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onApprove, onBlockUpdate);
+    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onApprove, onBlockUpdate, onScriptLog);
   }
 
   /**

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -1,5 +1,5 @@
-import { Bot, Check, ChevronDown, ChevronsUpDown, ChevronUp, Copy, FoldVertical, Trash2, UnfoldVertical } from "lucide-react";
-import { Fragment, memo, useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { Bot, Check, ChevronDown, ChevronsUpDown, ChevronUp, Copy, FoldVertical, Logs, Trash2, UnfoldVertical } from "lucide-react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ApproveGesture, blockText } from "./blocks";
 import { dotClass, formatDuration } from "./callFormat";
 import { formatClockTime, formatDayLabel, formatElapsed, isSameDay } from "./callTime";
@@ -12,7 +12,7 @@ import { Spinner } from "./components/spinner";
 import { consoles } from "./consoles";
 import { JsonViewerHandle } from "./JsonViewer";
 import { RunLog } from "./RunLog";
-import { ConsoleItem, ConsoleTab, ConsoleView, defaultView, followSelection, RunGroup, RunSelection } from "./runs";
+import { callRows, ConsoleItem, ConsoleTab, ConsoleView, defaultView, followSelection, LogFloor, printedCounts, RunGroup, RunSelection } from "./runs";
 import { runShortcutLabel } from "./RunButton";
 import { TableView } from "./tableView";
 
@@ -120,11 +120,22 @@ export function Console({ fileId, onAnswer, onCancelAsk, onDecide, tableViews, o
   }, [fileId, file.version, tailing]);
 
   const selectedGroup = groups.find((group) => group.run.id === selection?.runId);
-  const rows = selectedGroup?.calls ?? [];
+  const logFloor = file.logFloor;
+  // The merge is a walk of two ordered lists, so it is cheap — but it is read on
+  // every repaint of a run that may be thousands long, and both sides only ever
+  // grow at the end. Memoizing on the lengths is what makes a repaint that
+  // changed nothing cost nothing.
+  const rows = useMemo(
+    () => (selectedGroup ? callRows(selectedGroup, logFloor) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedGroup, selectedGroup?.calls.length, selectedGroup?.printed.length, logFloor],
+  );
+  const printed = useMemo(() => (selectedGroup ? printedCounts(selectedGroup) : { lines: 0, errors: 0 }), [selectedGroup, selectedGroup?.printed.length]);
   const selectedItem = selection?.itemId !== undefined ? rows.find((item) => item.id === selection.itemId) : undefined;
   const selectedCall = selectedItem?.call;
   const activeView = file.view ?? defaultView(selectedGroup);
   const waiting = selectedGroup?.awaiting;
+  const onLogFloorChange = useCallback((floor: LogFloor) => consoles.setLogFloor(fileId, floor, Date.now()), [fileId]);
 
   const selectRun = useCallback(
     (group: RunGroup) => {
@@ -171,7 +182,7 @@ export function Console({ fileId, onAnswer, onCancelAsk, onDecide, tableViews, o
     (itemId: string) => {
       if (!selectedGroup) return;
       setTailing(false);
-      onViewChange("log");
+      onViewChange("calls");
       onSelect({ runId: selectedGroup.run.id, itemId });
     },
     [selectedGroup, onSelect, onViewChange],
@@ -213,13 +224,16 @@ export function Console({ fileId, onAnswer, onCancelAsk, onDecide, tableViews, o
         <Console.RunSelect groups={groups} selectedGroup={selectedGroup} onSelect={selectRun} onClear={onClear} now={now} />
         <div className="h-4 w-px shrink-0 bg-border" />
         <SegmentedControl className="h-[26px] shrink-0 p-[2px]" aria-label="Run view">
+          {/* "Calls" rather than "Log": a row here is a call and only a call,
+              and "log" is what anyone means by what a script printed — which is
+              now a thing this view can mix in. */}
           <SegmentedControl.Button
-            selected={activeView === "log"}
+            selected={activeView === "calls"}
             className="h-[20px] px-2.5 py-0 text-xs"
-            onClick={() => onViewChange("log")}
-            data-testid="console-view-log"
+            onClick={() => onViewChange("calls")}
+            data-testid="console-view-calls"
           >
-            Log
+            Calls
           </SegmentedControl.Button>
           <SegmentedControl.Button
             selected={activeView === "canvas"}
@@ -258,9 +272,14 @@ export function Console({ fileId, onAnswer, onCancelAsk, onDecide, tableViews, o
             {position} of {groups.length}
           </span>
         </div>
+        {/* Only there when the run printed something, on the same rule as
+            everything else in this header: a control over nothing is chrome. */}
+        {activeView === "calls" && printed.lines > 0 && (
+          <Console.LogFloorSelect floor={logFloor} lines={printed.lines} errors={printed.errors} onChange={onLogFloorChange} />
+        )}
         {showUtilities && (
           <div className="ml-auto flex shrink-0 items-center gap-2 @max-[430px]:hidden">
-            {activeView === "log" && (
+            {activeView === "calls" && (
               <>
                 <IconButton
                   icon={FoldVertical}
@@ -313,6 +332,8 @@ export function Console({ fileId, onAnswer, onCancelAsk, onDecide, tableViews, o
           activeTab={activeTab}
           selectedItem={selectedItem}
           waiting={waiting !== undefined}
+          logFloor={logFloor}
+          printed={printed}
           jsonViewerRef={jsonViewerRef}
           now={now}
           tailing={tailing}
@@ -320,12 +341,80 @@ export function Console({ fileId, onAnswer, onCancelAsk, onDecide, tableViews, o
           onTailingChange={setTailing}
           onSelectRow={selectRow}
           onTabChange={onTabChange}
+          onShowLogs={() => onLogFloorChange("all")}
           onGoToCanvas={() => onViewChange("canvas")}
         />
       ) : null}
     </div>
   );
 }
+
+const FLOOR_LABELS: { floor: LogFloor; label: string; note: string }[] = [
+  { floor: "off", label: "Off", note: "Calls only" },
+  { floor: "error", label: "Errors", note: "console.error" },
+  { floor: "warn", label: "Warnings", note: "console.warn and above" },
+  { floor: "all", label: "All", note: "Everything the script printed" },
+];
+
+/**
+ * How much of what the script printed the calls view mixes in.
+ *
+ * A floor rather than a checkbox per level: the levels are ordered, and
+ * "warnings but not errors" is not a question anyone asks. It is one control
+ * because four switches over a list that is usually empty is more chrome than
+ * the thing it configures.
+ */
+Console.LogFloorSelect = function ({
+  floor,
+  lines,
+  errors,
+  onChange,
+}: {
+  floor: LogFloor;
+  lines: number;
+  errors: number;
+  onChange: (floor: LogFloor) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const active = floor !== "off";
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-testid="console-log-floor"
+          aria-label="Include what the script printed"
+          className={cn(
+            "ml-auto flex h-[26px] shrink-0 items-center gap-1.5 rounded-md border px-2 text-xs @max-[430px]:hidden",
+            active ? "border-border bg-muted text-foreground" : "border-transparent text-muted-foreground hover:bg-accent hover:text-foreground",
+          )}
+        >
+          <Logs size={13} />
+          <span className="font-mono tabular-nums">{lines}</span>
+          {errors > 0 && <span className="h-1.5 w-1.5 rounded-full bg-destructive" aria-label={`${errors} printed at error level`} />}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" side="bottom" className="w-[240px] p-0">
+        <div className="border-b border-border px-3 py-2 text-xs tracking-[0.06em] text-muted-foreground">SCRIPT LOG</div>
+        {FLOOR_LABELS.map((option) => (
+          <DropdownMenuItem
+            key={option.floor}
+            className={cn("h-9 gap-3 rounded-none px-3", option.floor === floor && "bg-accent")}
+            onSelect={() => {
+              onChange(option.floor);
+              setOpen(false);
+            }}
+          >
+            <span className="w-3 shrink-0">{option.floor === floor && <Check size={13} />}</span>
+            <span className="flex-1 text-xs text-foreground">{option.label}</span>
+            <span className="shrink-0 text-xs text-muted-foreground">{option.note}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
 
 interface RunSelectProps {
   groups: RunGroup[];

--- a/ui/src/RunLog.tsx
+++ b/ui/src/RunLog.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "./components/spinner";
 import { unwrapEnvelope } from "./httpEnvelope";
 import { JsonViewer, JsonViewerHandle } from "./JsonViewer";
 import { MethodCall } from "./kaja";
-import { callStatus, ConsoleItem, ConsoleTab, itemStatus, RunGroup, RunStatus } from "./runs";
+import { callStatus, ConsoleItem, ConsoleTab, itemStatus, LogFloor, printedLevel, RunGroup, RunStatus } from "./runs";
 import { runShortcutLabel } from "./RunButton";
 import { LogLevel } from "./server/api";
 import { unwrapFailure, upstreamRequestLine } from "./upstreamHeaders";
@@ -39,6 +39,10 @@ interface RunLogProps {
   activeTab: ConsoleTab;
   selectedItem?: ConsoleItem;
   waiting: boolean;
+  // How much of what the script printed is mixed into the rows, so the tail bar
+  // can say what is being left out.
+  logFloor: LogFloor;
+  printed: { lines: number; errors: number };
   jsonViewerRef: React.MutableRefObject<JsonViewerHandle | null>;
   now: number;
   tailing: boolean;
@@ -47,6 +51,7 @@ interface RunLogProps {
   onTailingChange: (tailing: boolean) => void;
   onSelectRow: (itemId: string) => void;
   onTabChange: (tab: ConsoleTab) => void;
+  onShowLogs: () => void;
   onGoToCanvas: () => void;
 }
 
@@ -66,6 +71,8 @@ export function RunLog({
   activeTab,
   selectedItem,
   waiting,
+  logFloor,
+  printed,
   jsonViewerRef,
   now,
   tailing,
@@ -73,6 +80,7 @@ export function RunLog({
   onTailingChange,
   onSelectRow,
   onTabChange,
+  onShowLogs,
   onGoToCanvas,
 }: RunLogProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -83,7 +91,11 @@ export function RunLog({
   const total = rows.length;
   const slowest = group.stats.slowest;
   const failures = group.failures;
-  const scriptFailed = group.items.some((item) => item.logs?.some((log) => log.level === LogLevel.LEVEL_ERROR));
+  const scriptFailed = group.items.some((item) => !item.printed && item.logs?.some((log) => log.level === LogLevel.LEVEL_ERROR));
+  // What the floor is keeping out. With the floor off that is everything the
+  // script printed, which is exactly when the tail bar has something to offer.
+  const shown = rows.length - group.calls.length;
+  const hidden = { lines: printed.lines - shown, errors: logFloor === "off" ? printed.errors : 0 };
 
   useLayoutEffect(() => {
     const element = scrollRef.current;
@@ -132,23 +144,36 @@ export function RunLog({
         ) : (
           <div style={{ height: total * CALL_ROW_HEIGHT }}>
             <div style={{ transform: `translateY(${first * CALL_ROW_HEIGHT}px)` }}>
-              {visible.map((item) => (
-                <RunLog.CallRow
-                  key={item.id}
-                  id={item.id}
-                  name={`${item.call!.service.name}.${item.call!.method.name}`}
-                  timestamp={item.timestamp}
-                  loopKey={item.key}
-                  status={itemStatus(item)}
-                  durationMs={item.call!.durationMs}
-                  errorCode={callErrorCode(item.call!)}
-                  fraction={barFraction(item.call!.durationMs, slowest)}
-                  selected={item.id === selectedItemId}
-                  stale={group.run.stale === true}
-                  onSelect={onSelectRow}
-                  now={now}
-                />
-              ))}
+              {visible.map((item) =>
+                item.call ? (
+                  <RunLog.CallRow
+                    key={item.id}
+                    id={item.id}
+                    name={`${item.call.service.name}.${item.call.method.name}`}
+                    timestamp={item.timestamp}
+                    loopKey={item.key}
+                    status={itemStatus(item)}
+                    durationMs={item.call.durationMs}
+                    errorCode={callErrorCode(item.call)}
+                    fraction={barFraction(item.call.durationMs, slowest)}
+                    selected={item.id === selectedItemId}
+                    stale={group.run.stale === true}
+                    onSelect={onSelectRow}
+                    now={now}
+                  />
+                ) : (
+                  <RunLog.LogRow
+                    key={item.id}
+                    id={item.id}
+                    timestamp={item.timestamp}
+                    level={printedLevel(item)}
+                    message={item.logs?.[0]?.message ?? ""}
+                    selected={item.id === selectedItemId}
+                    stale={group.run.stale === true}
+                    onSelect={onSelectRow}
+                  />
+                ),
+              )}
             </div>
           </div>
         )}
@@ -160,8 +185,11 @@ export function RunLog({
         rowsBelow={rowsBelow}
         failures={failures}
         dropped={group.dropped}
+        hiddenLines={hidden.lines}
+        hiddenErrors={hidden.errors}
         tailing={tailing}
         onFollow={() => onTailingChange(true)}
+        onShowLogs={onShowLogs}
         onGoToCanvas={onGoToCanvas}
       />
 
@@ -175,9 +203,13 @@ export function RunLog({
           <RunLog.NoPayload>Payload let go to keep this run bounded — run to see it live</RunLog.NoPayload>
         ) : selectedItem?.call ? (
           <RunLog.PayloadPane methodCall={selectedItem.call} activeTab={activeTab} onTabChange={onTabChange} jsonViewerRef={jsonViewerRef} />
+        ) : selectedItem?.printed ? (
+          <RunLog.PrintedPane message={selectedItem.logs?.[0]?.message ?? ""} level={printedLevel(selectedItem)} />
         ) : (
           <div className="flex min-h-0 flex-1 items-center justify-center text-xs text-muted-foreground">
-            {total === 0 ? "Nothing to show." : "Select a call."}
+            {/* With logs mixed in, a row is not necessarily a call — and this
+                pane is what a printed line's full text opens into. */}
+            {total === 0 ? "Nothing to show." : logFloor === "off" ? "Select a call." : "Select a row."}
           </div>
         )}
       </div>
@@ -196,6 +228,81 @@ RunLog.NoPayload = function ({ children }: { children: React.ReactNode }) {
   );
 };
 
+interface LogRowProps {
+  id: string;
+  timestamp: number;
+  level: LogLevel;
+  message: string;
+  selected: boolean;
+  stale: boolean;
+  onSelect: (itemId: string) => void;
+}
+
+/**
+ * One line the script printed, mixed into the calls at the point it was printed.
+ *
+ * It is the same fixed 24px as a call row and truncates rather than wrapping —
+ * the log's windowing is arithmetic only because every row is that height, and a
+ * `console.log` of a whole response would otherwise be a row a screen tall. The
+ * full line is one click away in the pane below, which had nothing to show for a
+ * row that isn't a call anyway.
+ */
+RunLog.LogRow = memo(function LogRow({ id, timestamp, level, message, selected, stale, onSelect }: LogRowProps) {
+  return (
+    <div
+      data-testid="console-log-row"
+      className={cn("flex shrink-0 cursor-pointer items-center gap-2.5 px-3", selected ? "bg-accent" : "hover:bg-accent/50", stale && "opacity-75")}
+      style={{ height: CALL_ROW_HEIGHT }}
+      onClick={() => onSelect(id)}
+    >
+      {/* A printed line is a channel rather than a verdict, so it takes a bar in
+          the status slot instead of a dot: it is deliberately not one of the
+          things the run's dot is the worst of. */}
+      <span className={cn("h-[9px] w-[2px] shrink-0 rounded-full", logLevelClass(level))} />
+      <span className="w-[8ch] shrink-0 font-mono text-xs tabular-nums text-muted-foreground @max-[360px]:hidden">{formatClockTime(timestamp)}</span>
+      <span className={cn("min-w-0 flex-1 truncate font-mono text-xs", level >= LogLevel.LEVEL_WARN ? logLevelTextClass(level) : "text-muted-foreground/80")}>
+        {message}
+      </span>
+    </div>
+  );
+});
+
+// The full text of a printed line, which is why the row above it may truncate.
+RunLog.PrintedPane = function ({ message, level }: { message: string; level: LogLevel }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-[30px] shrink-0 items-center gap-2 border-b border-border px-3">
+        <span className={cn("h-[9px] w-[2px] shrink-0 rounded-full", logLevelClass(level))} />
+        <span className="text-xs text-muted-foreground">{logLevelLabel(level)}</span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto px-3 py-2">
+        <pre className={cn("whitespace-pre-wrap break-words font-mono text-xs", level >= LogLevel.LEVEL_WARN ? logLevelTextClass(level) : "text-foreground")}>
+          {message}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+function logLevelClass(level: LogLevel): string {
+  if (level === LogLevel.LEVEL_ERROR) return "bg-destructive";
+  if (level === LogLevel.LEVEL_WARN) return "bg-amber-500";
+  return "bg-muted-foreground/40";
+}
+
+function logLevelTextClass(level: LogLevel): string {
+  if (level === LogLevel.LEVEL_ERROR) return "text-destructive";
+  if (level === LogLevel.LEVEL_WARN) return "text-amber-600 dark:text-amber-400";
+  return "text-muted-foreground";
+}
+
+function logLevelLabel(level: LogLevel): string {
+  if (level === LogLevel.LEVEL_ERROR) return "console.error";
+  if (level === LogLevel.LEVEL_WARN) return "console.warn";
+  if (level === LogLevel.LEVEL_DEBUG) return "console.debug";
+  return "console.log";
+}
+
 interface TailBarProps {
   waiting: boolean;
   scriptFailed: boolean;
@@ -204,8 +311,15 @@ interface TailBarProps {
   // Rows a very long run stopped keeping. The log says where it stops being
   // complete rather than quietly ending there.
   dropped: number;
+  // Lines the script printed that the floor is not showing, and how many of them
+  // were errors. Left out of the list is not the same as never happened, and a
+  // clean list over a run that printed an error is the one thing this refuses to
+  // be — so it is stated here, where what is out of sight is always stated.
+  hiddenLines: number;
+  hiddenErrors: number;
   tailing: boolean;
   onFollow: () => void;
+  onShowLogs: () => void;
   onGoToCanvas: () => void;
 }
 
@@ -214,8 +328,20 @@ interface TailBarProps {
  * script threw, is a fact about the whole run, and the log stays readable while
  * it waits — the pause blocks the script, not your reading.
  */
-RunLog.TailBar = function ({ waiting, scriptFailed, rowsBelow, failures, dropped, tailing, onFollow, onGoToCanvas }: TailBarProps) {
-  if (!waiting && !scriptFailed && rowsBelow <= 0 && failures === 0 && dropped === 0 && tailing) return null;
+RunLog.TailBar = function ({
+  waiting,
+  scriptFailed,
+  rowsBelow,
+  failures,
+  dropped,
+  hiddenLines,
+  hiddenErrors,
+  tailing,
+  onFollow,
+  onShowLogs,
+  onGoToCanvas,
+}: TailBarProps) {
+  if (!waiting && !scriptFailed && rowsBelow <= 0 && failures === 0 && dropped === 0 && hiddenLines === 0 && tailing) return null;
 
   const state = waiting ? "waiting" : scriptFailed ? "failed" : "counts";
 
@@ -238,6 +364,20 @@ RunLog.TailBar = function ({ waiting, scriptFailed, rowsBelow, failures, dropped
       {state === "failed" && <span className="text-destructive">Script failed</span>}
       {state === "counts" && rowsBelow > 0 && <span className="text-muted-foreground">{rowsBelow} more</span>}
       <div className="ml-auto flex shrink-0 items-center gap-3">
+        {hiddenLines > 0 && (
+          <button
+            type="button"
+            data-testid="console-show-logs"
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            onClick={onShowLogs}
+            title="Mix what the script printed into the calls"
+          >
+            {/* A dot rather than a second "errors" — the failed-call count sits a
+                few pixels to the right and the two must not read as one number. */}
+            {hiddenErrors > 0 && <span className="h-1.5 w-1.5 rounded-full bg-destructive" />}
+            {hiddenLines === 1 ? "1 log line" : `${hiddenLines} log lines`}
+          </button>
+        )}
         {dropped > 0 && <span className="text-muted-foreground">{dropped} not kept</span>}
         {failures > 0 && <span className="text-amber-600 dark:text-amber-400">{failures === 1 ? "1 error" : `${failures} errors`}</span>}
         {!tailing && (

--- a/ui/src/approve.test.ts
+++ b/ui/src/approve.test.ts
@@ -16,6 +16,7 @@ function held(decide: (call: ApproveBlock) => Promise<ApproveDecision>) {
       return decide(call);
     },
     (blockId, block) => void blocks.set(blockId, block),
+    () => {},
   );
   const approvals = (): ApproveBlock[] => [...blocks.values()].filter((block): block is ApproveBlock => block.kind === "approve");
   const only = (): ApproveBlock => {

--- a/ui/src/callGroups.test.ts
+++ b/ui/src/callGroups.test.ts
@@ -184,3 +184,23 @@ describe("groupKeyLabel", () => {
     expect(groupKeyLabel(items)).toBe("vera-lune, moth-lantern +2");
   });
 });
+
+describe("what a script printed", () => {
+  const printed = (id: string): ConsoleItem => ({ id, runId: "run-1", timestamp: 0, logs: [{ level: LogLevel.LEVEL_INFO, message: "tick" }], printed: true });
+
+  // The canvas is what the run drew, and printing is not drawing.
+  it("never reaches the canvas", () => {
+    const entries = foldCalls([call("c1", "ListShows"), printed("p1"), call("c2", "ListShows")]);
+    expect(entries.flatMap((entry) => (entry.kind === "calls" ? entry.items : [entry.item])).map((item) => item.id)).toEqual(["c1", "c2"]);
+  });
+
+  /**
+   * "Anything drawn between two calls breaks the group" is about drawing. A loop
+   * that logs each iteration would otherwise never fold at all.
+   */
+  it("does not break a loop's fold", () => {
+    const entries = foldCalls([call("c1", "ListShows"), printed("p1"), call("c2", "ListShows"), printed("p2"), call("c3", "ListShows")]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe("calls");
+  });
+});

--- a/ui/src/callGroups.ts
+++ b/ui/src/callGroups.ts
@@ -83,6 +83,17 @@ export class CallFold {
   }
 
   push(item: ConsoleItem): void {
+    /**
+     * A line the script printed is not something it drew, so it never reaches the
+     * canvas — it belongs in the calls view, where it can be read against the call
+     * before it.
+     *
+     * It doesn't break a fold either, which is the consequence worth stating:
+     * "anything drawn between two calls breaks the group" is about drawing, and a
+     * loop that logs each iteration would otherwise never fold at all.
+     */
+    if (item.printed) return;
+
     const name = callName(item);
     if (name === undefined) {
       this.#loose = 0;

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -75,7 +75,6 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
 
   let transport;
   if (isWailsEnvironment()) {
-    console.log("Creating client in Wails environment - using WailsTransport in target mode");
     // Use Wails transport in target mode for external API calls (supports both Twirp and gRPC)
     // Pass appRef so URL and headers are read dynamically at request time
     transport = new WailsTransport({

--- a/ui/src/consoles.test.ts
+++ b/ui/src/consoles.test.ts
@@ -391,10 +391,10 @@ describe("selection, tab and view", () => {
 
   it("sticks to the file across later runs", () => {
     start("a.ts", "run-1");
-    store.setView("a.ts", "log", NOW);
+    store.setView("a.ts", "calls", NOW);
     start("a.ts", "run-2");
 
-    expect(store.file("a.ts").view).toBe("log");
+    expect(store.file("a.ts").view).toBe("calls");
   });
 });
 
@@ -473,11 +473,11 @@ describe("the view a run opens in", () => {
     store.recordCall("a.ts", created.id, call("GetShow"), NOW);
     paint();
 
-    expect(defaultView(store.file("a.ts").groups[0])).toBe("log");
+    expect(defaultView(store.file("a.ts").groups[0])).toBe("calls");
   });
 
   it("opens on the log when there is no run at all", () => {
-    expect(defaultView(undefined)).toBe("log");
+    expect(defaultView(undefined)).toBe("calls");
   });
 });
 
@@ -552,5 +552,65 @@ describe("findBlock", () => {
     expect(store.findBlock("table-1")?.run.id).toBe(created.id);
     expect(store.findBlock("table-1")?.fileId).toBe("a.ts");
     expect(store.findBlock("nothing")).toBeUndefined();
+  });
+});
+
+describe("what a script printed", () => {
+  it("is kept beside the calls rather than among them", () => {
+    const created = start("a.ts");
+    store.recordCall("a.ts", created.id, call("GetShow"), NOW);
+    store.recordPrinted("a.ts", created.id, LogLevel.LEVEL_INFO, "42 shows", NOW + 1);
+    paint();
+
+    const group = store.file("a.ts").groups[0];
+    expect(group.calls).toHaveLength(1);
+    expect(group.printed).toHaveLength(1);
+    // Both are still items, which is what puts them in one order.
+    expect(group.items).toHaveLength(2);
+  });
+
+  /**
+   * A script whose only output is `console.log` would otherwise open on a canvas
+   * with nothing on it. Printing is not drawing.
+   */
+  it("does not count as something drawn", () => {
+    const created = start("a.ts");
+    store.recordPrinted("a.ts", created.id, LogLevel.LEVEL_INFO, "42 shows", NOW);
+    paint();
+
+    expect(store.file("a.ts").groups[0].drew).toBe(false);
+    expect(defaultView(store.file("a.ts").groups[0])).toBe("calls");
+  });
+
+  it("does not fail a run, even at error level", () => {
+    const created = start("a.ts");
+    store.recordCall("a.ts", created.id, call("GetShow"), NOW);
+    store.recordPrinted("a.ts", created.id, LogLevel.LEVEL_ERROR, "gave up on page 3", NOW + 1);
+    paint();
+
+    expect(store.file("a.ts").groups[0].status).toBe("success");
+    expect(store.file("a.ts").groups[0].failures).toBe(0);
+  });
+
+  // A script error is a verdict Kaja wrote, and goes on being one.
+  it("leaves a script error failing the run", () => {
+    const created = start("a.ts");
+    store.recordLogs("a.ts", created.id, [{ level: LogLevel.LEVEL_ERROR, message: "boom" }], NOW);
+    paint();
+
+    expect(store.file("a.ts").groups[0].status).toBe("error");
+  });
+});
+
+describe("the log floor", () => {
+  it("is off until it is asked for, and then sticks to the file", () => {
+    start("a.ts");
+    expect(store.file("a.ts").logFloor).toBe("off");
+
+    store.setLogFloor("a.ts", "all", NOW);
+    expect(store.file("a.ts").logFloor).toBe("all");
+    // Another file is another decision.
+    start("b.ts");
+    expect(store.file("b.ts").logFloor).toBe("off");
   });
 });

--- a/ui/src/consoles.ts
+++ b/ui/src/consoles.ts
@@ -2,8 +2,8 @@ import { Block, isAwaitingUser } from "./blocks";
 import { CallFold } from "./callGroups";
 import { MethodCall } from "./kaja";
 import { loopKey } from "./loopKey";
-import { ConsoleItem, ConsoleTab, ConsoleView, ItemStats, newItemId, Run, RunGroup, RunSelection, RunStatus } from "./runs";
-import { Log } from "./server/api";
+import { ConsoleItem, ConsoleTab, ConsoleView, ItemStats, LogFloor, newItemId, Run, RunGroup, RunSelection, RunStatus } from "./runs";
+import { Log, LogLevel } from "./server/api";
 
 /**
  * The console belongs to the file. A run is made by pressing Run on something,
@@ -43,6 +43,7 @@ const MAX_FILES = 50;
 class Group implements RunGroup {
   readonly items: ConsoleItem[] = [];
   readonly calls: ConsoleItem[] = [];
+  readonly printed: ConsoleItem[] = [];
   readonly stats = new ItemStats();
   readonly fold = new CallFold();
   drew = false;
@@ -83,7 +84,11 @@ class Group implements RunGroup {
     }
     this.items.push(item);
     if (item.call) this.calls.push(item);
-    if (item.block !== undefined || item.logs !== undefined) this.drew = true;
+    if (item.printed) this.printed.push(item);
+    // What the script drew, which is what decides the view a run opens in. A line
+    // it printed is not drawing: a script whose only output is `console.log`
+    // opening on its canvas would open on a canvas with nothing on it.
+    if (item.block !== undefined || (item.logs !== undefined && !item.printed)) this.drew = true;
     if (item.block !== undefined && isAwaitingUser(item.block)) this.#asked.push(item);
     this.stats.add(item);
     this.fold.push(item);
@@ -107,6 +112,9 @@ export class FileConsole {
   // Undefined until a view has been chosen, which is what lets a run that drew
   // something open on its canvas while an explicit choice still outranks it.
   view?: ConsoleView;
+  // How much of what a script printed the calls view mixes in. Off by default, so
+  // the list is a clean audit of calls until it is asked to be something else.
+  logFloor: LogFloor = "off";
   // Whether the store has been consulted for this file yet, so it is read once
   // rather than on every visit.
   loaded = false;
@@ -232,6 +240,13 @@ export class FileConsole {
 
   recordLogs(runId: string, logs: Log[], now: number): void {
     this.#append(runId, { id: newItemId(), runId, timestamp: now, logs });
+  }
+
+  // One `console.*` call from the script. Lines are kept one to an item rather
+  // than gathered: the calls view draws a row per line, and a row is what makes a
+  // line selectable and therefore readable in full.
+  recordPrinted(runId: string, level: LogLevel, message: string, now: number): void {
+    this.#append(runId, { id: newItemId(), runId, timestamp: now, logs: [{ level, message }], printed: true });
   }
 
   // The run's wall duration is known once the script has settled and everything
@@ -420,6 +435,12 @@ export class Consoles {
     this.#touch(fileId);
   }
 
+  recordPrinted(fileId: string | undefined, runId: string, level: LogLevel, message: string, now: number): void {
+    if (!fileId) return;
+    this.#ensure(fileId, now).recordPrinted(runId, level, message, now);
+    this.#touch(fileId);
+  }
+
   settleRun(fileId: string | undefined, runId: string, durationMs: number, now: number): boolean {
     if (!fileId) return false;
     const file = this.#ensure(fileId, now);
@@ -473,6 +494,16 @@ export class Consoles {
     const file = this.#ensure(fileId, now);
     if (file.view === view) return;
     file.view = view;
+    this.#touch(fileId, true);
+  }
+
+  // Whether the calls view mixes in what the script printed, and down to which
+  // level. Kept beside the view because it is the same kind of decision.
+  setLogFloor(fileId: string | undefined, floor: LogFloor, now: number): void {
+    if (!fileId) return;
+    const file = this.#ensure(fileId, now);
+    if (file.logFloor === floor) return;
+    file.logFloor = floor;
     this.#touch(fileId, true);
   }
 

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -143,6 +143,7 @@ test("defaultInput generates a request that serializes", () => {
       async () => "",
       async () => "approved" as const,
       () => {},
+      () => {},
     ),
   );
 

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -2,6 +2,7 @@ import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
 import { parseInteger } from "./ask";
 import { ApproveBlock, ApproveGesture, AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
+import { LogSink } from "./scriptConsole";
 import { pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
@@ -290,8 +291,8 @@ export class Kaja {
   #onApprove: ApproveRequest;
   #onBlockUpdate: BlockUpdate;
 
-  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest, onApprove: ApproveRequest, onBlockUpdate: BlockUpdate) {
-    this._internal = new KajaInternal(onMethodCallUpdate);
+  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest, onApprove: ApproveRequest, onBlockUpdate: BlockUpdate, onLog: LogSink) {
+    this._internal = new KajaInternal(onMethodCallUpdate, onLog);
     this.#onAsk = onAsk;
     this.#onApprove = onApprove;
     this.#onBlockUpdate = onBlockUpdate;
@@ -704,10 +705,18 @@ class KajaInternal {
    * that was full after the first few. Cleared with the approvals, by the run.
    */
   readonly sampledMethods = new Map<string, number>();
+  /**
+   * Where a line the script printed goes. It is here rather than passed into
+   * `runScript` because both doors — the editor's Run and the MCP server's — hold
+   * the one `Kaja`, and the sink outlives any single run the way the rest of this
+   * does.
+   */
+  readonly onLog: LogSink;
   #onMethodCallUpdate: MethodCallUpdate;
 
-  constructor(onMethodCallUpdate: MethodCallUpdate) {
+  constructor(onMethodCallUpdate: MethodCallUpdate, onLog: LogSink) {
     this.#onMethodCallUpdate = onMethodCallUpdate;
+    this.onLog = onLog;
   }
 
   methodCallUpdate(methodCall: MethodCall) {

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -30,8 +30,13 @@ const header = `// The Kaja runtime, imported as: import { kaja } from "kaja";
 // a top-level \`return\` is an error, so a script never returns anything. What it
 // produces it draws — kaja.text/code/table draw on the run's canvas, which is
 // what the person who ran it reads, and the calls it makes are recorded whether
-// or not it mentions them. console.log writes a transcript beside that, which is
-// somewhere to probe rather than somewhere to put a script's output.`;
+// or not it mentions them.
+//
+// console.log and friends write a log beside that: the console's Calls view can
+// mix those lines in among the calls, which is where a line is worth reading
+// against the call before it. It is somewhere to probe rather than somewhere to
+// put a script's output — the canvas is the output. There is no kaja.log; the
+// standard console is the logging API, at every level.`;
 
 export function kajaModuleDeclaration(variableNames: string[]): string {
   return `${header}

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -11,6 +11,7 @@ function draw() {
     () => Promise.reject(new Error("not asked")),
     () => Promise.reject(new Error("not approved")),
     (blockId, block) => void blocks.set(blockId, block),
+    () => {},
   );
   const only = (): TableBlock => {
     const block = [...blocks.values()].find((block) => block.kind === "table");

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -47,6 +47,7 @@ interface StoredItem {
   timestamp: number;
   call?: StoredCall;
   logs?: Log[];
+  printed?: boolean;
   block?: Block;
 }
 
@@ -145,7 +146,14 @@ export function serializeFile(runs: Run[], items: ConsoleItem[], now: number): S
 }
 
 function toStoredItem(item: ConsoleItem): StoredItem {
-  return { id: item.id, timestamp: item.timestamp, call: item.call ? toStoredCall(item.call) : undefined, logs: item.logs, block: storedBlock(item.block) };
+  return {
+    id: item.id,
+    timestamp: item.timestamp,
+    call: item.call ? toStoredCall(item.call) : undefined,
+    logs: item.logs,
+    printed: item.printed,
+    block: storedBlock(item.block),
+  };
 }
 
 // A question that was never answered is stored as one that was abandoned: the
@@ -186,6 +194,7 @@ export function deserializeFile(stored: StoredFile): LoadedRuns {
         timestamp: item.timestamp,
         call: item.call ? fromStoredCall(item.call) : undefined,
         logs: item.logs,
+        printed: item.printed,
         block: item.block,
       });
     }

--- a/ui/src/runs.test.ts
+++ b/ui/src/runs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { MethodCall } from "./kaja";
 import { Block } from "./blocks";
-import { callStatus, ConsoleItem, ItemStats, itemStatus, slowestOf, worstStatus } from "./runs";
+import { callRows, callStatus, ConsoleItem, ItemStats, itemStatus, printedCounts, printedLevel, RunGroup, slowestOf, worstStatus } from "./runs";
 import { LogLevel } from "./server/api";
 
 const NOW = 1_700_000_000_000;
@@ -173,5 +173,98 @@ describe("callStatus", () => {
   it("is streaming until the stream completes", () => {
     expect(callStatus(methodCall({ streamOutputs: [] }))).toBe("streaming");
     expect(callStatus(methodCall({ streamOutputs: [], streamComplete: true, output: {} }))).toBe("success");
+  });
+});
+
+function printed(id: string, at: number, level: LogLevel, message = "hello"): ConsoleItem {
+  return { id, runId: "run-1", timestamp: at, logs: [{ level, message }], printed: true };
+}
+
+// `callRows` reads the run's emission order off `items`, so a fixture states that
+// order and the two sub-lists are derived from it — the same way the store builds
+// them.
+function group(...items: ConsoleItem[]): RunGroup {
+  return { items, calls: items.filter((item) => item.call), printed: items.filter((item) => item.printed) } as RunGroup;
+}
+
+describe("printed items", () => {
+  /**
+   * A script that prints `console.error("retry 2")` in a loop and finishes is not
+   * a failed run. Only a verdict Kaja wrote about the run colours its dot.
+   */
+  it("never colour the run's status, at any level", () => {
+    expect(itemStatus(printed("p1", NOW, LogLevel.LEVEL_ERROR))).toBe("success");
+    expect(worstStatus([call("c1", "run-1"), printed("p1", NOW, LogLevel.LEVEL_ERROR)])).toBe("success");
+  });
+
+  // A script error is a verdict and goes on saying so.
+  it("leave a script error's verdict alone", () => {
+    expect(itemStatus(logs("l1", "run-1", LogLevel.LEVEL_ERROR))).toBe("error");
+  });
+
+  it("report the worst level they hold", () => {
+    expect(printedLevel(printed("p1", NOW, LogLevel.LEVEL_WARN))).toBe(LogLevel.LEVEL_WARN);
+    expect(printedLevel({ id: "p2", runId: "run-1", timestamp: NOW, printed: true, logs: [] })).toBe(LogLevel.LEVEL_DEBUG);
+  });
+});
+
+describe("callRows", () => {
+  const run = () =>
+    group(
+      printed("p1", NOW + 10, LogLevel.LEVEL_INFO),
+      call("c1", "run-1", { timestamp: NOW + 10 }),
+      printed("p2", NOW + 20, LogLevel.LEVEL_ERROR),
+      call("c2", "run-1", { timestamp: NOW + 20 }),
+    );
+
+  it("is calls and only calls with the floor off", () => {
+    expect(callRows(run(), "off")).toEqual(run().calls);
+  });
+
+  /**
+   * Every timestamp here is shared with the call beside it, which is what a log
+   * line printed immediately before a call actually looks like. Emission order is
+   * the answer; a timestamp tie-break would decide it by accident.
+   */
+  it("keeps the order things happened in, ties and all", () => {
+    expect(callRows(run(), "all").map((item) => item.id)).toEqual(["p1", "c1", "p2", "c2"]);
+  });
+
+  it("admits a level and everything above it", () => {
+    expect(callRows(run(), "error").map((item) => item.id)).toEqual(["c1", "p2", "c2"]);
+    expect(callRows(run(), "warn").map((item) => item.id)).toEqual(["c1", "p2", "c2"]);
+  });
+
+  it("returns the calls themselves when nothing is admitted, so the memo holds", () => {
+    const only = group(call("c1", "run-1"), printed("p1", NOW + 20, LogLevel.LEVEL_INFO));
+    expect(callRows(only, "error")).toBe(only.calls);
+  });
+
+  /**
+   * A line printed while a call is in flight sits after that call's row, not
+   * after its response: a call's row goes in when it was issued, which is what
+   * the log has always meant by order.
+   */
+  it("places a line printed during a call after that call", () => {
+    const during = group(call("c1", "run-1", { timestamp: NOW, durationMs: 500 }), printed("p1", NOW + 100, LogLevel.LEVEL_INFO));
+    expect(callRows(during, "all").map((item) => item.id)).toEqual(["c1", "p1"]);
+  });
+
+  // Blocks belong to the canvas and are never rows here.
+  it("leaves out what the run drew", () => {
+    const drew = group(call("c1", "run-1"), block("b1", "run-1", { kind: "text", text: "hello" }), printed("p1", NOW, LogLevel.LEVEL_INFO));
+    expect(callRows(drew, "all").map((item) => item.id)).toEqual(["c1", "p1"]);
+  });
+
+  it("keeps every line when there are no calls at all", () => {
+    const only = group(printed("p1", NOW, LogLevel.LEVEL_INFO), printed("p2", NOW, LogLevel.LEVEL_ERROR));
+    expect(callRows(only, "all").map((item) => item.id)).toEqual(["p1", "p2"]);
+  });
+});
+
+describe("printedCounts", () => {
+  it("counts the lines and the errors among them", () => {
+    const only = group(printed("p1", NOW, LogLevel.LEVEL_INFO), printed("p2", NOW, LogLevel.LEVEL_ERROR), printed("p3", NOW, LogLevel.LEVEL_ERROR));
+    expect(printedCounts(only)).toEqual({ lines: 3, errors: 2 });
   });
 });

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -52,6 +52,14 @@ export interface ConsoleItem {
   call?: MethodCall;
   logs?: Log[];
   block?: Block;
+  /**
+   * Set when the lines were printed by the script rather than written by Kaja as
+   * a verdict about the run. The difference is what they are worth: a verdict is
+   * the run's status, while a printed line is a channel — a script that prints
+   * `console.error("retry 2")` in a loop and finishes is not a failed run. So a
+   * printed item never colours the run's dot and never counts as something drawn.
+   */
+  printed?: boolean;
   // What identifies this call, read off its request when it was issued. The
   // request never changes after that, and the log draws this on every row — so
   // it is read once here rather than per row per repaint.
@@ -75,7 +83,34 @@ export type ConsoleTab = "request" | "response" | "headers";
  * it scannable at two hundred rows; the canvas wants to be varied. Serving both
  * in one surface bends one of them out of shape.
  */
-export type ConsoleView = "log" | "canvas";
+export type ConsoleView = "calls" | "canvas";
+
+/**
+ * How much of what the script printed the calls view mixes in. Off is the
+ * default, so the list is calls and nothing else until it is asked otherwise; the
+ * rest is a floor rather than a set of independent switches, because the levels
+ * are ordered (`LEVEL_DEBUG` 0 … `LEVEL_ERROR` 3) and "warnings but not errors"
+ * is not a thing anyone wants to ask for.
+ *
+ * It is remembered per file, on the same rule the view is: debugging is a mode,
+ * not a click.
+ */
+export type LogFloor = "off" | "error" | "warn" | "all";
+
+// The lowest level a floor admits. Off admits nothing, which is what makes this
+// undefined rather than a number no level can be below.
+export function logFloorLevel(floor: LogFloor): LogLevel | undefined {
+  switch (floor) {
+    case "off":
+      return undefined;
+    case "error":
+      return LogLevel.LEVEL_ERROR;
+    case "warn":
+      return LogLevel.LEVEL_WARN;
+    case "all":
+      return LogLevel.LEVEL_DEBUG;
+  }
+}
 
 /**
  * One run and everything under it. It is maintained by the file's console as the
@@ -87,8 +122,13 @@ export interface RunGroup {
   run: Run;
   // Everything the run produced, in emission order, never re-sorted.
   items: ConsoleItem[];
-  // The log's rows: a row is a call and only a call.
+  // The calls view's rows, before anything is mixed into them: a call and only a
+  // call.
   calls: ConsoleItem[];
+  // What the script printed, in emission order, kept beside the calls rather than
+  // among them — the mix is a view's decision and the floor can change without
+  // the run being re-read.
+  printed: ConsoleItem[];
   // The canvas, folded as it was drawn.
   entries: CanvasEntry[];
   // What the run says about itself, counted as its items arrived.
@@ -142,7 +182,17 @@ export function blockStatus(block: Block): RunStatus {
 export function itemStatus(item: ConsoleItem): RunStatus {
   if (item.call) return callStatus(item.call);
   if (item.block) return blockStatus(item.block);
+  // A line the script printed says something about the script's own reckoning,
+  // not about whether the run succeeded — only a verdict Kaja wrote does that.
+  if (item.printed) return "success";
   return item.logs ? logsStatus(item.logs) : "success";
+}
+
+// The level a printed item reports at, which is what the floor is read against
+// and what colours its row. An item holds the lines of one call, so it is one
+// level; the worst of them is the honest reading if that ever stops being true.
+export function printedLevel(item: ConsoleItem): LogLevel {
+  return (item.logs ?? []).reduce<LogLevel>((worst, log) => (log.level > worst ? log.level : worst), LogLevel.LEVEL_DEBUG);
 }
 
 export function itemName(item: ConsoleItem): string {
@@ -261,13 +311,53 @@ export function callCount(group: RunGroup): number {
 }
 
 /**
+ * The rows the calls view draws: its calls, with whatever the floor admits of
+ * what the script printed mixed in where it was printed.
+ *
+ * It reads `items`, which is the run in **emission order, never re-sorted** — so
+ * the order is the order things happened, by construction. Merging the two lists
+ * by timestamp was the obvious alternative and it is wrong: a log line and the
+ * call issued right after it land in the same millisecond often enough that the
+ * tie-break decides the reading, and `Date.now()` is not what put them in the run
+ * in the first place.
+ *
+ * A printed line therefore lands where it was **printed** and a call where it was
+ * **issued** — so a line printed while a call is in flight sits after that call's
+ * row, not after its response. That is what the log has always meant by order.
+ */
+export function callRows(group: RunGroup, floor: LogFloor): ConsoleItem[] {
+  const least = logFloorLevel(floor);
+  if (least === undefined || group.printed.length === 0) return group.calls;
+
+  const rows: ConsoleItem[] = [];
+  for (const item of group.items) {
+    if (item.call) rows.push(item);
+    else if (item.printed && printedLevel(item) >= least) rows.push(item);
+  }
+  // Nothing admitted means the calls themselves, so the caller's memo holds and
+  // the row list is the same object it was.
+  return rows.length === group.calls.length ? group.calls : rows;
+}
+
+// What the calls view's tail bar says about the lines it is not showing. A run
+// that printed an error and shows a clean list is a log that is silently
+// incomplete, which is the one thing this console refuses to be.
+export function printedCounts(group: RunGroup): { lines: number; errors: number } {
+  let errors = 0;
+  for (const item of group.printed) {
+    if (printedLevel(item) === LogLevel.LEVEL_ERROR) errors++;
+  }
+  return { lines: group.printed.length, errors };
+}
+
+/**
  * Which view a run opens in when nothing has been chosen. A script executed for
- * its output opens on that output; one that only calls opens on its log, where
+ * its output opens on that output; one that only calls opens on the calls, where
  * everything it did actually is. An explicit choice outranks this and sticks per
  * file — debugging is a mode, not a click.
  */
 export function defaultView(group: RunGroup | undefined): ConsoleView {
-  return group?.drew ? "canvas" : "log";
+  return group?.drew ? "canvas" : "calls";
 }
 
 // The measure a set of calls is drawn against, kept for reading a list that is

--- a/ui/src/scriptConsole.test.ts
+++ b/ui/src/scriptConsole.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { cloneConsole, formatLine, logFileLevel, scriptConsole } from "./scriptConsole";
+import { LogLevel } from "./server/api";
+
+function recorder() {
+  const lines: { level: LogLevel; message: string }[] = [];
+  return { lines, sink: (level: LogLevel, message: string) => void lines.push({ level, message }) };
+}
+
+// A console that records what it was asked to do, standing in for the real one.
+function fakeConsole(): { console: Console; calls: string[] } {
+  const calls: string[] = [];
+  const base = {
+    log: (...parts: unknown[]) => calls.push(`log:${parts.join(" ")}`),
+    info: (...parts: unknown[]) => calls.push(`info:${parts.join(" ")}`),
+    warn: (...parts: unknown[]) => calls.push(`warn:${parts.join(" ")}`),
+    error: (...parts: unknown[]) => calls.push(`error:${parts.join(" ")}`),
+    debug: (...parts: unknown[]) => calls.push(`debug:${parts.join(" ")}`),
+    table: (rows: unknown) => calls.push(`table:${JSON.stringify(rows)}`),
+    group: () => calls.push("group"),
+  };
+  return { console: base as unknown as Console, calls };
+}
+
+describe("scriptConsole", () => {
+  it("reports each level method at its proto level", () => {
+    const { lines, sink } = recorder();
+    const script = scriptConsole(sink, fakeConsole().console);
+
+    script.debug("d");
+    script.log("l");
+    script.info("i");
+    script.warn("w");
+    script.error("e");
+
+    expect(lines).toEqual([
+      { level: LogLevel.LEVEL_DEBUG, message: "d" },
+      // log and info are one level, which is what they effectively are anyway.
+      { level: LogLevel.LEVEL_INFO, message: "l" },
+      { level: LogLevel.LEVEL_INFO, message: "i" },
+      { level: LogLevel.LEVEL_WARN, message: "w" },
+      { level: LogLevel.LEVEL_ERROR, message: "e" },
+    ]);
+  });
+
+  it("still forwards the level methods to the real console", () => {
+    const real = fakeConsole();
+    const script = scriptConsole(recorder().sink, real.console);
+
+    script.log("hello");
+    script.error("boom");
+
+    expect(real.calls).toEqual(["log:hello", "error:boom"]);
+  });
+
+  /**
+   * The five-method stand-in this replaced made `console.table(rows)` throw
+   * "console.table is not a function" inside a script — a particularly bad way to
+   * find out that logging is being intercepted.
+   */
+  it("passes everything that is not a level straight through", () => {
+    const real = fakeConsole();
+    const { lines, sink } = recorder();
+    const script = scriptConsole(sink, real.console);
+
+    script.table([{ id: 1 }]);
+    script.group();
+
+    expect(real.calls).toEqual(['table:[{"id":1}]', "group"]);
+    // Instrumentation is devtools' business and stays there.
+    expect(lines).toEqual([]);
+  });
+
+  it("keeps working when the sink throws", () => {
+    const real = fakeConsole();
+    const script = scriptConsole(() => {
+      throw new Error("the console is gone");
+    }, real.console);
+
+    expect(() => script.log("still printed")).not.toThrow();
+    expect(real.calls).toEqual(["log:still printed"]);
+  });
+
+  it("finds methods that live on the prototype", () => {
+    const calls: string[] = [];
+    const prototype = { log: (...parts: unknown[]) => calls.push(parts.join(" ")) };
+    const real = Object.create(prototype) as Console;
+
+    scriptConsole(recorder().sink, real).log("from the prototype");
+
+    expect(calls).toEqual(["from the prototype"]);
+  });
+
+  it("clones a console without carrying its later patches", () => {
+    const real = fakeConsole();
+    const clone = cloneConsole(real.console);
+    (real.console as { log: unknown }).log = () => real.calls.push("patched");
+
+    clone.log("original");
+
+    expect(real.calls).toEqual(["log:original"]);
+  });
+});
+
+describe("formatLine", () => {
+  it("keeps strings as they were written and JSONs everything else", () => {
+    expect(formatLine(["shows:", 3, { id: "a" }])).toBe('shows: 3 {"id":"a"}');
+  });
+
+  // A bigint has no JSON form and is an ordinary proto field value.
+  it("prints a bigint rather than throwing over it", () => {
+    expect(formatLine([{ total: 9007199254740993n }])).toBe('{"total":"9007199254740993"}');
+  });
+
+  it("names an error rather than serialising it to {}", () => {
+    expect(formatLine([new TypeError("bad shape")])).toBe("TypeError: bad shape");
+  });
+
+  it("survives a value that cannot be serialised", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    expect(() => formatLine([cyclic])).not.toThrow();
+  });
+});
+
+describe("logFileLevel", () => {
+  it("keeps the level column a level", () => {
+    expect(logFileLevel(LogLevel.LEVEL_DEBUG)).toBe("DEBUG");
+    expect(logFileLevel(LogLevel.LEVEL_INFO)).toBe("INFO");
+    expect(logFileLevel(LogLevel.LEVEL_WARN)).toBe("WARN");
+    expect(logFileLevel(LogLevel.LEVEL_ERROR)).toBe("ERROR");
+  });
+});

--- a/ui/src/scriptConsole.ts
+++ b/ui/src/scriptConsole.ts
@@ -1,0 +1,124 @@
+import { LogLevel } from "./server/api";
+
+/**
+ * The `console` a script sees.
+ *
+ * A script's log lines belong to the run that printed them; every other
+ * `console.log` in Kaja belongs to whoever is debugging Kaja. Telling the two
+ * apart is not a judgement about a message — it is a matter of scope: the script
+ * body is wrapped in a function that takes `console` as a parameter, so inside it
+ * the name resolves to this wrapper and everywhere else to the real thing. App
+ * code a script calls into keeps the real console; a closure the script defines
+ * keeps this one, however late it fires.
+ *
+ * There is deliberately no `kaja.log`. The `kaja` object holds the verbs that are
+ * Kaja's own — drawing, asking, approving — and logging is not one of them:
+ * a second spelling of `console.log` would add a decision without adding a
+ * capability, and the value of a log line is that it costs nothing to write and
+ * nothing to delete.
+ */
+
+// Which proto level each console method reports at. `log` and `info` are one
+// level, which is what they effectively are in a browser too.
+export const CONSOLE_LEVELS: { readonly [method: string]: LogLevel } = {
+  debug: LogLevel.LEVEL_DEBUG,
+  log: LogLevel.LEVEL_INFO,
+  info: LogLevel.LEVEL_INFO,
+  warn: LogLevel.LEVEL_WARN,
+  error: LogLevel.LEVEL_ERROR,
+};
+
+export type LogSink = (level: LogLevel, message: string) => void;
+
+/**
+ * Everything the real console can do, with the five level methods reported to
+ * `sink` on the way through.
+ *
+ * The wrapper is built *from* the console rather than declared as a list of five
+ * methods: the list was what made `console.table(rows)` throw
+ * "console.table is not a function" inside an agent's snippet, which is a
+ * particularly bad way to find out that logging is being intercepted. Anything
+ * that isn't a level — `table`, `time`, `group`, `dir`, `trace`, and whatever a
+ * future runtime adds — passes straight through to devtools, which is where
+ * instrumentation belongs and where it stays.
+ */
+export function scriptConsole(sink: LogSink, real: Console = console): Console {
+  const wrapper = cloneConsole(real) as unknown as { [key: string]: unknown };
+
+  for (const [method, level] of Object.entries(CONSOLE_LEVELS)) {
+    const forward = wrapper[method] as ((...parts: unknown[]) => void) | undefined;
+    wrapper[method] = (...parts: unknown[]) => {
+      // Devtools first: a sink that throws must not swallow the line it was
+      // given, and a script's own logging must never be able to stop the script.
+      forward?.(...parts);
+      try {
+        sink(level, formatLine(parts));
+      } catch {
+        // A console that can fail is worse than one that is quiet.
+      }
+    };
+  }
+
+  return wrapper as unknown as Console;
+}
+
+/**
+ * A standalone object with every method the given console has, each forwarding to
+ * it. Used to build the script's console, and to keep hold of the real one before
+ * it is patched.
+ *
+ * Console methods sit on the object in some engines and on its prototype in
+ * others, and are not reliably enumerable in either — so the chain is walked by
+ * property name rather than spread or `for..in`. Each is bound to its owner: a
+ * method called with a different receiver is a detail no engine promises to
+ * tolerate.
+ */
+export function cloneConsole(real: Console): Console {
+  const clone: { [key: string]: unknown } = {};
+  for (let object: object | null = real; object && object !== Object.prototype; object = Object.getPrototypeOf(object)) {
+    for (const key of Object.getOwnPropertyNames(object)) {
+      if (key in clone) continue;
+      const value = (real as unknown as { [key: string]: unknown })[key];
+      clone[key] = typeof value === "function" ? (value as (...args: unknown[]) => unknown).bind(real) : value;
+    }
+  }
+  return clone as unknown as Console;
+}
+
+// One line from what was passed to one call. Strings are themselves, so the
+// commonest case reads as it was written; everything else is JSON, which is what
+// a script is printing when it prints anything else.
+export function formatLine(parts: unknown[]): string {
+  return parts.map(formatArg).join(" ");
+}
+
+function formatArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message ? `${value.name}: ${value.message}` : value.name;
+  try {
+    // A bigint has no JSON form and is an ordinary field value in a proto, so it
+    // is printed rather than thrown over.
+    return JSON.stringify(value, (_key, held) => (typeof held === "bigint" ? held.toString() : held)) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * How the level names reach `kaja.log`. The file is read by whoever is holding a
+ * broken build, so the level column stays a level and the origin is a marker in
+ * the message — `[ui] [ERROR] [script] …` says both things without teaching the
+ * file a second vocabulary.
+ */
+export function logFileLevel(level: LogLevel): string {
+  switch (level) {
+    case LogLevel.LEVEL_ERROR:
+      return "ERROR";
+    case LogLevel.LEVEL_WARN:
+      return "WARN";
+    case LogLevel.LEVEL_DEBUG:
+      return "DEBUG";
+    default:
+      return "INFO";
+  }
+}

--- a/ui/src/scriptRunner.test.ts
+++ b/ui/src/scriptRunner.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "bun:test";
 import { AskBlock } from "./blocks";
 import { Kaja } from "./kaja";
 import { runScriptCaptured } from "./scriptRunner";
+import { LogLevel } from "./server/api";
 
 function makeKaja(answer: (question: AskBlock) => string = () => ""): Kaja {
   return new Kaja(
     () => {},
     async (question) => answer(question),
     async () => "approved" as const,
+    () => {},
     () => {},
   );
 }
@@ -239,5 +241,66 @@ describe("kaja.value", () => {
         },
       },
     });
+  });
+});
+
+describe("the console a script sees", () => {
+  function withSink(): { kaja: Kaja; lines: { level: LogLevel; message: string }[] } {
+    const lines: { level: LogLevel; message: string }[] = [];
+    const kaja = new Kaja(
+      () => {},
+      async () => "",
+      async () => "approved" as const,
+      () => {},
+      (level, message) => void lines.push({ level, message }),
+    );
+    return { kaja, lines };
+  }
+
+  it("reports what the script printed, at the level it printed it", async () => {
+    const { kaja, lines } = withSink();
+
+    const run = await runScriptCaptured(`console.log("42 shows");\nconsole.error("gave up");`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(lines).toEqual([
+      { level: LogLevel.LEVEL_INFO, message: "42 shows" },
+      { level: LogLevel.LEVEL_ERROR, message: "gave up" },
+    ]);
+    // The agent's report gets the same lines, since a snippet is answered as well
+    // as recorded.
+    expect(run.console).toEqual(["42 shows", "gave up"]);
+  });
+
+  it("hands the script every console method, not only the five levels", async () => {
+    const { kaja } = withSink();
+
+    const run = await runScriptCaptured(`console.table([{ id: 1 }]);\nreturn typeof console.table;`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe("function");
+  });
+
+  /**
+   * The shadow is lexical, so a closure the script defines keeps it however late
+   * it fires — which is what makes a line printed from a callback land in the run
+   * that started it.
+   */
+  it("is kept by callbacks the script defines", async () => {
+    const { kaja, lines } = withSink();
+
+    const run = await runScriptCaptured(`await new Promise((done) => setTimeout(() => { console.log("later"); done(undefined); }, 0));`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(lines).toEqual([{ level: LogLevel.LEVEL_INFO, message: "later" }]);
+  });
+
+  it("does not capture logging from outside the script", async () => {
+    const { kaja, lines } = withSink();
+
+    console.log("this is Kaja debugging itself");
+    await runScriptCaptured(`console.log("this is the script");`, kaja, []);
+
+    expect(lines).toEqual([{ level: LogLevel.LEVEL_INFO, message: "this is the script" }]);
   });
 });

--- a/ui/src/scriptRunner.ts
+++ b/ui/src/scriptRunner.ts
@@ -2,6 +2,8 @@ import ts from "typescript";
 import { ApprovalRejectedError, AskCancelledError, Kaja } from "./kaja";
 import { Client, App, serviceId } from "./apps";
 import { printStatements } from "./appLoader";
+import { scriptConsole } from "./scriptConsole";
+import { deviceConsole } from "./uiLog";
 
 // Scripts are TypeScript but new Function only accepts JavaScript, so transpile
 // first. Parse errors are thrown with line numbers pointing into the user's
@@ -117,9 +119,14 @@ export function runScript(code: string, kaja: Kaja, apps: App[], onError: (error
   try {
     const { args, runCode } = prepareTask(code, kaja, apps);
 
-    // Wrap the user's code in an async function so async keyword can be used
+    // Wrap the user's code in an async function so async keyword can be used.
+    // `console` is a parameter of that wrapper, which is the whole of how a
+    // script's log lines are told from Kaja's own: inside the body the name
+    // resolves to the run's console, and everywhere else in the app to the real
+    // one — including in app code this script calls into.
     const func = new Function(
       ...Object.keys(args),
+      "console",
       `
       return (async function() {
         ${runCode}
@@ -127,7 +134,7 @@ export function runScript(code: string, kaja: Kaja, apps: App[], onError: (error
     `,
     );
 
-    result = func(...Object.values(args));
+    result = func(...Object.values(args), scriptConsole(kaja._internal.onLog, deviceConsole));
   } catch (err) {
     clearSignal();
     onError(err);
@@ -157,18 +164,14 @@ export interface CapturedRun {
 // agent can see what a script did.
 export async function runScriptCaptured(code: string, kaja: Kaja, apps: App[]): Promise<CapturedRun> {
   const lines: string[] = [];
-  const record = (level: string, parts: unknown[]) => {
-    lines.push(parts.map(stringifyConsoleArg).join(" "));
-    // Mirror to the real console so it still shows in dev tools.
-    (console as any)[level]?.(...parts);
-  };
-  const captureConsole = {
-    log: (...parts: unknown[]) => record("log", parts),
-    info: (...parts: unknown[]) => record("info", parts),
-    warn: (...parts: unknown[]) => record("warn", parts),
-    error: (...parts: unknown[]) => record("error", parts),
-    debug: (...parts: unknown[]) => record("debug", parts),
-  };
+  // The same console the editor's Run installs, teed into the report. An agent's
+  // snippet runs in the agent's scratch, so its lines belong in that scratch's
+  // console as well as in the answer: a run nobody is watching is still a run
+  // somebody can go and look at.
+  const captureConsole = scriptConsole((level, message) => {
+    lines.push(message);
+    kaja._internal.onLog(level, message);
+  }, deviceConsole);
 
   kaja._internal.approvedMethods.clear();
   kaja._internal.sampledMethods.clear();
@@ -195,14 +198,5 @@ export async function runScriptCaptured(code: string, kaja: Kaja, apps: App[]): 
       return { console: lines, error: `Script stopped: ${err.message}.` };
     }
     return { console: lines, error: err instanceof Error ? err.message : String(err) };
-  }
-}
-
-function stringifyConsoleArg(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
-  } catch {
-    return String(value);
   }
 }

--- a/ui/src/server/connection.ts
+++ b/ui/src/server/connection.ts
@@ -7,13 +7,9 @@ import { isWailsEnvironment } from "../wails";
 export function getApiClient(): ApiClient {
   // Always check environment fresh - don't cache if we're in a transitional state
   const isWails = isWailsEnvironment();
-  console.log("getApiClient() called - Creating API client for environment:", isWails ? "Wails" : "Web");
-
   if (isWails) {
-    console.log("Using WailsTransport in API mode");
     return new ApiClient(new WailsTransport({ mode: "api", protocol: Transport.TWIRP }));
   } else {
-    console.log("Using TwirpFetchTransport with baseUrl:", getBaseUrlForApi());
     return new ApiClient(
       new TwirpFetchTransport({
         baseUrl: getBaseUrlForApi(),

--- a/ui/src/server/wails-transport.ts
+++ b/ui/src/server/wails-transport.ts
@@ -262,12 +262,6 @@ export class WailsTransport implements RpcTransport {
     input: I,
     options: RpcOptions,
   ): { response: Promise<O>; status: Promise<RpcStatus>; trailers: Promise<RpcMetadata> } {
-    console.log(
-      `Wails${this.mode === "target" ? "Target" : ""}Transport calling method:`,
-      this.mode === "target" ? `${method.service.typeName}/${method.name}` : method.name,
-      this.mode === "target" ? `target: ${this.appRef?.target}` : "",
-    );
-
     const resultPromise = this.executeCall(method, input);
     const responsePromise = resultPromise.then((result) => result.output);
     const statusPromise = resultPromise.then(() => ({ code: "OK", detail: "" }));
@@ -282,25 +276,11 @@ export class WailsTransport implements RpcTransport {
 
   private async executeCall<I extends object, O extends object>(method: MethodInfo<I, O>, input: I): Promise<{ output: O; trailers: RpcMetadata }> {
     try {
-      console.log(`Executing Wails ${this.mode} call for method:`, method.name);
-      if (this.mode === "target") {
-        console.log("Target URL:", this.appRef?.target);
-      }
-      console.log("Input object:", input);
-
-      // Serialize input using protobuf-ts
+      // Serialize input using protobuf-ts. An empty result is valid: a method with
+      // no parameters has nothing to encode.
       const inputBytes = method.I.toBinary(input, { writeUnknownFields: false });
-      console.log("Serialized inputBytes length:", inputBytes.length);
-
-      // Empty serialization is valid for methods with no parameters
-      if (inputBytes.length === 0 && this.mode === "api") {
-        console.log("Empty serialization - this is valid for methods with no parameters like GetConfiguration");
-      }
-
       // Convert to array and ensure all values are valid bytes (0-255)
       const inputArray = Array.from(inputBytes);
-      console.log("Input array length:", inputArray.length);
-
       // Validate that all values are proper bytes (only if there are bytes)
       if (inputArray.length > 0) {
         const invalidBytes = inputArray.filter((b) => b < 0 || b > 255 || !Number.isInteger(b));
@@ -313,13 +293,11 @@ export class WailsTransport implements RpcTransport {
       const trailers: RpcMetadata = {};
 
       if (this.mode === "api") {
-        console.log("Calling Wails Twirp with method:", method.name);
         responseBody = await Twirp(method.name, inputArray);
       } else {
         // mode === "target" - read URL and headers dynamically from appRef
         const fullMethodPath = `${method.service.typeName}/${method.name}`;
         const headersJson = JSON.stringify(transportHeaders(this.appRef!.configuration));
-        console.log("Calling Wails Target with method:", fullMethodPath, "protocol:", this.protocol, "headers:", headersJson);
         const result = await Target(this.appRef!.target, fullMethodPath, inputArray, this.protocol, headersJson);
 
         if (result.statusCode >= 400) {
@@ -339,11 +317,8 @@ export class WailsTransport implements RpcTransport {
         responseBody = result.body;
       }
 
-      console.log(`Wails ${this.mode} result:`, responseBody);
-
       // Both API and Target modes use the same response handling (base64 decoding)
       const output = method.O.fromBinary(responseBytes(responseBody));
-      console.log(`Wails ${this.mode} output:`, output);
       return { output, trailers };
     } catch (error) {
       console.error(`Wails ${this.mode} call failed:`, error);

--- a/ui/src/uiLog.ts
+++ b/ui/src/uiLog.ts
@@ -1,3 +1,4 @@
+import { cloneConsole } from "./scriptConsole";
 import { LogFromUI } from "./wailsjs/go/main/App";
 import { isWailsEnvironment } from "./wails";
 
@@ -26,6 +27,30 @@ function send(level: string, args: unknown[]): void {
   const message = args.map(formatArg).join(" ");
   // Logging must never throw or recurse back into the patched console.
   LogFromUI(level, message).catch(() => {});
+}
+
+/**
+ * The console as it was before `installUiLog` patched it.
+ *
+ * A script's console forwards here rather than to the live one: the patched
+ * `error`/`warn` write to kaja.log themselves, and a script's lines are written
+ * there by `logScriptLine` with their origin attached — so forwarding to the
+ * patch would put every script error in the file twice, once anonymously.
+ */
+export const deviceConsole: Console = cloneConsole(console);
+
+/**
+ * A line a script printed, in kaja.log. The level column stays a level so the
+ * file is still greppable by severity, and `[script]` says where the line came
+ * from: `2026-08-10T… [ui] [INFO] [script] 42 shows`.
+ *
+ * No-op outside the desktop, like everything else here.
+ */
+export function logScriptLine(level: string, message: string): void {
+  if (!isWailsEnvironment()) {
+    return;
+  }
+  LogFromUI(level, `[script] ${message}`).catch(() => {});
 }
 
 /**


### PR DESCRIPTION
A script's `console.log` went to the webview console and nowhere else, so it was invisible in a shipped build. It now lands in the run it was printed in: the log view is **Calls**, and one control mixes those lines in — off by default, as a severity floor, with the tail bar stating what it's hiding.

Also deletes the eight per-call `console.log`s the Wails transport wrote on every call, one of which printed the app's headers.

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkZf7CLBN4r6KvwkNXcp4)_