### PR TITLE
Deployed demo.kaja.tools from this repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,9 @@
 name: main
+# What a push to main ships: the published image, and the public demo.
+#
+# The two are independent builds of the same commit and run in parallel — the
+# demo builds `workspace/` into the image it runs, so it has nothing to wait for
+# the Docker Hub push to hand it.
 on:
   push:
     branches:
@@ -26,3 +31,36 @@ jobs:
             kajatools/kaja:latest
           build-args: |
             GIT_REF=${{ github.sha }}
+
+  # demo.kaja.tools, deployed from the commit that changed it rather than from
+  # whatever image happened to be published when something else deployed. This
+  # is the same app and the same certificate as before; only what deploys it
+  # moved here.
+  #
+  # Uses the FLY_API_TOKEN the preview workflow already needs. GIT_REF is what
+  # the running Kaja reports as its version, so the demo names its own commit.
+  demo:
+    runs-on: ubuntu-latest
+    # A Fly deploy of an app must not overlap with another of the same app.
+    concurrency: deploy-demo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FLY_API_TOKEN:-}" ]; then
+            echo "::error::FLY_API_TOKEN secret is not set — create one with 'fly tokens create org <org>'"
+            exit 1
+          fi
+          flyctl deploy . \
+            --config deploy/demo/fly.toml \
+            --build-arg GIT_REF="${{ github.sha }}" \
+            --remote-only \
+            --yes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1061,6 +1061,7 @@ Both share the same backend code but differ in how they're packaged:
 - `quirks/proto/`, `grpcbin/proto/` - Proto files for the Twirp service and grpcb.in. Nothing else needs local protos: theatre is OpenAPI (its spec is fetched from `spec_url` at runtime) and seating uses gRPC server reflection
 - Run `scripts/demo-protos` to update proto files from kaja-tools/website and moul/pb
 - The `scripts/server` script starts kaja with this workspace by default
+- **It is also what both public deployments serve**, baked into the image by the Dockerfile's `demo` stage: `demo.kaja.tools` (`deploy/demo/fly.toml`, deployed by the **main** workflow on every push to main) and each pull request's own app (`deploy/preview/fly.toml`). One image and one workspace rather than a separate public config, so a change is clicked through on exactly what it becomes when it merges — and so the demo can never drift from what a developer sees. The demo services themselves live in kaja-tools/website; nothing of the demo's configuration does any more.
 
 ### Code Generation Flow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@ EXPOSE 41520
 CMD ["./server"]
 
 # The same server with the demo workspace baked in, so it needs no volume to
-# have something to show. This is what the per-pull-request preview app on Fly
-# deploys (deploy/preview/fly.toml).
-FROM server AS preview
+# have something to show. Both Fly deployments are this one image: demo.kaja.tools
+# (deploy/demo/fly.toml) and every pull request's own app
+# (deploy/preview/fly.toml). One target rather than two is the point — what a
+# pull request is clicked through on is what the demo will be once it merges.
+FROM server AS demo
 COPY workspace /workspace
 
 # What ships, and last on purpose: a `docker build .` that names no target

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="https://kaja.tools/demo/"><strong>Live Demo</strong></a> ·
+  <a href="https://demo.kaja.tools"><strong>Live Demo</strong></a> ·
   <a href="https://kaja.tools"><strong>Website</strong></a>
 </p>
 
@@ -32,7 +32,7 @@
 </p>
 
 <p align="center">
-  <a href="https://kaja.tools/demo/">
+  <a href="https://demo.kaja.tools">
     <img src="docs/screenshot-1.png" alt="Kaja — calling a gRPC service with TypeScript" width="720" />
   </a>
 </p>
@@ -147,15 +147,23 @@ The development scripts require [Go](https://go.dev/doc/install) and [Bun](https
 - Test UI: `(cd ui && bun test)`
 - TSC UI: `(cd ui && bun run tsc)`
 - Test server: `(cd server && go test ./... -tags development -v)` — the tag `scripts/server` builds with. Without it the packages embed a production UI bundle, which only `go run cmd/build-ui/main.go` writes.
-- Update demo protos: `scripts/demo-protos` (The demo services are deployed via [kaja/tools/website](github.com/kaja-tools/website))
+- Update demo protos: `scripts/demo-protos` — refreshes the `quirks` and `grpcb.in` protos in `workspace/`. The demo *services* live in [kaja-tools/website](https://github.com/kaja-tools/website); `theatre` and `seating` need no protos here, since one is OpenAPI and the other serves gRPC reflection.
 
-### Preview apps
+### The demo, and the preview apps
 
-Every pull request is deployed to its own Fly app at `https://kaja-pr-<number>.fly.dev`, so a change can be clicked through before it is merged. The **preview** workflow rebuilds it on every push and destroys the app when the pull request closes; the URL is a comment on the pull request throughout.
+Both public deployments serve this repository's own `workspace/` — the demo apps `scripts/server` starts on — baked into the image by the Dockerfile's `demo` stage. **One image, two places it runs**, so a change is clicked through on exactly what it will become:
 
-The preview serves this repository's own `workspace/` — the demo apps `scripts/server` starts on — baked into the image by the Dockerfile's `preview` stage. Its configuration is read-only, like any server build, so a preview never asks Fly for a disk.
+- **[demo.kaja.tools](https://demo.kaja.tools)** (`deploy/demo/fly.toml`) — deployed by the **main** workflow on every push to `main`, and so from the commit that changed it. One machine stays up, so the first visitor of the day doesn't wait for a cold start.
+- **`https://kaja-pr-<number>.fly.dev`** (`deploy/preview/fly.toml`) — one app per pull request, so a change can be clicked through before it is merged. The **preview** workflow rebuilds it on every push and destroys the app when the pull request closes; the URL is a comment on the pull request throughout. A preview runs no machine until someone opens its URL.
 
-Fork pull requests are skipped: they have no access to the token. Setting this up in a fresh repository takes a `FLY_API_TOKEN` secret that may create and destroy apps (`fly tokens create org <org>` — an app-scoped deploy token can't create the per-pull-request apps), and optionally a `FLY_ORG` variable if the org isn't `personal`.
+The workspace's configuration is read-only, like any server build, so neither ever asks Fly for a disk, and `workspace/scripts/` ships with them — the demo opens with scripts to press Run on.
+
+Fork pull requests are skipped: they have no access to the token. Setting this up in a fresh repository takes a `FLY_API_TOKEN` secret that may create and destroy apps (`fly tokens create org <org>` — an app-scoped deploy token can't create the per-pull-request apps), and optionally a `FLY_ORG` variable if the org isn't `personal`. The demo's own app and certificate are created once, by hand:
+
+```bash
+fly apps create kaja-demo
+fly certs add demo.kaja.tools --app kaja-demo
+```
 
 ### Releases
 

--- a/deploy/demo/fly.toml
+++ b/deploy/demo/fly.toml
@@ -1,0 +1,39 @@
+# The Fly config demo.kaja.tools is deployed with, on every push to main. The
+# app and its certificate already exist; nothing here creates either.
+#   fly certs add demo.kaja.tools --app kaja-demo
+#
+# It is the same image a pull request preview runs (deploy/preview/fly.toml),
+# built from the same target, so what a change was clicked through on before it
+# merged is what the demo becomes after.
+#
+# The Dockerfile is at the repository root, so the build context must be too:
+#   fly deploy . --config deploy/demo/fly.toml
+app = "kaja-demo"
+primary_region = "sjc"
+
+[build]
+  # Resolved relative to this file; the build context is the repository root.
+  dockerfile = "../../Dockerfile"
+  # The server plus workspace/, so the demo serves this repository's own apps.
+  build-target = "demo"
+
+[http_service]
+  internal_port = 41520
+  force_https = true
+  # Unlike a preview, this is a front door: one machine stays up, so the first
+  # visitor of the day doesn't wait for a cold start.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  # A deploy that ends with a server that never answered should fail the check
+  # rather than replace a working demo with one that doesn't load.
+  [[http_service.checks]]
+    path = "/status"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/deploy/preview/fly.toml
+++ b/deploy/preview/fly.toml
@@ -10,8 +10,9 @@ primary_region = "sjc"
 [build]
   # Resolved relative to this file; the build context is the repository root.
   dockerfile = "../../Dockerfile"
-  # The server plus workspace/, so the preview comes up on the demo apps.
-  build-target = "preview"
+  # The server plus workspace/, so the preview comes up on the demo apps — the
+  # same image demo.kaja.tools runs.
+  build-target = "demo"
 
 [http_service]
   internal_port = 41520


### PR DESCRIPTION
The demo and the pull-request previews are now one image — the Dockerfile's `preview` stage becomes `demo`, and the **main** workflow deploys it to the existing `kaja-demo` app on every push to main.

So a change is clicked through on exactly what it becomes when it merges, and the demo ships with the commit that changed it. `workspace/` is the only demo configuration now; the copy in kaja-tools/website goes away in kaja-tools/website#55, which should merge alongside this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7eYZ68CoWmmCm3E9LrpkQ)_