### PR TITLE
Gave the canvas table a frame, a real toolbar and a total

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,6 +603,27 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
     until it runs out and a click that yields nothing closes it out. This is also
     why the page clamp lets **one** page past the loaded rows through — paging
     into rows that aren't here yet is how they are asked for.
+  - **How big the whole thing is, the script is the only one who can say.**
+    `.total(count)` on the handle takes the number an API reports beside a page,
+    said from inside the source's own loop as it learns it (`totalOf`), and the
+    toolbar reads `1–50 of 2,431` instead of counting what it holds. It is a verb
+    rather than an option because the count arrives *with* the first page — an
+    option would make every script fetch a page before drawing the table it is
+    fetching for — and it is on the handle rather than a second parameter of the
+    source because arity there already means "restart me for each search". A
+    cursor-based API has nothing to say and says nothing: the count is then what
+    is loaded, marked `of 120+` while the source is open and exact once it runs
+    out. **A total is a claim and exhaustion is the truth** — a source that
+    promised 2,431 and stopped at 2,000 has 2,000 rows in it, and a count the
+    rows have already passed is one the table can see is wrong. A restart clears
+    it, because it counted a result set nobody is asking about any more. It is
+    also the one thing that spares the no-lookahead click: with a total, the
+    pager stops where the set does.
+  - **A live table's first page is pulled a microtask after it is drawn.** A
+    source reports its total through the handle the script is still assigning
+    (`const shows = kaja.table(…, async function* () { shows.total(…) })`), so
+    nothing the source runs may happen before that name is bound. The run still
+    waits for it (`LiveTable.first`, awaited by `settleTables`).
   - **Declaring the search parameter is what asks for the search text.** A source
     that takes one is restarted for each new search (a new search is a new result
     set); one that doesn't is never restarted, and the box filters the rows
@@ -614,6 +635,22 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
     rows, holding the search box, the count and the pager. A static table that
     fits on a page reads exactly as it did before any of this existed, and a
     pager under a fifty-row table is a control you have to go looking for.
+  - **The table is the one block with a frame, because it is the one block wider
+    than the text.** Without it the header row reads as another line of the
+    paragraph above it. So: a card (`rounded-lg border`), a 40px toolbar on
+    `bg-card` above the rows, a `bg-muted` header band, 26px rows, and the
+    canvas's own 16px gap doing the separating. Everything in the toolbar is
+    **28px** — the search box is a real input, and Previous/Next are two 28px
+    buttons **joined into one pair**, so there is no gap between them to miss
+    into. That is what the 12px chevrons in a line of body text were not.
+  - **One row is one line.** Cells truncate rather than wrap — a wrapped cell
+    breaks the 26px rhythm the grid is read down — and a long one carries its
+    full value as a hover title. A column whose every non-empty cell is a number
+    reads from the right (`numericColumns`), decided by what the cells are rather
+    than by anything declared, since a script hands the table text.
+  - **The empty state is a row inside the frame**, not the run's blankslate:
+    `No rows match “xyz”` with Clear search beside it. So is a source's error,
+    with its Retry. Both are 40px, and the columns stay on screen above them.
   - **A live table expires like a payload does.** The source is a closure, so it
     cannot be stored: read back, the table is the rows it had, saying
     `run to load the rest` rather than offering a Next that leads nowhere

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -156,7 +156,22 @@ kaja.table(["id", "title", "seats"], async function* (search) {
 
 Declare the `search` parameter and the search box is handed to your source, which
 is started again for each new search; leave it out and the box filters the rows
-already loaded. **Nobody is paging your run**, so `run_script` draws the first
+already loaded. **If the API reports a total, hand it on** — the table counts the
+rows it has and nothing else, so `1–50 of 2,431` is a number only your source
+knows:
+
+```ts
+const customers = kaja.table(["key", "name"], async function* () {
+  for (let page = 1; ; page++) {
+    const result = await Customers.ListCustomers({ page });
+    customers.total(result.totalCount);
+    yield* result.items.map((customer) => [customer.key, customer.name]);
+  }
+});
+```
+
+A source paging a cursor has no total and says nothing; the table then reports
+what it has loaded and that there is more. **Nobody is paging your run**, so `run_script` draws the first
 page and reports `more: true` — if you need the whole set, write the loop and
 read it yourself. Prefer this over `.row(...)` whenever the API pages: the person
 who opens the script gets the rest without running anything.
@@ -185,9 +200,10 @@ What each member is for:
 - `kaja.text(text)`, `kaja.code(code, language?)` — draw a line or a snippet on
   the canvas.
 - `kaja.table(columns, rows?)` — draw a table; the handle's `.row(...cells)`
-  appends to it and hands back a row whose `.update(...cells)` rewrites it, and
-  `.column(name)` adds a column. `rows` can be an array, or a source (an async
-  generator) the table pulls a page at a time as it is paged through.
+  appends to it and hands back a row whose `.update(...cells)` rewrites it,
+  `.column(name)` adds a column, and `.total(count)` states how many rows the
+  whole result set holds when the API says. `rows` can be an array, or a source
+  (an async generator) the table pulls a page at a time as it is paged through.
 - `kaja.askStr(question)`, `kaja.askInt(question)`,
   `kaja.askSelect(question, options)` — ask the user for text, a whole number,
   or one of a list; each blocks on a human and hands back the kind of thing it

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CircleX, Search, ShieldQuestionMark } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CircleX, Search, ShieldQuestionMark, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { answerPlaceholder, answerProblem, AskAnswerType, normalizeAnswer } from "./ask";
 import { ApproveBlock, ApproveGesture, AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
@@ -7,7 +7,7 @@ import { cn } from "./cn";
 import { Button } from "./components/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { Spinner } from "./components/spinner";
-import { hasControls, NO_TABLE_VIEW, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
+import { hasControls, NO_TABLE_VIEW, numericColumns, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
 import { ConsoleItem, FailureNotice, RunGroup } from "./runs";
 import { barHeight, BAR_MAX_HEIGHT, slotsFor, SLOT_WIDTH, StripSlot, TICK_HEIGHT, TICK_WIDTH } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
@@ -311,6 +311,11 @@ interface TableProps {
 }
 
 /**
+ * The one block that is wider than the text around it, so it is the one block
+ * with a frame: a card with its own toolbar, a header band under it, and the
+ * canvas's 16px gap doing the rest. Without the frame the header row reads as
+ * another line of the paragraph above it.
+ *
  * A wide table scrolls inside itself; the canvas never scrolls sideways as a
  * whole, because everything above and below it would move with it.
  *
@@ -328,63 +333,86 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   // a second search — and ⏎ says "now", which is what the wait is for.
   const [search, searchNow] = useDebounced(view.search.trim(), searchesLocally(block) ? 0 : 300);
   const { needed, want } = pullNeeded(block, { page: shown.page, search });
+  const numeric = numericColumns(shown.rows, block.columns.length);
 
   useEffect(() => {
     if (needed) onPull(id, search, want);
   }, [needed, id, search, want, onPull]);
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="overflow-hidden rounded-lg border border-border">
       {/* One bar, above the rows. A pager under a fifty-row table is a control
           you have to go looking for, and on a canvas of several blocks it is
-          hard to tell which table it belongs to. */}
+          hard to tell which table it belongs to. Everything in it is 28px,
+          which is what a pointer wants and what a 12px glyph never was. */}
       {controls && (
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <Search size={12} className="shrink-0" />
-          <input
-            data-testid="canvas-table-search"
-            className="min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
-            placeholder={searchesLocally(block) ? "Search loaded rows…" : "Search…"}
-            value={view.search}
-            // A new search is a new set, so it is read from the first page.
-            onChange={(event) => onView(id, { page: 0, search: event.target.value })}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") searchNow();
-            }}
-          />
+        <div className="flex h-10 items-center gap-2 border-b border-border bg-card px-2">
+          <div className="flex h-7 w-[200px] min-w-0 shrink items-center gap-1.5 rounded-md border border-input bg-background px-2 focus-within:border-ring">
+            <Search size={13} className="shrink-0 text-muted-foreground" />
+            <input
+              data-testid="canvas-table-search"
+              className="min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
+              placeholder={searchesLocally(block) ? "Search rows" : "Search"}
+              value={view.search}
+              // A new search is a new set, so it is read from the first page.
+              onChange={(event) => onView(id, { page: 0, search: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") searchNow();
+              }}
+            />
+            {view.search !== "" && (
+              <button
+                type="button"
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+                onClick={() => onView(id, { page: 0, search: "" })}
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
           {block.loading && <Spinner className="size-3 shrink-0" />}
-          <span data-testid="canvas-table-summary" className="shrink-0 truncate tabular-nums @max-[420px]:hidden">
-            {tableSummary(block, shown)}
-          </span>
-          <button
-            type="button"
-            className="shrink-0 disabled:opacity-40 enabled:hover:text-foreground"
-            disabled={!shown.hasPrevious}
-            aria-label="Previous page"
-            onClick={() => onView(id, { ...view, page: shown.page - 1 })}
-          >
-            <ChevronLeft size={12} />
-          </button>
-          <button
-            type="button"
-            data-testid="canvas-table-next"
-            className="shrink-0 disabled:opacity-40 enabled:hover:text-foreground"
-            disabled={!shown.hasNext || block.loading === true}
-            aria-label="Next page"
-            onClick={() => onView(id, { ...view, page: shown.page + 1 })}
-          >
-            <ChevronRight size={12} />
-          </button>
+          <div className="ml-auto flex min-w-0 items-center gap-2">
+            <span data-testid="canvas-table-summary" className="min-w-0 truncate tabular-nums text-muted-foreground @max-[520px]:hidden">
+              {tableSummary(block, shown)}
+            </span>
+            {/* Two buttons joined into a pair: one target to aim at, and the
+                gap between them can't be missed into. */}
+            <div className="flex shrink-0 overflow-hidden rounded-md border border-input">
+              <button
+                type="button"
+                className="flex h-7 w-7 items-center justify-center border-r border-input text-muted-foreground disabled:opacity-40 enabled:hover:bg-accent enabled:hover:text-accent-foreground"
+                disabled={!shown.hasPrevious}
+                aria-label="Previous page"
+                onClick={() => onView(id, { ...view, page: shown.page - 1 })}
+              >
+                <ChevronLeft size={15} />
+              </button>
+              <button
+                type="button"
+                data-testid="canvas-table-next"
+                className="flex h-7 w-7 items-center justify-center text-muted-foreground disabled:opacity-40 enabled:hover:bg-accent enabled:hover:text-accent-foreground"
+                disabled={!shown.hasNext || block.loading === true}
+                aria-label="Next page"
+                onClick={() => onView(id, { ...view, page: shown.page + 1 })}
+              >
+                <ChevronRight size={15} />
+              </button>
+            </div>
+          </div>
         </div>
       )}
       <div className="overflow-x-auto">
         <table className="w-full border-collapse">
           <thead>
-            <tr>
+            <tr className="bg-muted">
               {block.columns.map((column, index) => (
                 <th
                   key={index}
-                  className="whitespace-nowrap border-b border-border py-1 pr-4 text-left text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+                  className={cn(
+                    "h-7 whitespace-nowrap border-b border-border px-3 text-left font-medium uppercase text-muted-foreground",
+                    numeric[index] && "text-right",
+                  )}
                 >
                   {column}
                 </th>
@@ -393,9 +421,15 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
           </thead>
           <tbody>
             {shown.rows.map((row, rowIndex) => (
-              <tr key={rowIndex}>
+              // One row is one line: a cell that wrapped would break the 26px
+              // rhythm the whole grid is read down.
+              <tr key={rowIndex} className="last:[&>td]:border-b-0">
                 {row.map((cell, cellIndex) => (
-                  <td key={cellIndex} className="border-b border-border/50 py-1 pr-4 align-top text-foreground">
+                  <td
+                    key={cellIndex}
+                    className={cn("h-[26px] max-w-[48ch] truncate border-b border-border/50 px-3 text-foreground", numeric[cellIndex] && "text-right")}
+                    title={cell.length > 48 ? cell : undefined}
+                  >
                     {cell}
                   </td>
                 ))}
@@ -403,14 +437,35 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
             ))}
           </tbody>
         </table>
-        {shown.rows.length === 0 && (
-          <div className="py-1.5 text-muted-foreground">{block.loading ? "Loading…" : shown.filtered ? "No rows match." : "No rows yet…"}</div>
-        )}
       </div>
+      {shown.rows.length === 0 && (
+        <div className="flex h-10 items-center gap-2 px-3 text-muted-foreground">
+          {block.loading ? (
+            "Loading…"
+          ) : shown.filtered ? (
+            <>
+              <span className="min-w-0 truncate">No rows match “{view.search.trim()}”</span>
+              <button
+                type="button"
+                className="shrink-0 underline decoration-muted-foreground/40 underline-offset-2 hover:text-foreground"
+                onClick={() => onView(id, { page: 0, search: "" })}
+              >
+                Clear search
+              </button>
+            </>
+          ) : (
+            "No rows yet…"
+          )}
+        </div>
+      )}
       {block.error !== undefined && (
-        <div className="flex items-center gap-2 text-destructive">
+        <div className="flex h-10 items-center gap-2 border-t border-border bg-destructive/10 px-3 text-destructive">
           <span className="min-w-0 flex-1 truncate">{block.error}</span>
-          <button type="button" className="shrink-0 hover:text-foreground" onClick={() => onPull(id, search, shown.want)}>
+          <button
+            type="button"
+            className="shrink-0 underline decoration-destructive/40 underline-offset-2 hover:text-foreground"
+            onClick={() => onPull(id, search, shown.want)}
+          >
             Retry
           </button>
         </div>

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -45,6 +45,11 @@ export interface TableBlock {
   expired?: boolean;
   // How many rows a page holds. Absent means the default.
   pageSize?: number;
+  // How many rows the whole result set holds, as the script reported it — the
+  // count an API sends beside a page, which nothing else here could know. Absent
+  // is the honest state of a cursor-based source: the table then says how many it
+  // has and that there are more, rather than implying the two are the same.
+  total?: number;
   // What the last pull failed with. The call itself is in the log; this is what
   // the table says about why it stopped filling.
   error?: string;

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -121,6 +121,7 @@ export interface BlockUpdate {
 export interface Table {
   row(...cells: unknown[]): Row;
   column(name: string): void;
+  total(count: number | undefined): void;
 }
 
 /**
@@ -173,6 +174,10 @@ interface LiveTable {
   // search changes drops what it was doing instead of appending to the new set.
   generation: number;
   pulling?: Promise<void>;
+  // The first page, which is pulled a microtask after the table is drawn. It is
+  // held apart from `pulling` because it settles before that one is set, and the
+  // run waits for both.
+  first?: Promise<void>;
 }
 
 // Live sources are closures, so they are held rather than collected. A console
@@ -440,10 +445,23 @@ export class Kaja {
    *       if (!(pageToken = page.nextPageToken)) return;
    *     }
    *   });
+   *
+   * An API that reports how many rows there are in total is the only thing that
+   * knows; say it through the handle as the pages arrive, and the table states it
+   * instead of counting what it has.
+   *
+   *   const shows = kaja.table(["id", "title"], async function* () {
+   *     for (let page = 1; ; page++) {
+   *       const result = await Shows.ListShows({ page });
+   *       shows.total(result.totalCount);
+   *       yield* result.shows.map((show) => [show.id, show.title]);
+   *     }
+   *   });
    */
   table(columns: string[], rows?: RowSource, options?: TableOptions): Table {
     const blockId = newBlockId();
     const block: TableBlock = { kind: "table", columns: columns.map(formatCell), rows: [], pageSize: options?.pageSize };
+    let live: LiveTable | undefined;
 
     if (Array.isArray(rows)) {
       block.rows = rows.map((row) => padCells(toCells(row), block.columns.length));
@@ -461,14 +479,20 @@ export class Kaja {
       block.live = true;
       block.serverSearch = restartable && rows.length > 0;
       block.loadedSearch = "";
-      this.#openTable(blockId, { block, open, restartable, search: "", generation: 0 });
+      live = { block, open, restartable, search: "", generation: 0 };
+      this.#openTable(blockId, live);
     }
 
     this.#onBlockUpdate(blockId, { ...block });
     // A live table draws its first page itself rather than waiting to be looked
     // at: the run is what fetched it, so its calls belong in the run's log — and
     // a run nobody is watching (an agent's) still reports a page of rows.
-    if (block.live) void this.pullTable(blockId, "", pageSizeOf(block));
+    //
+    // A microtask later, though, so `const shows = kaja.table(…)` is assigned
+    // before any source body runs. A source reports its total through that
+    // handle, from inside its own loop, and pulling here and now would run the
+    // loop while the name it reaches for is still in its dead zone.
+    if (live) live.first = Promise.resolve().then(() => void this.pullTable(blockId, "", pageSizeOf(block)));
 
     // A new array each time, at both levels: the canvas compares what it was
     // handed against what it holds, and a row pushed or spliced into the same
@@ -500,6 +524,13 @@ export class Kaja {
         // and the rows can never disagree about how many columns there are.
         block.columns = [...block.columns, formatCell(name)];
         block.rows = block.rows.map((row) => padCells(row, block.columns.length));
+        this.#onBlockUpdate(blockId, { ...block });
+      },
+      total: (count: number | undefined) => {
+        // A total is a claim about the whole set, so anything that isn't a count
+        // says nothing rather than something wrong — an API that stops reporting
+        // one leaves the table where a cursor-based source always is.
+        block.total = typeof count === "number" && Number.isFinite(count) && count >= 0 ? Math.floor(count) : undefined;
         this.#onBlockUpdate(blockId, { ...block });
       },
     };
@@ -542,6 +573,10 @@ export class Kaja {
       table.block.rows = [];
       table.block.exhausted = false;
       table.block.loadedSearch = search;
+      // A total counts a result set, and this is a different one. The source
+      // reports the new one as it answers; until it does, the table says how many
+      // it has and that there are more, which is what it in fact knows.
+      table.block.total = undefined;
     } else if (table.pulling) {
       // Single flight: a pull already under way is filling the same table, and a
       // second one would interleave its rows with the first's.
@@ -602,9 +637,14 @@ export class Kaja {
    */
   async settleTables(): Promise<void> {
     for (let pass = 0; pass < 8; pass++) {
-      const pulling = [...this.#tables.values()].map((table) => table.pulling).filter((promise): promise is Promise<void> => promise !== undefined);
+      const pulling = [...this.#tables.values()]
+        .flatMap((table) => [table.first, table.pulling])
+        .filter((promise): promise is Promise<void> => promise !== undefined);
       if (pulling.length === 0) return;
       await Promise.all(pulling);
+      // The first pull is over once it has been awaited; leaving it here would
+      // make every later pass find work that is already done.
+      for (const table of this.#tables.values()) table.first = undefined;
     }
   }
 

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -90,6 +90,24 @@ export interface Table {
    * blank cell for it.
    */
   column(name: string): void;
+  /**
+   * State how many rows there are in the whole result set — the count an API
+   * reports beside a page, which is the only place it can come from. Say it as
+   * you learn it; the last word wins, and a new search starts the question over.
+   *
+   *   const customers = kaja.table(["key", "name"], async function* (search) {
+   *     for (let page = 1; ; page++) {
+   *       const result = await Customers.ListCustomers({ page, search });
+   *       customers.total(result.totalCount);
+   *       yield* result.items.map((customer) => [customer.key, customer.name]);
+   *     }
+   *   });
+   *
+   * A source paging a cursor has nothing to say here and says nothing: the table
+   * then reports how many rows it has loaded and that there are more, rather
+   * than passing that count off as the total.
+   */
+  total(count: number | undefined): void;
 }
 
 /** A row already on the canvas, which the run can keep up to date. */
@@ -237,6 +255,10 @@ export declare const kaja: {
    *       if (!(pageToken = page.nextPageToken)) return;
    *     }
    *   });
+   *
+   * The table counts the rows it has. An API that reports how many there are in
+   * total is the only thing that knows, so hand that on with the handle's
+   * total() as the pages arrive.
    */
   table(columns: string[], rows?: RowSource, options?: { pageSize?: number }): Table;
   /**

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -228,6 +228,43 @@ describe("kaja.table", () => {
     expect(only().rows).toEqual([["one"]]);
   });
 
+  // The count an API reports beside a page is the one thing the table cannot
+  // work out for itself, so the script hands it on.
+  it("takes a total from the script", () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["n"]);
+
+    table.total(2431);
+    expect(only().total).toBe(2431);
+
+    // A source that stops reporting one leaves the table where a cursor-based
+    // source always is, and anything that isn't a count says nothing at all.
+    table.total(undefined);
+    expect(only().total).toBeUndefined();
+    table.total(Number.NaN);
+    expect(only().total).toBeUndefined();
+  });
+
+  // A source reports its total from inside its own loop, through the handle the
+  // script is still assigning — so nothing it yields may run before it is.
+  it("takes a total from a source, through the handle", async () => {
+    const { kaja, only, id } = draw();
+    const shows: { total(count: number): void } = kaja.table(["n"], async function* (search: string) {
+      shows.total(search === "" ? 2431 : 12);
+      yield ["one"];
+      yield ["two"];
+    });
+    await kaja.settleTables();
+
+    expect(only().rows).toHaveLength(2);
+    expect(only().total).toBe(2431);
+
+    // A new search is a new result set, so the count it had answers a question
+    // nobody is asking any more.
+    await kaja.pullTable(id(), "vera", 50);
+    expect(only().total).toBe(12);
+  });
+
   // A block read back from the store has no source; Next has to say so rather
   // than lead nowhere.
   it("reports a table whose source it no longer holds", async () => {

--- a/ui/src/mcpCatalog.test.ts
+++ b/ui/src/mcpCatalog.test.ts
@@ -187,6 +187,10 @@ describe("buildMcpCatalog", () => {
     expect(built.apps).toHaveLength(0);
     expect(built.runtime).toContain("export declare const kaja: {");
     expect(built.runtime).toContain("table(columns: string[], rows?: RowSource, options?: { pageSize?: number }): Table;");
+    // Including the verbs on the handle it hands back — the total is a number
+    // only the script's source has, so an agent has to be able to read that it
+    // is wanted.
+    expect(built.runtime).toContain("total(count: number | undefined): void;");
     expect(built.runtime).toContain('"API_BASE_URL": string;');
     // The rule the type system can't state, said where the declaration is read.
     expect(built.runtime).toContain("a top-level `return` is an error");

--- a/ui/src/tableView.test.ts
+++ b/ui/src/tableView.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { TableBlock } from "./blocks";
-import { hasControls, pullNeeded, tableSummary, tableWindow } from "./tableView";
+import { hasControls, numericColumns, pullNeeded, tableSummary, tableWindow, totalOf } from "./tableView";
 
 function table(rows: number, extra: Partial<TableBlock> = {}): TableBlock {
   return {
@@ -76,6 +76,15 @@ describe("tableWindow", () => {
   it("does not offer a next page past a local filter's matches", () => {
     expect(tableWindow(table(25, { live: true }), { page: 0, search: "show 2" }).hasNext).toBe(false);
   });
+
+  // A source that reported a total has said where it ends, which is the one
+  // thing that spares the click that comes back with nothing.
+  it("stops at a total the source reported", () => {
+    expect(tableWindow(table(20, { live: true, total: 20 }), { page: 1, search: "" }).hasNext).toBe(false);
+    expect(tableWindow(table(20, { live: true, total: 200 }), { page: 1, search: "" }).hasNext).toBe(true);
+    // …and the clamp stops letting a page past the loaded rows through with it.
+    expect(tableWindow(table(20, { live: true, total: 20 }), { page: 5, search: "" }).page).toBe(1);
+  });
 });
 
 describe("pullNeeded", () => {
@@ -127,6 +136,11 @@ describe("pullNeeded", () => {
     expect(pullNeeded(block, { page: 1, search: "vera" })).toEqual({ needed: true, want: 20 });
   });
 
+  it("stops asking once it holds every row the source counted", () => {
+    expect(pullNeeded(table(20, { live: true, total: 20 }), { page: 2, search: "" }).needed).toBe(false);
+    expect(pullNeeded(table(20, { live: true, total: 200 }), { page: 2, search: "" }).needed).toBe(true);
+  });
+
   it("never asks on behalf of a source that is gone", () => {
     const block = table(3, { live: true, expired: true, serverSearch: true, loadedSearch: "vera" });
 
@@ -153,20 +167,62 @@ describe("hasControls", () => {
   });
 });
 
+describe("totalOf", () => {
+  it("is the rows, until a source says otherwise", () => {
+    expect(totalOf(table(25))).toEqual({ count: 25, exact: true });
+    // A source that is still open has only counted this far, and says so.
+    expect(totalOf(table(25, { live: true }))).toEqual({ count: 25, exact: false });
+    expect(totalOf(table(25, { live: true, total: 2431 }))).toEqual({ count: 2431, exact: true });
+  });
+
+  // A total is a claim and exhaustion is the truth.
+  it("prefers what the source turned out to hold", () => {
+    expect(totalOf(table(20, { live: true, exhausted: true, total: 2431 }))).toEqual({ count: 20, exact: true });
+    expect(totalOf(table(25, { live: true, total: 10 }))).toEqual({ count: 25, exact: true });
+  });
+});
+
 describe("tableSummary", () => {
-  it("states a total it knows, and a count it doesn't", () => {
+  it("states a total the script reported, and marks one it inferred", () => {
     const block = table(25);
     expect(tableSummary(block, tableWindow(block, { page: 0, search: "" }))).toBe("1–10 of 25");
 
     const live = table(25, { live: true });
-    expect(tableSummary(live, tableWindow(live, { page: 0, search: "" }))).toBe("1–10 · 25 loaded");
+    expect(tableSummary(live, tableWindow(live, { page: 0, search: "" }))).toBe("1–10 of 25+");
 
-    const expired = table(25, { expired: true });
-    expect(tableSummary(expired, tableWindow(expired, { page: 0, search: "" }))).toBe("1–10 of 25 loaded — run to load the rest");
+    const counted = table(25, { live: true, total: 2431 });
+    expect(tableSummary(counted, tableWindow(counted, { page: 0, search: "" }))).toBe("1–10 of 2,431");
+
+    const expired = table(25, { expired: true, total: 2431 });
+    expect(tableSummary(expired, tableWindow(expired, { page: 0, search: "" }))).toBe("1–10 of 2,431 loaded — run to load the rest");
   });
 
   it("says a local filter is searching what is loaded", () => {
     const block = table(25, { live: true });
-    expect(tableSummary(block, tableWindow(block, { page: 0, search: "show 2" }))).toBe("1–6 of 6 matching, of 25 loaded");
+    expect(tableSummary(block, tableWindow(block, { page: 0, search: "show 2" }))).toBe("1–6 of 6 matching · 25 loaded");
+    expect(tableSummary(block, tableWindow(block, { page: 0, search: "vera" }))).toBe("No rows matching · 25 loaded");
+  });
+
+  it("says so when there is nothing", () => {
+    const block = table(0, { live: true });
+    expect(tableSummary(block, tableWindow(block, { page: 0, search: "" }))).toBe("No rows");
+  });
+});
+
+describe("numericColumns", () => {
+  // A script hands the table text, so a column of numbers is one that looks like
+  // it — decided per column, and never by one cell that happens to be a digit.
+  it("reads a column of numbers off the page", () => {
+    const rows = [
+      ["ten_zvm78", "17mar2022", "4", "1,204"],
+      ["ent_YEQwo", "adam-user", "", "-12.5"],
+    ];
+
+    expect(numericColumns(rows, 4)).toEqual([false, false, true, true]);
+  });
+
+  it("calls an empty column nothing", () => {
+    expect(numericColumns([["", ""]], 2)).toEqual([false, false]);
+    expect(numericColumns([], 2)).toEqual([false, false]);
   });
 });

--- a/ui/src/tableView.ts
+++ b/ui/src/tableView.ts
@@ -47,6 +47,25 @@ export function hasControls(block: TableBlock): boolean {
   return block.live === true || block.expired === true || block.rows.length > pageSizeOf(block);
 }
 
+/**
+ * How big the whole result set is, and whether that is the size of it or only
+ * what has been seen so far. A script that has an API's count says it; one
+ * paging a cursor has nothing to say, and the table counts what it has and marks
+ * the number as a floor rather than passing it off as the total.
+ */
+export interface TableTotal {
+  count: number;
+  exact: boolean;
+}
+
+export function totalOf(block: TableBlock): TableTotal {
+  // A total is a claim and exhaustion is the truth: a source that reported 2,431
+  // and ran out at 2,000 has 2,000 rows in it. The other way round, a count the
+  // rows have already passed is a number the table can see is wrong.
+  if (block.total !== undefined && block.exhausted !== true) return { count: Math.max(block.total, block.rows.length), exact: true };
+  return { count: block.rows.length, exact: !isOpen(block) };
+}
+
 export interface TableWindow {
   // The rows to draw, and where they sit in what the table has.
   rows: string[][];
@@ -75,7 +94,7 @@ export function tableWindow(block: TableBlock, view: TableView): TableWindow {
   // The last page of what is loaded — plus one while the source is open, since
   // paging into rows that aren't here yet is exactly how they are asked for.
   const loadedPages = Math.max(0, Math.ceil(rows.length / size) - 1);
-  const page = Math.max(0, Math.min(view.page, isOpen(block) && !filtered ? loadedPages + 1 : loadedPages));
+  const page = Math.max(0, Math.min(view.page, canGrow(block) && !filtered ? loadedPages + 1 : loadedPages));
   const start = page * size;
   const shown = rows.slice(start, start + size);
 
@@ -90,8 +109,9 @@ export function tableWindow(block: TableBlock, view: TableView): TableWindow {
     hasPrevious: page > 0,
     // No lookahead: pulling one row past the page to light the button up would
     // fetch a whole page to answer a question nobody asked. A live source offers
-    // Next until it runs out, and a click that yields nothing closes it out.
-    hasNext: start + shown.length < rows.length || (isOpen(block) && !filtered),
+    // Next until it runs out, and a click that yields nothing closes it out —
+    // unless it reported a total, which is exactly the click that saves.
+    hasNext: start + shown.length < rows.length || (canGrow(block) && !filtered),
     want: (page + 1) * size,
   };
 }
@@ -99,6 +119,13 @@ export function tableWindow(block: TableBlock, view: TableView): TableWindow {
 // Whether more rows can still be had from the source.
 export function isOpen(block: TableBlock): boolean {
   return block.live === true && block.exhausted !== true && block.expired !== true;
+}
+
+// …and whether they are worth asking for. A source that reported a total has
+// said where it ends, so the pager stops there rather than on the click that
+// comes back with nothing.
+export function canGrow(block: TableBlock): boolean {
+  return isOpen(block) && (block.total === undefined || block.rows.length < block.total);
 }
 
 /**
@@ -122,18 +149,53 @@ export function pullNeeded(block: TableBlock, view: TableView): { needed: boolea
   if (block.loading === true || block.error !== undefined || block.exhausted === true) return { needed: false, want };
   // Searching what is loaded must not pull an API dry to find three rows.
   if (searchesLocally(block) && view.search.trim() !== "") return { needed: false, want };
-  return { needed: block.rows.length < want, want };
+  return { needed: canGrow(block) && block.rows.length < want, want };
 }
 
 /**
- * What the footer says about how much there is. A static table knows its total;
- * a live one only knows what it has, and says so rather than implying the count
- * is the answer.
+ * What the toolbar says about how much there is. One sentence in one shape —
+ * `1–50 of 2,431` — with a `+` where the total is a floor rather than a count:
+ * the script reported one, or the source ran out and what is loaded is all there
+ * was, or neither and the table says how far it has got.
  */
 export function tableSummary(block: TableBlock, window: TableWindow): string {
-  const range = window.total === 0 ? "No rows" : `${window.from}–${window.to} of ${window.total}`;
-  if (window.filtered) return `${range} matching, of ${window.loaded} loaded`;
-  if (block.expired === true) return `${range} loaded — run to load the rest`;
-  if (isOpen(block)) return `${window.from}–${window.to} · ${window.loaded} loaded`;
-  return range;
+  const range = `${count(window.from)}–${count(window.to)}`;
+  if (window.filtered) {
+    return window.total === 0
+      ? `No rows matching · ${count(window.loaded)} loaded`
+      : `${range} of ${count(window.total)} matching · ${count(window.loaded)} loaded`;
+  }
+  const whole = totalOf(block);
+  if (whole.count === 0) return "No rows";
+  const total = `${count(whole.count)}${whole.exact ? "" : "+"}`;
+  // A source that said how many there are before it had sent any: the count is
+  // the one thing worth stating, and the rows are on their way.
+  if (window.to === 0) return `0 of ${total}`;
+  if (block.expired === true) return `${range} of ${total} loaded — run to load the rest`;
+  return `${range} of ${total}`;
+}
+
+function count(value: number): string {
+  return value.toLocaleString();
+}
+
+const NUMBER = /^[-+]?(\d{1,3}(,\d{3})+|\d+)(\.\d+)?%?$/;
+
+/**
+ * Which columns read from the right. A script hands the table text, so this is
+ * decided by what the cells are rather than by anything declared: a column is a
+ * column of numbers when every cell in it that says anything is one. It is
+ * settled on the page being drawn, which is the only place it shows.
+ */
+export function numericColumns(rows: string[][], columns: number): boolean[] {
+  return Array.from({ length: columns }, (_, index) => {
+    let seen = false;
+    for (const row of rows) {
+      const cell = (row[index] ?? "").trim();
+      if (cell === "") continue;
+      if (!NUMBER.test(cell)) return false;
+      seen = true;
+    }
+    return seen;
+  });
 }


### PR DESCRIPTION
`kaja.table`'s handle grows a third verb — `.total(count)` — which a source calls from inside its own loop as the API reports it, so the toolbar reads `1–50 of 2,431`; a cursor-based source says nothing and gets `of 120+` until it runs out.

The block is design 1B: a card with a 40px toolbar (real search input, paired 28px pager), a `bg-muted` header band, 26px truncating rows, numeric columns read from the right, and the empty and failed states as rows inside the frame.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VR2nmRF8yfyyBwyvyFjhWg)_