### PR TITLE
Centred the macOS window buttons on the header band

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -804,6 +804,28 @@ absent whenever there is nothing unsaved, which is most of the time. The sidebar
 across the seam, and the macOS traffic lights stay in it (the row takes over the
 inset only when the sidebar is collapsed).
 
+- **The lights move to the band, not the band to the lights**
+  (`desktop/traffic_lights_darwin.m`). AppKit centres the three window buttons
+  on the 28pt title bar, six points above the centre of the 40px band, so the
+  window's top-left corner read as two staggered baselines — the lights on one,
+  and **+**, `{ }`, the panel toggle and the file's own Save on the other. There
+  is no position to set: `mac.TitleBar` is six booleans, and Wails has had the
+  request open since v2. So the title bar container is made as tall as the band
+  and the buttons are centred in it, which is what Electron's
+  `trafficLightPosition` is underneath — public AppKit throughout, so it holds
+  in the sandboxed App Store build, and it is the same cgo-rather-than-a-library
+  move the keychain and the Finder reveal already make. **Nothing in the layout
+  moves and no vertical space is spent**, which is why this and not a strip of
+  its own for the lights (28px, on a laptop) or a 28px row pinned to the top of
+  a 40px band (bottom-heavy by 12px, for no native change).
+  - **Re-applied rather than set once.** AppKit re-lays the container out
+    whenever it feels like it — the window title changes, which kaja does on
+    every run, and the appearance changes, and fullscreen ends. So the geometry
+    is re-applied from an observation of the container's own frame plus the
+    window's resize and exit-fullscreen notifications, and applying it is a
+    no-op once it is already right. **Fullscreen is left alone**: there the
+    buttons belong to the menu bar overlay, which is AppKit's to place.
+
 - **"Open" is not a concept** — `views.ts`. Once the strip was gone, the open set
   only fed the recent chips, `⌘P⏎`, and its own Close command, so it was a thing
   that existed to serve itself. What is left is a **cache**: `MOUNTED_LIMIT`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -818,13 +818,22 @@ inset only when the sidebar is collapsed).
   moves and no vertical space is spent**, which is why this and not a strip of
   its own for the lights (28px, on a laptop) or a 28px row pinned to the top of
   a 40px band (bottom-heavy by 12px, for no native change).
-  - **Re-applied rather than set once.** AppKit re-lays the container out
-    whenever it feels like it — the window title changes, which kaja does on
-    every run, and the appearance changes, and fullscreen ends. So the geometry
-    is re-applied from an observation of the container's own frame plus the
-    window's resize and exit-fullscreen notifications, and applying it is a
-    no-op once it is already right. **Fullscreen is left alone**: there the
-    buttons belong to the menu bar overlay, which is AppKit's to place.
+  - **The container only makes the room; the move is the buttons' own.** AppKit
+    lays the buttons out a fixed distance below the container's *top*, so a
+    taller container moves nothing by itself — it is what keeps them from being
+    clipped once they are lower than AppKit would ever put them.
+  - **Re-applied rather than set once.** AppKit re-runs that layout whenever it
+    feels like it — the window is first shown, the title changes (which kaja
+    does on every run), the appearance changes, fullscreen ends — and puts the
+    buttons back. Applying once landed the first window 6px out and fixed
+    itself on the next click into the app, which is the shape of the bug this
+    is written against. So **every view between the window and the buttons is
+    watched**, the buttons included, and applying is a no-op once it is already
+    right. It is **deferred to the end of the run loop turn**, so the last word
+    belongs to us rather than to the layout pass still running, and a pass that
+    moved all four views is one apply rather than four. **Fullscreen is left
+    alone**: there the buttons belong to the menu bar overlay, which is
+    AppKit's to place.
 
 - **"Open" is not a concept** — `views.ts`. Once the strip was gone, the open set
   only fed the recent chips, `⌘P⏎`, and its own Close command, so it was a thing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -829,11 +829,16 @@ inset only when the sidebar is collapsed).
     itself on the next click into the app, which is the shape of the bug this
     is written against. So **every view between the window and the buttons is
     watched**, the buttons included, and applying is a no-op once it is already
-    right. It is **deferred to the end of the run loop turn**, so the last word
-    belongs to us rather than to the layout pass still running, and a pass that
-    moved all four views is one apply rather than four. **Fullscreen is left
-    alone**: there the buttons belong to the menu bar overlay, which is
-    AppKit's to place.
+    right — which is what most of those passes come to.
+  - **Corrected in the same turn it is broken in, and again once that turn is
+    over.** The first is what stops it being seen: the pass that moved the
+    buttons ends in a frame, and a move put right on the *next* turn is a
+    visible jump about a second after the window opens, which is what deferring
+    it alone looked like. The second is the backstop, because the pass is still
+    running and may move them again after we are done. Setting a frame posts
+    the notification this all hangs off, so the reentrancy guard is what keeps
+    the correction out of itself. **Fullscreen is left alone**: there the
+    buttons belong to the menu bar overlay, which is AppKit's to place.
 
 - **"Open" is not a concept** — `views.ts`. Once the strip was gone, the open set
   only fed the recent chips, `⌘P⏎`, and its own Close command, so it was a thing

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -37,6 +37,11 @@ import (
 // GitRef is the git commit hash or tag, set at build time via ldflags
 var GitRef string
 
+// headerBandHeight is the 40px row the sidebar header and the command row share
+// across the seam (Sidebar.tsx, CommandRow.tsx). The window buttons are centred
+// on it rather than on the title bar AppKit would measure against.
+const headerBandHeight = 40
+
 //go:embed all:frontend/dist
 var assets embed.FS
 
@@ -130,6 +135,10 @@ func (a *App) startup(ctx context.Context) {
 
 	// Register the macOS "Run Kaja Script" text service (no-op on other platforms).
 	registerServices(ctx)
+
+	// The window buttons are part of the same row as the sidebar header and the
+	// command row, so they sit on the same line as everything in it.
+	alignTrafficLights(headerBandHeight)
 
 	// The MCP server's lifetime is the process's: the UI only reports it.
 	a.startMCPServer()

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -136,10 +136,6 @@ func (a *App) startup(ctx context.Context) {
 	// Register the macOS "Run Kaja Script" text service (no-op on other platforms).
 	registerServices(ctx)
 
-	// The window buttons are part of the same row as the sidebar header and the
-	// command row, so they sit on the same line as everything in it.
-	alignTrafficLights(headerBandHeight)
-
 	// The MCP server's lifetime is the process's: the UI only reports it.
 	a.startMCPServer()
 
@@ -754,6 +750,14 @@ func main() {
 	app := NewApp(twirpHandler, apiService, configurationWatcher, bookmarkStore, kajaDir)
 
 	appMenu := app.buildAppMenu()
+
+	// The window buttons are part of the same row as the sidebar header and the
+	// command row, so they sit on the same line as everything in it. Asked for
+	// here rather than from the startup hook, which runs on a goroutine of its
+	// own and behind whatever else that hook does: this is the window's
+	// geometry, so it is queued before the app runs rather than racing the
+	// first frame.
+	alignTrafficLights(headerBandHeight)
 
 	err = wails.Run(&options.App{
 		Title: "Kaja",

--- a/desktop/traffic_lights_darwin.go
+++ b/desktop/traffic_lights_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo LDFLAGS: -framework Cocoa
+#include <stdlib.h>
+
+// Defined in traffic_lights_darwin.m.
+void kajaAlignTrafficLights(double bandHeight);
+*/
+import "C"
+
+// alignTrafficLights centres the macOS window buttons on a band of the given
+// height instead of on the title bar AppKit measures against.
+func alignTrafficLights(bandHeight int) {
+	C.kajaAlignTrafficLights(C.double(bandHeight))
+}

--- a/desktop/traffic_lights_darwin.m
+++ b/desktop/traffic_lights_darwin.m
@@ -6,20 +6,26 @@
 // Neither AppKit nor Wails has a position to set (AppKit only offers the whole
 // title bar, and wails/v2 mac.TitleBar is six booleans), so we do what every
 // app that wants this does: make the title bar container as tall as the band
-// and centre the buttons in it. Nothing here is private — the buttons are asked
-// for by name and only their frames are touched — so it holds in the sandboxed
-// App Store build.
+// and put the buttons in the middle of it. Nothing here is private — the
+// buttons are asked for by name and only their frames are touched — so it
+// holds in the sandboxed App Store build.
 //
-// AppKit re-lays the container out on its own schedule: the window title
-// changes, the appearance changes, fullscreen ends. That is what the observers
-// are for, and why applying the geometry is written to be a no-op once it is
-// already right.
+// A taller container does not move anything on its own: AppKit lays the
+// buttons out a fixed distance below the container's top, so the container is
+// only what keeps them from being clipped and the move is the buttons' own.
+// AppKit re-runs that layout on its own schedule — the window is first shown,
+// the title changes, the appearance changes, fullscreen ends — and puts them
+// back where it wants them, so every view between the window and the buttons
+// is watched and the geometry is applied again whenever one of them moves.
+// Applying is written to be a no-op once it is already right, and is deferred
+// to the end of the run loop turn so the last word belongs to us rather than
+// to the layout pass that is still running.
 
 @interface KajaTrafficLights : NSObject {
     CGFloat _bandHeight;
-    NSWindow *_window;    // The app's own window; dropped when it closes.
-    NSView *_container;   // The title bar container currently being observed.
-    BOOL _applying;
+    NSWindow *_window;   // The app's own window; dropped when it closes.
+    NSArray *_observed;  // The views being watched, retained for as long as they are.
+    BOOL _scheduled;
 }
 - (instancetype)initWithBandHeight:(CGFloat)bandHeight;
 @end
@@ -95,7 +101,7 @@ void kajaAlignTrafficLights(double bandHeight) {
 
 - (void)windowChanged:(NSNotification *)notification {
     if (notification.object == _window) {
-        [self apply];
+        [self scheduleApply];
     }
 }
 
@@ -105,15 +111,29 @@ void kajaAlignTrafficLights(double bandHeight) {
         return;
     }
     _window = nil;
-    [self observeContainer:nil];
+    [self observe:[NSArray array]];
 }
 
-- (void)containerFrameChanged:(NSNotification *)notification {
-    [self apply];
+- (void)viewFrameChanged:(NSNotification *)notification {
+    [self scheduleApply];
+}
+
+// AppKit moves the buttons from inside its own layout pass, and a frame set
+// while that is running is one it may still overwrite. Waiting for the turn to
+// end also folds a pass that moved all four views into a single apply.
+- (void)scheduleApply {
+    if (_scheduled || _window == nil) {
+        return;
+    }
+    _scheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self apply];
+    });
 }
 
 - (void)apply {
-    if (_applying || _window == nil) {
+    _scheduled = NO;
+    if (_window == nil) {
         return;
     }
     // In fullscreen the buttons belong to the menu bar overlay, which is
@@ -128,7 +148,8 @@ void kajaAlignTrafficLights(double bandHeight) {
     if (close == nil || miniaturize == nil || zoom == nil) {
         return;
     }
-    NSView *container = close.superview.superview;
+    NSView *titleBar = close.superview;
+    NSView *container = titleBar.superview;
     if (container == nil) {
         return;
     }
@@ -137,8 +158,7 @@ void kajaAlignTrafficLights(double bandHeight) {
         return;
     }
 
-    _applying = YES;
-    [self observeContainer:container];
+    [self observe:@[ container, titleBar, close, miniaturize, zoom ]];
 
     NSRect wanted = container.frame;
     wanted.size.height = _bandHeight;
@@ -147,34 +167,35 @@ void kajaAlignTrafficLights(double bandHeight) {
         [container setFrame:wanted];
     }
 
-    CGFloat y = floor((_bandHeight - buttonHeight) / 2.0);
+    // The container is now the band, so the middle of the band is the middle of
+    // the container — in the coordinates of whatever view holds the buttons.
+    NSPoint middle = [titleBar convertPoint:NSMakePoint(0.0, _bandHeight / 2.0) fromView:container];
+    CGFloat y = floor(middle.y - buttonHeight / 2.0);
     for (NSButton *button in @[ close, miniaturize, zoom ]) {
         if (NSMinY(button.frame) != y) {
             [button setFrameOrigin:NSMakePoint(NSMinX(button.frame), y)];
         }
     }
-    _applying = NO;
 }
 
-// The buttons can be removed and re-added, taking the container with them, so
-// the observation follows whichever container is holding them now. It is
-// retained for as long as it is observed, since the notification centre does
-// not hold it and an observation of a released view is a dangling one.
-- (void)observeContainer:(NSView *)container {
-    if (container == _container) {
+// The buttons can be removed and re-added, taking their container with them, so
+// the observation follows whichever views are holding them now. They are
+// retained for as long as they are observed, since the notification centre does
+// not hold them and an observation of a released view is a dangling one.
+- (void)observe:(NSArray *)views {
+    if ([_observed isEqualToArray:views]) {
         return;
     }
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    if (_container != nil) {
-        [center removeObserver:self name:NSViewFrameDidChangeNotification object:_container];
-        [_container release];
+    for (NSView *view in _observed) {
+        [center removeObserver:self name:NSViewFrameDidChangeNotification object:view];
     }
-    _container = [container retain];
-    if (container == nil) {
-        return;
+    [_observed release];
+    _observed = [views retain];
+    for (NSView *view in _observed) {
+        [view setPostsFrameChangedNotifications:YES];
+        [center addObserver:self selector:@selector(viewFrameChanged:) name:NSViewFrameDidChangeNotification object:view];
     }
-    [container setPostsFrameChangedNotifications:YES];
-    [center addObserver:self selector:@selector(containerFrameChanged:) name:NSViewFrameDidChangeNotification object:container];
 }
 
 @end

--- a/desktop/traffic_lights_darwin.m
+++ b/desktop/traffic_lights_darwin.m
@@ -16,15 +16,16 @@
 // AppKit re-runs that layout on its own schedule — the window is first shown,
 // the title changes, the appearance changes, fullscreen ends — and puts them
 // back where it wants them, so every view between the window and the buttons
-// is watched and the geometry is applied again whenever one of them moves.
-// Applying is written to be a no-op once it is already right, and is deferred
-// to the end of the run loop turn so the last word belongs to us rather than
-// to the layout pass that is still running.
+// is watched and the geometry is applied again whenever one of them moves,
+// both inside the pass that moved it and once that pass is over. Applying is
+// written to be a no-op once it is already right, which is what most of those
+// passes come to.
 
 @interface KajaTrafficLights : NSObject {
     CGFloat _bandHeight;
     NSWindow *_window;   // The app's own window; dropped when it closes.
     NSArray *_observed;  // The views being watched, retained for as long as they are.
+    BOOL _applying;
     BOOL _scheduled;
 }
 - (instancetype)initWithBandHeight:(CGFloat)bandHeight;
@@ -114,26 +115,31 @@ void kajaAlignTrafficLights(double bandHeight) {
     [self observe:[NSArray array]];
 }
 
+// Corrected twice, for two different reasons. Now, because this turn ends in a
+// frame and a move put right on the next turn is a jump — which is what
+// correcting it only on the next turn looked like. And again once the turn is
+// over, because the pass that moved this view is still running and may move it
+// again after we are done.
 - (void)viewFrameChanged:(NSNotification *)notification {
+    [self apply];
     [self scheduleApply];
 }
 
-// AppKit moves the buttons from inside its own layout pass, and a frame set
-// while that is running is one it may still overwrite. Waiting for the turn to
-// end also folds a pass that moved all four views into a single apply.
 - (void)scheduleApply {
     if (_scheduled || _window == nil) {
         return;
     }
     _scheduled = YES;
     dispatch_async(dispatch_get_main_queue(), ^{
+        self->_scheduled = NO;
         [self apply];
     });
 }
 
+// Setting a frame in here posts the notification that calls this back, so the
+// guard is what keeps the correction out of itself.
 - (void)apply {
-    _scheduled = NO;
-    if (_window == nil) {
+    if (_applying || _window == nil) {
         return;
     }
     // In fullscreen the buttons belong to the menu bar overlay, which is
@@ -160,6 +166,7 @@ void kajaAlignTrafficLights(double bandHeight) {
 
     [self observe:@[ container, titleBar, close, miniaturize, zoom ]];
 
+    _applying = YES;
     NSRect wanted = container.frame;
     wanted.size.height = _bandHeight;
     wanted.origin.y = NSHeight(_window.frame) - _bandHeight;
@@ -176,6 +183,7 @@ void kajaAlignTrafficLights(double bandHeight) {
             [button setFrameOrigin:NSMakePoint(NSMinX(button.frame), y)];
         }
     }
+    _applying = NO;
 }
 
 // The buttons can be removed and re-added, taking their container with them, so

--- a/desktop/traffic_lights_darwin.m
+++ b/desktop/traffic_lights_darwin.m
@@ -1,0 +1,180 @@
+#import <Cocoa/Cocoa.h>
+
+// AppKit centres the three window buttons on the 28pt title bar, which is 6pt
+// above the centre of the 40px band the sidebar header and the command row
+// share — so the window's top-left corner reads as two staggered baselines.
+// Neither AppKit nor Wails has a position to set (AppKit only offers the whole
+// title bar, and wails/v2 mac.TitleBar is six booleans), so we do what every
+// app that wants this does: make the title bar container as tall as the band
+// and centre the buttons in it. Nothing here is private — the buttons are asked
+// for by name and only their frames are touched — so it holds in the sandboxed
+// App Store build.
+//
+// AppKit re-lays the container out on its own schedule: the window title
+// changes, the appearance changes, fullscreen ends. That is what the observers
+// are for, and why applying the geometry is written to be a no-op once it is
+// already right.
+
+@interface KajaTrafficLights : NSObject {
+    CGFloat _bandHeight;
+    NSWindow *_window;    // The app's own window; dropped when it closes.
+    NSView *_container;   // The title bar container currently being observed.
+    BOOL _applying;
+}
+- (instancetype)initWithBandHeight:(CGFloat)bandHeight;
+@end
+
+static KajaTrafficLights *trafficLights = nil;
+
+// Centres the macOS window buttons on a band of the given height. Called from
+// Go (traffic_lights_darwin.go); the first call is the one that counts.
+void kajaAlignTrafficLights(double bandHeight) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (trafficLights != nil) {
+            return;
+        }
+        trafficLights = [[KajaTrafficLights alloc] initWithBandHeight:bandHeight];
+    });
+}
+
+@implementation KajaTrafficLights
+
+- (instancetype)initWithBandHeight:(CGFloat)bandHeight {
+    self = [super init];
+    if (self == nil) {
+        return nil;
+    }
+    _bandHeight = bandHeight;
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self selector:@selector(windowBecameMain:) name:NSWindowDidBecomeMainNotification object:nil];
+    [center addObserver:self selector:@selector(windowChanged:) name:NSWindowDidResizeNotification object:nil];
+    [center addObserver:self selector:@selector(windowChanged:) name:NSWindowDidExitFullScreenNotification object:nil];
+    [center addObserver:self selector:@selector(windowWillClose:) name:NSWindowWillCloseNotification object:nil];
+
+    // Wails creates the window before it calls the Go startup hook, so it is
+    // normally already there; becoming main is the fallback for when it isn't.
+    if (![self adopt:[NSApp mainWindow]]) {
+        for (NSWindow *window in [NSApp windows]) {
+            if ([self adopt:window]) {
+                break;
+            }
+        }
+    }
+    return self;
+}
+
+// Takes the app's own window, which is the one titled window that isn't a
+// panel. Everything else AppKit hands us — alerts, file dialogs, menus — has no
+// buttons of ours to move.
+- (BOOL)adopt:(NSWindow *)window {
+    if (_window != nil || window == nil) {
+        return NO;
+    }
+    if ([window isKindOfClass:[NSPanel class]]) {
+        return NO;
+    }
+    if ((window.styleMask & NSWindowStyleMaskTitled) == 0) {
+        return NO;
+    }
+    if ([window standardWindowButton:NSWindowCloseButton] == nil) {
+        return NO;
+    }
+    _window = window;
+    [self apply];
+    return YES;
+}
+
+- (void)windowBecameMain:(NSNotification *)notification {
+    if (_window == nil) {
+        [self adopt:notification.object];
+        return;
+    }
+    [self windowChanged:notification];
+}
+
+- (void)windowChanged:(NSNotification *)notification {
+    if (notification.object == _window) {
+        [self apply];
+    }
+}
+
+// The window is not retained, so let go of it before it is gone.
+- (void)windowWillClose:(NSNotification *)notification {
+    if (notification.object != _window) {
+        return;
+    }
+    _window = nil;
+    [self observeContainer:nil];
+}
+
+- (void)containerFrameChanged:(NSNotification *)notification {
+    [self apply];
+}
+
+- (void)apply {
+    if (_applying || _window == nil) {
+        return;
+    }
+    // In fullscreen the buttons belong to the menu bar overlay, which is
+    // AppKit's to lay out. Exiting it brings us back here.
+    if ((_window.styleMask & NSWindowStyleMaskFullScreen) != 0) {
+        return;
+    }
+
+    NSButton *close = [_window standardWindowButton:NSWindowCloseButton];
+    NSButton *miniaturize = [_window standardWindowButton:NSWindowMiniaturizeButton];
+    NSButton *zoom = [_window standardWindowButton:NSWindowZoomButton];
+    if (close == nil || miniaturize == nil || zoom == nil) {
+        return;
+    }
+    NSView *container = close.superview.superview;
+    if (container == nil) {
+        return;
+    }
+    CGFloat buttonHeight = NSHeight(close.frame);
+    if (buttonHeight <= 0 || _bandHeight < buttonHeight) {
+        return;
+    }
+
+    _applying = YES;
+    [self observeContainer:container];
+
+    NSRect wanted = container.frame;
+    wanted.size.height = _bandHeight;
+    wanted.origin.y = NSHeight(_window.frame) - _bandHeight;
+    if (!NSEqualRects(wanted, container.frame)) {
+        [container setFrame:wanted];
+    }
+
+    CGFloat y = floor((_bandHeight - buttonHeight) / 2.0);
+    for (NSButton *button in @[ close, miniaturize, zoom ]) {
+        if (NSMinY(button.frame) != y) {
+            [button setFrameOrigin:NSMakePoint(NSMinX(button.frame), y)];
+        }
+    }
+    _applying = NO;
+}
+
+// The buttons can be removed and re-added, taking the container with them, so
+// the observation follows whichever container is holding them now. It is
+// retained for as long as it is observed, since the notification centre does
+// not hold it and an observation of a released view is a dangling one.
+- (void)observeContainer:(NSView *)container {
+    if (container == _container) {
+        return;
+    }
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    if (_container != nil) {
+        [center removeObserver:self name:NSViewFrameDidChangeNotification object:_container];
+        [_container release];
+    }
+    _container = [container retain];
+    if (container == nil) {
+        return;
+    }
+    [container setPostsFrameChangedNotifications:YES];
+    [center addObserver:self selector:@selector(containerFrameChanged:) name:NSViewFrameDidChangeNotification object:container];
+}
+
+@end

--- a/desktop/traffic_lights_other.go
+++ b/desktop/traffic_lights_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package main
+
+// alignTrafficLights is macOS-only: nothing else draws window buttons inside
+// the app's own chrome.
+func alignTrafficLights(bandHeight int) {}


### PR DESCRIPTION
Header alignment 1a: the traffic lights move to the 40px band instead of the band moving to them. Wails has no position to set, so the title bar container is made as tall as the band and the buttons are centred in it (public AppKit, App Store safe), re-applied whenever AppKit re-lays it out.

Needs a run on a Mac to confirm — it can't be built or seen from a Linux session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUFo7K3x73gVunJtHf6HRH)_