### PR TITLE
Deployed every pull request to its own Fly app

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -18,7 +18,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Build Docker image
-        run: docker build . -t kaja-dev:latest --build-arg RUN_TESTS=true --build-arg GIT_REF=${{ github.sha }}
+        run: docker build . -t kaja-dev:latest --target runner --build-arg RUN_TESTS=true --build-arg GIT_REF=${{ github.sha }}
 
       - name: Start Docker container
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          target: runner
           push: true
           tags: |
             kajatools/kaja:latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,96 @@
+name: preview
+# Every pull request gets its own Kaja running on Fly, at
+# https://kaja-pr-<number>.fly.dev, serving the repository's own demo workspace
+# (workspace/kaja.json). It is rebuilt on every push to the pull request and
+# destroyed when the pull request closes.
+#
+# Needs a FLY_API_TOKEN repository secret that may create and destroy apps in
+# the org — `fly tokens create org <org>`, not the app-scoped deploy token —
+# and optionally a FLY_ORG repository variable (defaults to "personal").
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# One deploy per pull request at a time; a newer push supersedes an in-flight
+# one, and closing supersedes both.
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
+  APP_NAME: kaja-pr-${{ github.event.number }}
+
+jobs:
+  deploy:
+    # A fork's pull request has no access to the token, so there is nothing to
+    # deploy with. Closing is the destroy job's.
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Check the token is set
+        run: |
+          if [ -z "${FLY_API_TOKEN:-}" ]; then
+            echo "::error::FLY_API_TOKEN secret is not set — create one with 'fly tokens create org <org>'"
+            exit 1
+          fi
+
+      - name: Create the app if it doesn't exist yet
+        run: flyctl apps create "$APP_NAME" --org "$FLY_ORG" || true
+
+      # The Dockerfile is at the repository root, so the build context is "."
+      # and the config is passed separately. GIT_REF is what the running Kaja
+      # reports as its version, so the preview names the commit it was built
+      # from.
+      - name: Deploy
+        run: |
+          flyctl deploy . \
+            --config deploy/preview/fly.toml \
+            --app "$APP_NAME" \
+            --build-arg GIT_REF="${{ github.event.pull_request.head.sha }}" \
+            --ha=false \
+            --remote-only \
+            --yes
+
+      - name: Build the preview comment
+        run: |
+          {
+            echo "## 🚀 Preview"
+            echo
+            echo "This pull request is running at <https://${APP_NAME}.fly.dev>."
+            echo
+            echo "It serves the \`workspace/\` demo configuration, read-only, and is destroyed when this pull request closes."
+          } > preview-comment.md
+
+      - name: Post sticky preview comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: preview
+          path: preview-comment.md
+
+  destroy:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Destroy the app
+        run: flyctl apps destroy "$APP_NAME" --yes || true
+
+      - name: Remove the preview comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: preview
+          delete: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -63,21 +63,11 @@ jobs:
             --remote-only \
             --yes
 
-      - name: Build the preview comment
-        run: |
-          {
-            echo "## 🚀 Preview"
-            echo
-            echo "This pull request is running at <https://${APP_NAME}.fly.dev>."
-            echo
-            echo "It serves the \`workspace/\` demo configuration, read-only, and is destroyed when this pull request closes."
-          } > preview-comment.md
-
-      - name: Post sticky preview comment
+      - name: Comment the preview URL on the pull request
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: preview
-          path: preview-comment.md
+          message: "🚀 Preview app deployed: https://${{ env.APP_NAME }}.fly.dev"
 
   destroy:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN if [ "$RUN_TESTS" = "true" ] ; then \
   fi
 RUN go build -ldflags "-X main.GitRef=$GIT_REF" -o /build/server ./cmd/server
 
-FROM alpine:latest AS runner
+FROM alpine:latest AS server
 COPY --from=builder /build/server /server/
 RUN apk update && apk add --no-cache make
 WORKDIR /server
@@ -35,7 +35,11 @@ CMD ["./server"]
 
 # The same server with the demo workspace baked in, so it needs no volume to
 # have something to show. This is what the per-pull-request preview app on Fly
-# deploys (deploy/preview/fly.toml). It is the last stage, so everything that
-# builds the published image asks for "runner" by name.
-FROM runner AS preview
+# deploys (deploy/preview/fly.toml).
+FROM server AS preview
 COPY workspace /workspace
+
+# What ships, and last on purpose: a `docker build .` that names no target
+# builds the final stage, so the published image stays the plain server however
+# many variants are added above it.
+FROM server AS runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,10 @@ WORKDIR /server
 EXPOSE 41520
 #CMD ["sh", "-c", "sleep 10000000 && ./server"]
 CMD ["./server"]
+
+# The same server with the demo workspace baked in, so it needs no volume to
+# have something to show. This is what the per-pull-request preview app on Fly
+# deploys (deploy/preview/fly.toml). It is the last stage, so everything that
+# builds the published image asks for "runner" by name.
+FROM runner AS preview
+COPY workspace /workspace

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ The development scripts require [Go](https://go.dev/doc/install) and [Bun](https
 - Test server: `(cd server && go test ./... -tags development -v)` — the tag `scripts/server` builds with. Without it the packages embed a production UI bundle, which only `go run cmd/build-ui/main.go` writes.
 - Update demo protos: `scripts/demo-protos` (The demo services are deployed via [kaja/tools/website](github.com/kaja-tools/website))
 
+### Preview apps
+
+Every pull request is deployed to its own Fly app at `https://kaja-pr-<number>.fly.dev`, so a change can be clicked through before it is merged. The **preview** workflow rebuilds it on every push and destroys the app when the pull request closes; the URL is a comment on the pull request throughout.
+
+The preview serves this repository's own `workspace/` — the demo apps `scripts/server` starts on — baked into the image by the Dockerfile's `preview` stage. Its configuration is read-only, like any server build, so a preview never asks Fly for a disk.
+
+Fork pull requests are skipped: they have no access to the token. Setting this up in a fresh repository takes a `FLY_API_TOKEN` secret that may create and destroy apps (`fly tokens create org <org>` — an app-scoped deploy token can't create the per-pull-request apps), and optionally a `FLY_ORG` variable if the org isn't `personal`.
+
 ### Releases
 
 Releases are cut from GitHub — no local build needed. Every push to `main` uploads a new build to TestFlight. To ship a version, run the **release** workflow (Actions → Run workflow):

--- a/deploy/preview/fly.toml
+++ b/deploy/preview/fly.toml
@@ -1,0 +1,35 @@
+# The Fly config every pull request preview is deployed with. One config serves
+# them all: the workflow passes the app name (kaja-pr-<number>) with --app, so
+# the name below is only what flyctl falls back to.
+#
+# The Dockerfile is at the repository root, so the build context must be too:
+#   fly deploy . --config deploy/preview/fly.toml --app kaja-pr-123
+app = "kaja-preview"
+primary_region = "sjc"
+
+[build]
+  # Resolved relative to this file; the build context is the repository root.
+  dockerfile = "../../Dockerfile"
+  # The server plus workspace/, so the preview comes up on the demo apps.
+  build-target = "preview"
+
+[http_service]
+  internal_port = 41520
+  force_https = true
+  # A preview is idle almost all of its life: no machine runs until someone
+  # opens the URL, and it stops again afterwards.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  # A deploy that ends with a server that never answered should fail the check
+  # rather than hand out a URL that doesn't load.
+  [[http_service.checks]]
+    path = "/status"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/scripts/docker
+++ b/scripts/docker
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 docker rm -f kaja-dev &> /dev/null || true
 
 GIT_REF=$(git rev-parse HEAD 2>/dev/null || echo "")
-docker build . -t kaja-dev:latest --build-arg RUN_TESTS=true --build-arg GIT_REF=$GIT_REF
+docker build . -t kaja-dev:latest --target runner --build-arg RUN_TESTS=true --build-arg GIT_REF=$GIT_REF
 
 rm pipe &> /dev/null || true
 mkfifo pipe


### PR DESCRIPTION
Every PR now gets its own Kaja at `https://kaja-pr-<number>.fly.dev`, serving this repo's `workspace/` demo apps, rebuilt on each push and destroyed when the PR closes.

- `.github/workflows/preview.yml` — creates/deploys/destroys the per-PR Fly app and keeps a sticky comment with the URL
- `deploy/preview/fly.toml` — one config for all previews (the app name comes from `--app`)
- `Dockerfile` — a `preview` stage that bakes `workspace/` into the server image; the three existing builds now ask for `runner` by name so the published image is unchanged

Needs a `FLY_API_TOKEN` secret that may create and destroy apps (`fly tokens create org <org>`).

---
_Generated by [Claude Code](https://claude.ai/code/session_014xPBoqttKvngFB85mMN2PT)_