### PR TITLE
Kept the old page on screen under the loading delay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,15 +655,19 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
       were reading: `opacity-40` and `pointer-events-none` rather than thrown
       away, with a 2px indeterminate bar along the bottom edge of the toolbar
       and a spinner in place of the pressed button's chevron, so the loader is
-      also where the click was.
+      also where the click was. **It stays on the click, and dims on the
+      delay** — the two are separate (`stale` and `holding`), because a page
+      cleared while the dim waits its 150ms out is the blink the wait exists to
+      prevent.
     - **A first draw has nothing to dim**, so it draws skeleton rows — one per
       row of the page being fetched, one slow shimmer across the whole set, and
       bar widths fixed per column index, since widths that re-roll on every
       render look like activity that isn't there.
-    - **Under 150ms nothing is drawn at all** (`TABLE_LOADING_DELAY_MS`). A page
-      off a local server is back inside a frame or two, and a dim that flashes
-      reads as a glitch rather than as progress. The frame is already held, so
-      the wait costs no movement.
+    - **Under 150ms nothing is said at all** (`TABLE_LOADING_DELAY_MS`): no dim,
+      no bar, no skeleton — the rows just change. A page off a local server is
+      back inside a frame or two, and a dim that flashes reads as a glitch
+      rather than as progress. The frame is already held, so the wait costs no
+      movement.
     - **The toolbar states the page that was clicked**, not the rows in hand
       (`TableWindow.pending`): `51–100 of 2,431` while it is fetched, or
       `Loading 1–50…` before a source has reported a count. The range used to be

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -356,10 +356,14 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   // is a press cleared between the click and the fetch it caused.
   if (pressed !== undefined && block.loading !== true && !shown.pending) setPressed(undefined);
 
-  // Nothing is destroyed and nothing resizes: the old page holds its place at
-  // reduced opacity until the new one is here.
-  const holding = busy && shown.pending && shown.held.length > 0;
-  const drawn = holding ? shown.held : shown.rows;
+  // Nothing is destroyed and nothing resizes: the page that was on screen is
+  // what is on screen until the next one is here. That happens on the click,
+  // never on the delay — the wait decides when to *say* a page is coming, and a
+  // page cleared while the saying waits is the blink the wait was there to
+  // prevent.
+  const stale = shown.pending && shown.held.length > 0;
+  const drawn = stale ? shown.held : shown.rows;
+  const holding = busy && stale;
   const skeleton = busy && shown.pending && drawn.length === 0;
   // A search bound for the source is debounced; one that filters what is loaded
   // is not, because it costs nothing and lagging under the keystrokes is worse.


### PR DESCRIPTION
Pressing Next blanked the table for a frame before the dim appeared — the held page was gated on the same 150ms delay as the dim, so for the length of the wait there was neither the old page nor anything said about the new one. Holding the page is now decided by the click and dimming it by the delay.

---
_Generated by [Claude Code](https://claude.ai/code/session_015opX2ZngoipWhiANumoGt2)_