### PR TITLE
Paged the demo scripts through the theatre programme

### DIFF
--- a/workspace/scripts/programme.ts
+++ b/workspace/scripts/programme.ts
@@ -1,26 +1,23 @@
-// This week at The Kaja Theatre, drawn as a table.
-//
-// The shortest thing a script can be: one call, no parameters, one table.
-// Everything a script has to say it draws on the run's canvas — press Run and
-// look there, not at the Calls view, which is where you go when the answer is
-// wrong.
-
 import { kaja } from "kaja";
 import { TheKajaTheatre } from "theatre/service";
 
-const { items: shows } = await TheKajaTheatre.ListShows({});
-
-kaja.text(`${shows.length} films screening this week.`);
-
-const table = kaja.table(["id", "film", "director", "year", "runs", "starts", "from"]);
-for (const show of shows) {
-  table.row(
-    show.id,
-    show.title,
-    show.director,
-    show.year,
-    `${show.runtimeMinutes} min`,
-    new Date(show.startsAt).toLocaleString(undefined, { weekday: "short", hour: "2-digit", minute: "2-digit" }),
-    `€${(show.basePriceCents / 100).toFixed(2)}`,
-  );
-}
+const programme = kaja.table(
+  ["id", "film", "director", "year", "runs", "starts", "from"],
+  async function* () {
+    for (let cursor = ""; ; ) {
+      const page = await TheKajaTheatre.ListShows({ limit: 100, cursor });
+      programme.total(page.total);
+      yield* page.shows.map((show) => [
+        show.id,
+        show.title,
+        show.director,
+        show.year,
+        `${show.runtimeMinutes} min`,
+        new Date(show.startsAt).toLocaleString(undefined, { weekday: "short", hour: "2-digit", minute: "2-digit" }),
+        `€${(show.basePriceCents / 100).toFixed(2)}`,
+      ]);
+      if (!(cursor = page.nextCursor)) return;
+    }
+  },
+  { pageSize: 100 },
+);

--- a/workspace/scripts/seat-map.ts
+++ b/workspace/scripts/seat-map.ts
@@ -1,22 +1,12 @@
-// Where the free seats are, for a film you pick.
-//
-// Two apps in one script: the programme comes from an OpenAPI service over
-// HTTP, the seats from a gRPC one, and the script joins them on the id. A
-// script is not bound to an app — it binds to whatever its imports resolve to
-// at run time.
-//
-// kaja.askSelect parks the run on the canvas until the question is answered,
-// so there is no reason to hard-code an id to try a second film.
-
 import { kaja } from "kaja";
 import { TheKajaTheatre } from "theatre/service";
 import { Seating, SeatStatus, Section } from "seating/proto/seating";
 
-const { items: shows } = await TheKajaTheatre.ListShows({});
+const programme = await TheKajaTheatre.ListShows({ limit: 100, cursor: "" });
 
 const show = await kaja.askSelect(
-  "Which film?",
-  shows.map((show) => ({ label: `${show.title} · ${show.director}, ${show.year}`, value: show })),
+  `Which film? The first 100 screenings of ${programme.total}.`,
+  programme.shows.map((show) => ({ label: `${show.title} · ${show.director}, ${show.year}`, value: show })),
 );
 
 const { seatMap } = await Seating.GetSeatMap({ showId: show.id });
@@ -24,8 +14,6 @@ if (!seatMap) throw new Error(`No seat map for ${show.id}`);
 
 kaja.text(`${show.title} — ${seatMap.available} free, ${seatMap.held} held, ${seatMap.sold} sold.`);
 
-// The house is busy: other customers are booking while this runs, so the same
-// call a minute from now is a different answer.
 const table = kaja.table(["section", "row", "free", "held", "sold", "seats"]);
 for (const section of seatMap.sections) {
   for (const row of section.rows) {


### PR DESCRIPTION
`ListShows` is paginated now, so the two demo scripts that read it take pages of 100: `programme.ts` becomes a live table whose async generator source walks the whole programme and reports `total`, and `seat-map.ts` takes the first page for its select. Comments stripped from both.

---
_Generated by [Claude Code](https://claude.ai/code/session_0121YdWtf3L4MjVw45U4UgPY)_