### PR TITLE
Held the table's height and its page while it fetches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,6 +643,32 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
     **28px** — the search box is a real input, and Previous/Next are two 28px
     buttons **joined into one pair**, so there is no gap between them to miss
     into. That is what the 12px chevrons in a line of body text were not.
+  - **Paging moves nothing** (`holdsPage`, `bodyMinHeight`). A fetch is 200–800ms
+    and a table sits in the middle of a document, so a page that collapsed to a
+    loading row and grew back would move every block below it twice per click.
+    The frame keeps the height of a **full page** — `28 + pageSize × 26` as a
+    `min-height` on the body — for as long as the table can page; only the final
+    page of a table that can no longer page shrinks to its rows, and by then
+    nothing is going to move again. A local filter is instant and its result is
+    the whole of it, so it is the one narrowing allowed to shrink.
+    - **The old page stays, dimmed** (`TableWindow.held`). It is the page you
+      were reading: `opacity-40` and `pointer-events-none` rather than thrown
+      away, with a 2px indeterminate bar along the bottom edge of the toolbar
+      and a spinner in place of the pressed button's chevron, so the loader is
+      also where the click was.
+    - **A first draw has nothing to dim**, so it draws skeleton rows — one per
+      row of the page being fetched, one slow shimmer across the whole set, and
+      bar widths fixed per column index, since widths that re-roll on every
+      render look like activity that isn't there.
+    - **Under 150ms nothing is drawn at all** (`TABLE_LOADING_DELAY_MS`). A page
+      off a local server is back inside a frame or two, and a dim that flashes
+      reads as a glitch rather than as progress. The frame is already held, so
+      the wait costs no movement.
+    - **The toolbar states the page that was clicked**, not the rows in hand
+      (`TableWindow.pending`): `51–100 of 2,431` while it is fetched, or
+      `Loading 1–50…` before a source has reported a count. The range used to be
+      read off rows that hadn't arrived, so it dropped to zero and back on every
+      click — including the first draw, which is the one everybody sees.
   - **One row is one line.** Cells truncate rather than wrap — a wrapped cell
     breaks the 26px rhythm the grid is read down — and a long one carries its
     full value as a hover title. A column whose every non-empty cell is a number

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -7,7 +7,7 @@ import { cn } from "./cn";
 import { Button } from "./components/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { Spinner } from "./components/spinner";
-import { hasControls, NO_TABLE_VIEW, numericColumns, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
+import { bodyMinHeight, hasControls, NO_TABLE_VIEW, numericColumns, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
 import { ConsoleItem, FailureNotice, RunGroup } from "./runs";
 import { barHeight, BAR_MAX_HEIGHT, slotsFor, SLOT_WIDTH, StripSlot, TICK_HEIGHT, TICK_WIDTH } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
@@ -25,6 +25,20 @@ const STRIP_RESERVE = 160;
 // much it kept back — a decision is never made from a payload you had to leave
 // the screen to read, so Expand is beside the number.
 const APPROVE_CLIP_LINES = 12;
+
+/**
+ * How long a table's pull has to be taking before anything is drawn about it. A
+ * page off a local server is back inside a frame or two, and a dim that flashes
+ * for 40ms reads as a glitch rather than as progress.
+ */
+const TABLE_LOADING_DELAY_MS = 150;
+
+/**
+ * Skeleton bar widths, by column index. Fixed rather than random: widths that
+ * re-roll on every render look like activity that isn't there, and a column of
+ * bars that all end in the same place reads as a column.
+ */
+const SKELETON_WIDTHS = ["58%", "76%", "44%", "66%", "52%", "70%"];
 
 interface CanvasProps {
   group: RunGroup;
@@ -323,30 +337,50 @@ interface TableProps {
  * what pulls the source, and nothing else does. A search that the source takes
  * restarts it; one it doesn't filters the rows already here, and says so — a
  * local filter that fetched would pull an API dry to find three rows.
+ *
+ * **Paging moves nothing.** The frame keeps the height of a full page while the
+ * table can still page, so the blocks below it stay where they are; the page
+ * that was on screen stays too, dimmed, until the next one is here. Only a first
+ * draw has nothing to dim, and that is what the skeleton rows are for.
  */
 Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   const shown = tableWindow(block, view);
   const controls = hasControls(block);
+  const busy = useDelayed(block.loading === true, TABLE_LOADING_DELAY_MS);
+  // Which chevron was pressed, so the spinner is where the click was. It is the
+  // press that is remembered rather than the direction of the move: the page can
+  // be clamped, and a pull can start without either button being touched.
+  const [pressed, setPressed] = useState<"previous" | "next" | undefined>(undefined);
+  // Forgotten once the page it asked for is here — and not a moment before: the
+  // pull it started is one effect away, so a press cleared on "not loading yet"
+  // is a press cleared between the click and the fetch it caused.
+  if (pressed !== undefined && block.loading !== true && !shown.pending) setPressed(undefined);
+
+  // Nothing is destroyed and nothing resizes: the old page holds its place at
+  // reduced opacity until the new one is here.
+  const holding = busy && shown.pending && shown.held.length > 0;
+  const drawn = holding ? shown.held : shown.rows;
+  const skeleton = busy && shown.pending && drawn.length === 0;
   // A search bound for the source is debounced; one that filters what is loaded
   // is not, because it costs nothing and lagging under the keystrokes is worse.
   // The text is settled before it is debounced, so the space after a word is not
   // a second search — and ⏎ says "now", which is what the wait is for.
   const [search, searchNow] = useDebounced(view.search.trim(), searchesLocally(block) ? 0 : 300);
   const { needed, want } = pullNeeded(block, { page: shown.page, search });
-  const numeric = numericColumns(shown.rows, block.columns.length);
+  const numeric = numericColumns(drawn, block.columns.length);
 
   useEffect(() => {
     if (needed) onPull(id, search, want);
   }, [needed, id, search, want, onPull]);
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
+    <div className="overflow-hidden rounded-lg border border-border" aria-busy={busy || undefined}>
       {/* One bar, above the rows. A pager under a fifty-row table is a control
           you have to go looking for, and on a canvas of several blocks it is
           hard to tell which table it belongs to. Everything in it is 28px,
           which is what a pointer wants and what a 12px glyph never was. */}
       {controls && (
-        <div className="flex h-10 items-center gap-2 border-b border-border bg-card px-2">
+        <div className="relative flex h-10 items-center gap-2 border-b border-border bg-card px-2">
           <div className="flex h-7 w-[200px] min-w-0 shrink items-center gap-1.5 rounded-md border border-input bg-background px-2 focus-within:border-ring">
             <Search size={13} className="shrink-0 text-muted-foreground" />
             <input
@@ -371,22 +405,34 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
               </button>
             )}
           </div>
-          {block.loading && <Spinner className="size-3 shrink-0" />}
+          {/* A pull in flight, along the bottom edge of the toolbar: the one
+              thing that moves, 2px of it, and it says nothing about how far
+              along the fetch is because nothing knows. */}
+          {busy && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden">
+              <div className="h-full w-1/3 rounded-full bg-foreground/40 animate-sweep motion-reduce:animate-none" />
+            </div>
+          )}
           <div className="ml-auto flex min-w-0 items-center gap-2">
             <span data-testid="canvas-table-summary" className="min-w-0 truncate tabular-nums text-muted-foreground @max-[520px]:hidden">
               {tableSummary(block, shown)}
             </span>
             {/* Two buttons joined into a pair: one target to aim at, and the
-                gap between them can't be missed into. */}
+                gap between them can't be missed into. The loader is also where
+                the click was — the pressed one holds a spinner in place of its
+                chevron, rather than the toolbar reporting it somewhere else. */}
             <div className="flex shrink-0 overflow-hidden rounded-md border border-input">
               <button
                 type="button"
                 className="flex h-7 w-7 items-center justify-center border-r border-input text-muted-foreground disabled:opacity-40 enabled:hover:bg-accent enabled:hover:text-accent-foreground"
                 disabled={!shown.hasPrevious}
                 aria-label="Previous page"
-                onClick={() => onView(id, { ...view, page: shown.page - 1 })}
+                onClick={() => {
+                  setPressed("previous");
+                  onView(id, { ...view, page: shown.page - 1 });
+                }}
               >
-                <ChevronLeft size={15} />
+                {busy && pressed === "previous" ? <Spinner className="size-3.5" /> : <ChevronLeft size={15} />}
               </button>
               <button
                 type="button"
@@ -394,70 +440,96 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
                 className="flex h-7 w-7 items-center justify-center text-muted-foreground disabled:opacity-40 enabled:hover:bg-accent enabled:hover:text-accent-foreground"
                 disabled={!shown.hasNext || block.loading === true}
                 aria-label="Next page"
-                onClick={() => onView(id, { ...view, page: shown.page + 1 })}
+                onClick={() => {
+                  setPressed("next");
+                  onView(id, { ...view, page: shown.page + 1 });
+                }}
               >
-                <ChevronRight size={15} />
+                {busy && pressed === "next" ? <Spinner className="size-3.5" /> : <ChevronRight size={15} />}
               </button>
             </div>
           </div>
         </div>
       )}
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse">
-          <thead>
-            <tr className="bg-muted">
-              {block.columns.map((column, index) => (
-                <th
-                  key={index}
-                  className={cn(
-                    "h-7 whitespace-nowrap border-b border-border px-3 text-left font-medium uppercase text-muted-foreground",
-                    numeric[index] && "text-right",
-                  )}
-                >
-                  {column}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {shown.rows.map((row, rowIndex) => (
-              // One row is one line: a cell that wrapped would break the 26px
-              // rhythm the whole grid is read down.
-              <tr key={rowIndex} className="last:[&>td]:border-b-0">
-                {row.map((cell, cellIndex) => (
-                  <td
-                    key={cellIndex}
-                    className={cn("h-[26px] max-w-[48ch] truncate border-b border-border/50 px-3 text-foreground", numeric[cellIndex] && "text-right")}
-                    title={cell.length > 48 ? cell : undefined}
+      {/* The height of a full page, held for as long as the table can page, so
+          a fetch, a short last page and a filtered result all leave the blocks
+          below exactly where they were. */}
+      <div className="relative flex flex-col" style={{ minHeight: bodyMinHeight(block, shown) }}>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="bg-muted">
+                {block.columns.map((column, index) => (
+                  <th
+                    key={index}
+                    className={cn(
+                      "h-7 whitespace-nowrap border-b border-border px-3 text-left font-medium uppercase text-muted-foreground",
+                      numeric[index] && "text-right",
+                    )}
                   >
-                    {cell}
-                  </td>
+                    {column}
+                  </th>
                 ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      {shown.rows.length === 0 && (
-        <div className="flex h-10 items-center gap-2 px-3 text-muted-foreground">
-          {block.loading ? (
-            "Loading…"
-          ) : shown.filtered ? (
-            <>
-              <span className="min-w-0 truncate">No rows match “{view.search.trim()}”</span>
-              <button
-                type="button"
-                className="shrink-0 underline decoration-muted-foreground/40 underline-offset-2 hover:text-foreground"
-                onClick={() => onView(id, { page: 0, search: "" })}
-              >
-                Clear search
-              </button>
-            </>
-          ) : (
-            "No rows yet…"
-          )}
+            </thead>
+            {/* Rows that are on their way out stop responding to the pointer:
+                what is under it is the page you were reading, not the one you
+                asked for. */}
+            <tbody className={cn(holding && "pointer-events-none opacity-40")}>
+              {skeleton
+                ? Array.from({ length: shown.expected }, (_, rowIndex) => (
+                    <tr key={rowIndex} className="last:[&>td]:border-b-0">
+                      {block.columns.map((_, cellIndex) => (
+                        <td key={cellIndex} className="h-[26px] border-b border-border/50 px-3">
+                          <div className="h-2 rounded-full bg-foreground/10" style={{ width: SKELETON_WIDTHS[cellIndex % SKELETON_WIDTHS.length] }} />
+                        </td>
+                      ))}
+                    </tr>
+                  ))
+                : drawn.map((row, rowIndex) => (
+                    // One row is one line: a cell that wrapped would break the
+                    // 26px rhythm the whole grid is read down.
+                    <tr key={rowIndex} className="last:[&>td]:border-b-0">
+                      {row.map((cell, cellIndex) => (
+                        <td
+                          key={cellIndex}
+                          className={cn("h-[26px] max-w-[48ch] truncate border-b border-border/50 px-3 text-foreground", numeric[cellIndex] && "text-right")}
+                          title={cell.length > 48 ? cell : undefined}
+                        >
+                          {cell}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+            </tbody>
+          </table>
         </div>
-      )}
+        {/* One slow shimmer across the whole set rather than one per bar: fifty
+            bars each pulsing on their own is a light show, not a wait. */}
+        {skeleton && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 top-7 bg-gradient-to-r from-transparent via-foreground/[0.06] to-transparent animate-shimmer motion-reduce:animate-none" />
+        )}
+        {/* Nothing at all while a page is on its way and under the delay: a
+            flash of loading state is worse than no state. */}
+        {drawn.length === 0 && !skeleton && !shown.pending && (
+          <div className="flex h-10 items-center gap-2 px-3 text-muted-foreground">
+            {shown.filtered ? (
+              <>
+                <span className="min-w-0 truncate">No rows match “{view.search.trim()}”</span>
+                <button
+                  type="button"
+                  className="shrink-0 underline decoration-muted-foreground/40 underline-offset-2 hover:text-foreground"
+                  onClick={() => onView(id, { page: 0, search: "" })}
+                >
+                  Clear search
+                </button>
+              </>
+            ) : (
+              "No rows yet…"
+            )}
+          </div>
+        )}
+      </div>
       {block.error !== undefined && (
         <div className="flex h-10 items-center gap-2 border-t border-border bg-destructive/10 px-3 text-destructive">
           <span className="min-w-0 flex-1 truncate">{block.error}</span>
@@ -488,6 +560,24 @@ function useDebounced<T>(value: T, delay: number): [T, () => void] {
     return () => clearTimeout(timer);
   }, [value, delay]);
   return [delay === 0 ? value : settled, () => setSettled(value)];
+}
+
+/**
+ * True once something has been true for this long, and false the moment it
+ * stops. A loading state is worth drawing only if it will be read: under the
+ * delay the fetch is already back, and what was drawn about it was a flicker.
+ */
+function useDelayed(active: boolean, delay: number): boolean {
+  const [held, setHeld] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setHeld(false);
+      return;
+    }
+    const timer = setTimeout(() => setHeld(true), delay);
+    return () => clearTimeout(timer);
+  }, [active, delay]);
+  return active && held;
 }
 
 interface AskProps {

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Block, TableBlock } from "./blocks";
 import { Kaja } from "./kaja";
+import { bodyMinHeight, tableSummary, tableWindow } from "./tableView";
 
 // A Kaja with nowhere to draw but a map of what it drew, which is what a table
 // is: a block that keeps being handed back with more in it.
@@ -270,6 +271,42 @@ describe("kaja.table", () => {
   it("reports a table whose source it no longer holds", async () => {
     const { kaja } = draw();
     expect(await kaja.pullTable("block-gone", "", 50)).toBe(false);
+  });
+
+  /**
+   * The whole of what paging looks like, against the shape a real script has: a
+   * source that fetches a page at a time and reports the count it was sent
+   * beside it. Nothing about the frame may move between these states — the range
+   * never drops to zero, and the height is a full page throughout.
+   */
+  it("never drops to nothing between one page and the next", async () => {
+    const { kaja, only, id } = draw();
+    const shows = kaja.table(["id"], async function* () {
+      for (let page = 1; ; page++) {
+        shows.total(2431);
+        yield* Array.from({ length: 50 }, (_, row) => [`show-${(page - 1) * 50 + row}`]);
+      }
+    });
+
+    const height = 28 + 50 * 26;
+    const at = (page: number) => {
+      const window = tableWindow(only(), { page, search: "" });
+      return { summary: tableSummary(only(), window), height: bodyMinHeight(only(), window), rows: window.rows.length, held: window.held.length };
+    };
+
+    // Drawn, and its first page not yet asked for: the count is the one thing
+    // nothing knows yet, so the table says which rows are on their way.
+    expect(at(0)).toEqual({ summary: "Loading 1–50…", height, rows: 0, held: 0 });
+
+    await kaja.settleTables();
+    expect(at(0)).toEqual({ summary: "1–50 of 2,431", height, rows: 50, held: 0 });
+
+    // Next, before the pull it asks for has landed: the page that was on screen
+    // is what stays there, and the toolbar already states the page being read.
+    expect(at(1)).toEqual({ summary: "51–100 of 2,431", height, rows: 0, held: 50 });
+
+    await kaja.pullTable(id(), "", 100);
+    expect(at(1)).toEqual({ summary: "51–100 of 2,431", height, rows: 50, held: 0 });
   });
 
   it("takes a plain array of rows from an iterable source", async () => {

--- a/ui/src/tableView.test.ts
+++ b/ui/src/tableView.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { TableBlock } from "./blocks";
-import { hasControls, numericColumns, pullNeeded, tableSummary, tableWindow, totalOf } from "./tableView";
+import { bodyMinHeight, hasControls, numericColumns, pullNeeded, tableSummary, tableWindow, totalOf } from "./tableView";
 
 function table(rows: number, extra: Partial<TableBlock> = {}): TableBlock {
   return {
@@ -84,6 +84,68 @@ describe("tableWindow", () => {
     expect(tableWindow(table(20, { live: true, total: 200 }), { page: 1, search: "" }).hasNext).toBe(true);
     // …and the clamp stops letting a page past the loaded rows through with it.
     expect(tableWindow(table(20, { live: true, total: 20 }), { page: 5, search: "" }).page).toBe(1);
+  });
+});
+
+describe("a page in flight", () => {
+  // Nothing is destroyed and nothing resizes: the page that was on screen stays
+  // there while the next one is fetched.
+  it("holds the page that was on screen", () => {
+    const shown = tableWindow(table(10, { live: true }), { page: 1, search: "" });
+
+    expect(shown.pending).toBe(true);
+    expect(shown.rows).toEqual([]);
+    expect(shown.held.map((row) => row[0])).toEqual(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
+  });
+
+  // The first draw of a table has nothing to hold, which is what the skeleton
+  // rows are for — and how many of them there are is what the frame reserves.
+  it("has nothing to hold on a first draw, and expects a full page", () => {
+    const shown = tableWindow(table(0, { live: true }), { page: 0, search: "" });
+
+    expect([shown.pending, shown.held.length, shown.expected]).toEqual([true, 0, 10]);
+  });
+
+  it("expects the short last page a reported total pins down", () => {
+    expect(tableWindow(table(20, { live: true, total: 25 }), { page: 2, search: "" }).expected).toBe(5);
+  });
+
+  // A page that stopped is not a page on its way: Retry is what asks again.
+  it("is not pending once the source ran out, was counted out, or failed", () => {
+    expect(tableWindow(table(10, { live: true, exhausted: true }), { page: 1, search: "" }).pending).toBe(false);
+    expect(tableWindow(table(20, { live: true, total: 20 }), { page: 1, search: "" }).pending).toBe(false);
+    expect(tableWindow(table(10, { live: true, error: "unreachable" }), { page: 1, search: "" }).pending).toBe(false);
+    expect(tableWindow(table(25, { live: true }), { page: 0, search: "show 2" }).pending).toBe(false);
+  });
+});
+
+describe("holdsPage", () => {
+  function hold(block: TableBlock, view = { page: 0, search: "" }) {
+    return bodyMinHeight(block, tableWindow(block, view));
+  }
+
+  // A fetch is 200–800ms and a table sits in the middle of a document: a page
+  // that collapsed and grew back would move everything below it twice a click.
+  it("keeps a full page's height while the table can page", () => {
+    // header 28 + 10 rows × 26.
+    expect(hold(table(0, { live: true }))).toBe(288);
+    expect(hold(table(10, { live: true }), { page: 1, search: "" })).toBe(288);
+    expect(hold(table(25, { live: true, exhausted: true }))).toBe(288);
+  });
+
+  // …and only then. By the last page of a table that can no longer page nothing
+  // is going to move again, and a local filter's result is the whole of it.
+  it("lets the rows decide once there is nothing left to page to", () => {
+    expect(hold(table(25, { live: true, exhausted: true }), { page: 2, search: "" })).toBeUndefined();
+    expect(hold(table(25), { page: 2, search: "" })).toBeUndefined();
+    expect(hold(table(25, { live: true }), { page: 0, search: "show 2" })).toBeUndefined();
+    // A table that fits on a page was never a frame with a pager in it.
+    expect(hold(table(10))).toBeUndefined();
+  });
+
+  // A short last page still reserves what it is about to take, not a page.
+  it("reserves what a counted last page will fill", () => {
+    expect(hold(table(20, { live: true, total: 25 }), { page: 2, search: "" })).toBe(158);
   });
 });
 
@@ -204,8 +266,27 @@ describe("tableSummary", () => {
   });
 
   it("says so when there is nothing", () => {
-    const block = table(0, { live: true });
+    const block = table(0, { live: true, exhausted: true });
     expect(tableSummary(block, tableWindow(block, { page: 0, search: "" }))).toBe("No rows");
+  });
+
+  // The count used to drop to zero and back on every click, because the range
+  // was read off rows that hadn't arrived. A page in flight states the page that
+  // was clicked, and the count once the source has reported one.
+  it("states the page being fetched rather than the rows in hand", () => {
+    const first = table(0, { live: true });
+    expect(tableSummary(first, tableWindow(first, { page: 0, search: "" }))).toBe("Loading 1–10…");
+
+    const counted = table(0, { live: true, total: 2431 });
+    expect(tableSummary(counted, tableWindow(counted, { page: 0, search: "" }))).toBe("1–10 of 2,431");
+
+    const paging = table(10, { live: true, total: 2431 });
+    expect(tableSummary(paging, tableWindow(paging, { page: 1, search: "" }))).toBe("11–20 of 2,431");
+
+    // A source that reported a count knows where its last page ends, so the
+    // range it states is the short one it is about to draw.
+    const last = table(20, { live: true, total: 25 });
+    expect(tableSummary(last, tableWindow(last, { page: 2, search: "" }))).toBe("21–25 of 25");
   });
 });
 

--- a/ui/src/tableView.ts
+++ b/ui/src/tableView.ts
@@ -8,6 +8,15 @@ import { TableBlock } from "./blocks";
  */
 export const DEFAULT_PAGE_SIZE = 50;
 
+/**
+ * The frame a table is drawn in. The heights are stated here as well as in the
+ * class names because the room a page takes is arithmetic the table does: a page
+ * in flight holds exactly the height the page it is fetching will fill, so
+ * nothing below the table moves while it is fetched.
+ */
+const ROW_HEIGHT = 26;
+const HEADER_HEIGHT = 28;
+
 // Where a table is currently pointed. This is view state rather than something
 // the run drew, so it is held beside the console and not in the block.
 export interface TableView {
@@ -81,6 +90,16 @@ export interface TableWindow {
   hasNext: boolean;
   // How many rows the source must hold for this page to be full.
   want: number;
+  // The page isn't here yet and the source can still bring it, so what is drawn
+  // is a page in flight rather than the page as it is.
+  pending: boolean;
+  // What stays on screen while it is: the page that was being read, which is
+  // dimmed rather than thrown away. Empty when there is nothing to hold — the
+  // first draw of a table, or a source restarted by a search.
+  held: string[][];
+  // How many rows this page holds once it is here. A total the source reported
+  // is what makes a short last page reserve the room it will actually take.
+  expected: number;
 }
 
 /**
@@ -98,14 +117,28 @@ export function tableWindow(block: TableBlock, view: TableView): TableWindow {
   const start = page * size;
   const shown = rows.slice(start, start + size);
 
+  // A page that isn't full yet and a source that can still fill it: the rows are
+  // on their way. An error is the one thing that says they are not — the table
+  // stopped where it stopped, and Retry is what asks again.
+  const pending = !filtered && block.error === undefined && shown.length < size && canGrow(block);
+  const whole = totalOf(block);
+  const expected = !filtered && whole.exact ? Math.max(0, Math.min(size, whole.count - start)) : size;
+  // The range being fetched, not the rows in hand: the toolbar states the page
+  // that was clicked for as long as it takes to arrive, rather than dropping to
+  // zero and back on every click.
+  const to = pending ? start + expected : start + shown.length;
+
   return {
     rows: shown,
     page,
-    from: shown.length === 0 ? 0 : start + 1,
-    to: start + shown.length,
+    from: to === 0 ? 0 : start + 1,
+    to,
     total: rows.length,
     loaded: block.rows.length,
     filtered,
+    pending,
+    held: pending && page > 0 ? rows.slice(start - size, start) : [],
+    expected,
     hasPrevious: page > 0,
     // No lookahead: pulling one row past the page to light the button up would
     // fetch a whole page to answer a question nobody asked. A live source offers
@@ -153,6 +186,26 @@ export function pullNeeded(block: TableBlock, view: TableView): { needed: boolea
 }
 
 /**
+ * Whether the frame keeps the height of a full page. A fetch is 200–800ms and a
+ * table is drawn in the middle of a document, so a page that collapsed to a
+ * loading row and grew back would move everything below it twice per click. The
+ * frame holds for as long as the table can page; only the final page of a table
+ * that can no longer page shrinks to its rows, and by then nothing is going to
+ * move again. A local filter is instant and its result is the whole of it, so it
+ * is the one narrowing that is allowed to shrink.
+ */
+export function holdsPage(block: TableBlock, window: TableWindow): boolean {
+  if (!hasControls(block) || window.filtered) return false;
+  return window.pending || block.loading === true || window.hasNext;
+}
+
+/** The height that hold comes to, or nothing where the rows decide it. */
+export function bodyMinHeight(block: TableBlock, window: TableWindow): number | undefined {
+  if (!holdsPage(block, window)) return undefined;
+  return HEADER_HEIGHT + window.expected * ROW_HEIGHT;
+}
+
+/**
  * What the toolbar says about how much there is. One sentence in one shape —
  * `1–50 of 2,431` — with a `+` where the total is a floor rather than a count:
  * the script reported one, or the source ran out and what is loaded is all there
@@ -166,10 +219,14 @@ export function tableSummary(block: TableBlock, window: TableWindow): string {
       : `${range} of ${count(window.total)} matching · ${count(window.loaded)} loaded`;
   }
   const whole = totalOf(block);
+  // A page in flight states the page that was clicked. A source that reported a
+  // count says it too — that is the whole of what is known — and one that hasn't
+  // says only which rows are on their way, rather than passing off what it
+  // happens to hold as the size of the set.
+  if (window.pending) return whole.exact && whole.count > 0 ? `${range} of ${count(whole.count)}` : `Loading ${range}…`;
   if (whole.count === 0) return "No rows";
   const total = `${count(whole.count)}${whole.exact ? "" : "+"}`;
-  // A source that said how many there are before it had sent any: the count is
-  // the one thing worth stating, and the rows are on their way.
+  // A source that said how many there are and then stopped before sending any.
   if (window.to === 0) return `0 of ${total}`;
   if (block.expired === true) return `${range} of ${total} loaded — run to load the rest`;
   return `${range} of ${total}`;

--- a/ui/src/tailwind.css
+++ b/ui/src/tailwind.css
@@ -99,11 +99,37 @@
   /* A run in flight: the mark drawing itself left to right, over and over for
      as long as the run is going. */
   --animate-trace: trace 1.4s linear infinite;
+
+  /* A table's page in flight: 2px along the bottom edge of its toolbar. It is
+     indeterminate because nothing knows how far along a fetch is. */
+  --animate-sweep: sweep 1.1s ease-in-out infinite;
+
+  /* One shimmer across a whole set of skeleton rows — slow, because it is
+     saying "waiting", not "working". */
+  --animate-shimmer: shimmer 1.8s linear infinite;
 }
 
 @keyframes trace {
   to {
     stroke-dashoffset: 0;
+  }
+}
+
+@keyframes sweep {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(300%);
+  }
+}
+
+@keyframes shimmer {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
   }
 }
 


### PR DESCRIPTION
A canvas table no longer collapses while it pages: the frame keeps the height of a full page for as long as the table can page, the page you were reading stays put at `opacity-40` under a 2px bar while the next one is in flight, and a first draw — which has nothing to dim — gets skeleton rows. The toolbar states the page that was clicked (`51–100 of 2,431`, or `Loading 1–50…` before a source reports a count) instead of dropping to zero and back.

---
_Generated by [Claude Code](https://claude.ai/code/session_015opX2ZngoipWhiANumoGt2)_