### PR TITLE
Let a table cell be a value the script is still getting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,6 +586,41 @@ support surface. There is no `kaja.html`, no styling arguments, no layout contro
   how it looks. A handle into a table filled from a **source** goes quiet rather
   than throwing — a server-side search restarts the source from the top, so the
   row it pointed at is answering a question nobody is asking any more.
+- **A cell that is work rather than a value says which kind of work it is, and
+  that is the whole of loading-versus-here** (`CellStatus` on the block,
+  `LiveCell` beside it). A **promise** is work the script already started, so the
+  table only waits for it; a **function** is work nobody has asked for yet, so
+  the table asks — when the row is drawn, and again if a failed one is retried.
+  That is `restartable` one level down: a function can be called again and a
+  promise is finished, which is why one offers Retry and the other can't. An
+  `Error`, thrown or returned, is a cell that stopped. Nothing in the signatures
+  changed — `row(...cells: unknown[])` always accepted all of this, and a promise
+  used to render as `{}`.
+  - **The row is drawn with everything it already has**, which is the point: the
+    rows appear at once and the cells fetched by a second call fill in after
+    them. A waiting cell is the **same bar a skeleton row draws** — with no
+    shimmer (cells fill one at a time and that is movement enough) and no 150ms
+    delay (the bar arrives *with* the row rather than replacing something, so
+    there is nothing to flash). A stopped one is a dim `—` with the message on
+    hover: a column of numbers with `429 Too Many Requests` in the middle of it
+    stops being a column, and the width is 12ch on a good day.
+  - **Drawn is what asks** (`pendingCells`, `pullCells`). The canvas asks for
+    every waiting cell it can see on every frame, so *asking* is idempotent
+    rather than the work — a cell is started once, and the table is what knows
+    it. The exception is the one that has to be: a failed cell is asked for only
+    when someone asks, since retrying on sight is a loop and not a retry. The
+    first page is asked for with the table, on the rule that already makes a live
+    table pull its own — a run nobody is watching still fills one. Six cells are
+    in flight at a time, because a page draw asks for fifty at once.
+  - **A cell is addressed by where its row sits, not by where it landed on the
+    page** (`TableWindow.indices`), which is arithmetic until a local filter takes
+    rows out of the middle. Answers are checked against the row's **revision** on
+    the way in, so a row rewritten and a source restarted both drop what was
+    still coming — they answered the row as it was. A block whose cells have all
+    landed is stored as the plain table it has become, and one read back has lost
+    its closures, so a waiting cell reads as the `run to load` the table already
+    says. An agent's run reports the cells that never landed rather than passing
+    off blanks as values.
 - **A table's rows are an iterable, and that is the whole of static-versus-live.**
   An array is one; so is an async generator, and one of those only runs when
   something pulls it — which is what makes paging fetch a page and nothing else.

--- a/desktop/mcp/guide.md
+++ b/desktop/mcp/guide.md
@@ -139,6 +139,25 @@ changed; fewer cells than columns leaves the rest blank. `table.column(name)`
 adds a column if the run turns out to need one, and the rows already drawn grow a
 blank cell for it.
 
+**A cell can be a value you do not have yet.** Hand the table a promise where a
+value would go and the row is drawn with everything it already has, with that one
+cell loading until it lands — which is what to write when part of a row comes
+from a second call:
+
+```ts
+const seating = Seating.GetAvailability({ showIds: shows.map((show) => show.id) });
+for (const show of shows) {
+  table.row(show.id, show.title, seating.then((s) => s.byShow[show.id].available));
+}
+```
+
+A **function** instead of a promise is work nobody has asked for yet: it is
+called when its row is drawn, so rows past the first page cost nothing until
+someone pages to them, and a failed one can be retried from the canvas. Nobody is
+paging your run, so a function past the first page is never called in it — use a
+promise when the value has to be in the run you are reporting. A cell that fails
+draws as `—` with the message on hover, and the rest of the table carries on.
+
 **A table can page and search itself.** Hand it the rows instead of pushing
 them, and it gets a search box and a pager for free — an array is drawn as it is,
 and a function is pulled a page at a time, only when the person reading it pages
@@ -204,6 +223,8 @@ What each member is for:
   `.column(name)` adds a column, and `.total(count)` states how many rows the
   whole result set holds when the API says. `rows` can be an array, or a source
   (an async generator) the table pulls a page at a time as it is paged through.
+  A cell can be a promise or a function rather than a value, and draws as loading
+  until it arrives.
 - `kaja.askStr(question)`, `kaja.askInt(question)`,
   `kaja.askSelect(question, options)` — ask the user for text, a whole number,
   or one of a list; each blocks on a human and hands back the kind of thing it

--- a/desktop/mcp/run.go
+++ b/desktop/mcp/run.go
@@ -143,6 +143,14 @@ func renderBlock(index int, block BlockLog) string {
 		if len(block.Columns) > 0 {
 			fmt.Fprintf(&b, "  [%s]", strings.Join(block.Columns, ", "))
 		}
+		// A cell that is a function is fetched when its row is drawn, and nobody
+		// is drawing this one past the first page.
+		if block.Pending > 0 {
+			fmt.Fprintf(&b, "  %d cell(s) not loaded", block.Pending)
+		}
+		if block.Failed > 0 {
+			fmt.Fprintf(&b, "  %d cell(s) failed", block.Failed)
+		}
 	} else if block.Label != "" {
 		fmt.Fprintf(&b, "  %s", block.Label)
 	}

--- a/desktop/mcp/server.go
+++ b/desktop/mcp/server.go
@@ -61,6 +61,11 @@ type BlockLog struct {
 	Label   string   `json:"label,omitempty"`
 	Columns []string `json:"columns,omitempty"`
 	Rows    int      `json:"rows,omitempty"`
+	// Cells of a table that hold no value: the ones still to be fetched, and the
+	// ones that stopped. A table with holes in it must say so rather than read
+	// as a table of blanks.
+	Pending int `json:"pending,omitempty"`
+	Failed  int `json:"failed,omitempty"`
 }
 
 // RunResult is the outcome of running a script in the webview. Result is what a

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,9 +21,9 @@ import { Definition } from "./Definition";
 import { Destination, Finder } from "./Finder";
 import { Splitter } from "./Splitter";
 import { answerPlaceholder, answerProblem, normalizeAnswer } from "./ask";
-import { ApproveBlock, ApproveGesture, AskBlock, Block, blockLabel } from "./blocks";
+import { ApproveBlock, ApproveGesture, AskBlock, Block, blockLabel, CellStatus, TableBlock } from "./blocks";
 import { ApprovalRejectedError, ApproveDecision, AskCancelledError, Kaja, MethodCall } from "./kaja";
-import { TableView } from "./tableView";
+import { CellRef, TableView } from "./tableView";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
 import { appendCall, createScratch, findUntouched, isUntouched, markRun, pruneScratches, reopen, Scratch, takeOver, withCode } from "./scratches";
@@ -596,6 +596,29 @@ export function App() {
       const live = await kajaRef.current!.pullTable(blockId, search, want);
       if (!live) {
         consoles.recordBlock(found.fileId, found.run.id, blockId, { ...table, live: false, expired: true }, Date.now());
+      }
+    } finally {
+      pullRunRef.current = previous;
+    }
+  }, []);
+
+  /**
+   * Start the cells a table is drawing — or retry one that stopped. The same
+   * shape as a pull, and for the same reason: the work belongs to the run whose
+   * canvas asked for it, and a table whose closures are gone says so rather than
+   * leaving a row of bars that will never fill.
+   */
+  const onTableCells = useCallback(async (blockId: string, cells: CellRef[]) => {
+    const found = consoles.findBlock(blockId);
+    const table = found?.block;
+    if (!found || table?.kind !== "table") return;
+
+    const previous = pullRunRef.current;
+    pullRunRef.current = found.run;
+    try {
+      const held = await kajaRef.current!.pullCells(blockId, cells);
+      if (!held) {
+        consoles.recordBlock(found.fileId, found.run.id, blockId, { ...table, expired: true }, Date.now());
       }
     } finally {
       pullRunRef.current = previous;
@@ -2397,6 +2420,7 @@ export function App() {
                         tableViews={tableViews}
                         onTableView={onTableView}
                         onTablePull={onTablePull}
+                        onTableCells={onTableCells}
                         onClear={currentFileId ? () => onClearConsole(currentFileId) : undefined}
                       />
                     </div>
@@ -2697,7 +2721,26 @@ function toBlockLog(block: Block) {
     // agent has nobody to press Next, so it is told the rows are a page rather
     // than the set — the loop that would fetch the rest is its own to write.
     more: table?.live === true && table.exhausted !== true ? true : undefined,
+    // A cell that is a function is fetched when its row is drawn, and past the
+    // first page nobody drew this one. A table with holes in it says so rather
+    // than reading as a table of blanks.
+    ...countCells(table),
   };
+}
+
+// The cells that hold no value, told apart by whether they are still coming or
+// have stopped. Both are absent from a table whose cells are all values, which
+// is every table that has none.
+function countCells(table: TableBlock | undefined): { pending?: number; failed?: number } {
+  let pending = 0;
+  let failed = 0;
+  for (const row of Object.values<{ [column: number]: CellStatus }>(table?.cells ?? {})) {
+    for (const status of Object.values<CellStatus>(row)) {
+      if (status.error === undefined) pending++;
+      else failed++;
+    }
+  }
+  return { pending: pending || undefined, failed: failed || undefined };
 }
 
 // toMethodCallLog flattens a MethodCall into the shape the MCP server returns to

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,13 +1,26 @@
-import { AlertTriangle, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CircleX, Search, ShieldQuestionMark, X } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CircleX, RotateCw, Search, ShieldQuestionMark, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { answerPlaceholder, answerProblem, AskAnswerType, normalizeAnswer } from "./ask";
-import { ApproveBlock, ApproveGesture, AskBlock, Block, CodeBlock, TableBlock, TextBlock } from "./blocks";
+import { ApproveBlock, ApproveGesture, AskBlock, Block, CellStatus, cellStatus, CodeBlock, TableBlock, TextBlock } from "./blocks";
 import { formatBytes, formatDuration } from "./callFormat";
 import { cn } from "./cn";
 import { Button } from "./components/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/dropdown-menu";
 import { Spinner } from "./components/spinner";
-import { bodyMinHeight, hasControls, NO_TABLE_VIEW, numericColumns, pullNeeded, searchesLocally, tableSummary, tableWindow, TableView } from "./tableView";
+import {
+  bodyMinHeight,
+  CellRef,
+  cellsKey,
+  hasControls,
+  NO_TABLE_VIEW,
+  numericColumns,
+  pendingCells,
+  pullNeeded,
+  searchesLocally,
+  tableSummary,
+  tableWindow,
+  TableView,
+} from "./tableView";
 import { ConsoleItem, FailureNotice, RunGroup } from "./runs";
 import { barHeight, BAR_MAX_HEIGHT, slotsFor, SLOT_WIDTH, StripSlot, TICK_HEIGHT, TICK_WIDTH } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
@@ -65,6 +78,8 @@ interface CanvasProps {
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
+  // The cells a drawn page is waiting for, and the retry of one that stopped.
+  onTableCells: (blockId: string, cells: CellRef[]) => void;
 }
 
 /**
@@ -85,6 +100,7 @@ export function Canvas({
   tableViews,
   onTableView,
   onTablePull,
+  onTableCells,
 }: CanvasProps) {
   const drawn = group.drawn;
   const unreported = group.unreported;
@@ -140,6 +156,7 @@ export function Canvas({
             tableViews={tableViews}
             onTableView={onTableView}
             onTablePull={onTablePull}
+            onTableCells={onTableCells}
           />
         </div>
       ))}
@@ -246,9 +263,11 @@ interface EntryProps {
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
+  // The cells a drawn page is waiting for, and the retry of one that stopped.
+  onTableCells: (blockId: string, cells: CellRef[]) => void;
 }
 
-Canvas.Entry = function ({ item, fullScreen, onAnswer, onCancelAsk, onDecide, onFullScreen, tableViews, onTableView, onTablePull }: EntryProps) {
+Canvas.Entry = function ({ item, fullScreen, onAnswer, onCancelAsk, onDecide, onFullScreen, tableViews, onTableView, onTablePull, onTableCells }: EntryProps) {
   if (item.logs) return <Canvas.Logs logs={item.logs} />;
   if (!item.block) return null;
   return (
@@ -263,6 +282,7 @@ Canvas.Entry = function ({ item, fullScreen, onAnswer, onCancelAsk, onDecide, on
       tableViews={tableViews}
       onTableView={onTableView}
       onTablePull={onTablePull}
+      onTableCells={onTableCells}
     />
   );
 };
@@ -280,16 +300,30 @@ interface BlockProps {
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
+  // The cells a drawn page is waiting for, and the retry of one that stopped.
+  onTableCells: (blockId: string, cells: CellRef[]) => void;
 }
 
-Canvas.Block = function ({ id, block, fullScreen, onAnswer, onCancelAsk, onDecide, onFullScreen, tableViews, onTableView, onTablePull }: BlockProps) {
+Canvas.Block = function ({
+  id,
+  block,
+  fullScreen,
+  onAnswer,
+  onCancelAsk,
+  onDecide,
+  onFullScreen,
+  tableViews,
+  onTableView,
+  onTablePull,
+  onTableCells,
+}: BlockProps) {
   switch (block.kind) {
     case "text":
       return <Canvas.Text block={block} fullScreen={fullScreen} />;
     case "code":
       return <Canvas.Code block={block} />;
     case "table":
-      return <Canvas.Table id={id} block={block} view={tableViews[id] ?? NO_TABLE_VIEW} onView={onTableView} onPull={onTablePull} />;
+      return <Canvas.Table id={id} block={block} view={tableViews[id] ?? NO_TABLE_VIEW} onView={onTableView} onPull={onTablePull} onCells={onTableCells} />;
     case "ask":
       return <Canvas.Ask id={id} block={block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
     case "approve":
@@ -322,6 +356,7 @@ interface TableProps {
   view: TableView;
   onView: (blockId: string, view: TableView) => void;
   onPull: (blockId: string, search: string, want: number) => void;
+  onCells: (blockId: string, cells: CellRef[]) => void;
 }
 
 /**
@@ -342,8 +377,14 @@ interface TableProps {
  * table can still page, so the blocks below it stay where they are; the page
  * that was on screen stays too, dimmed, until the next one is here. Only a first
  * draw has nothing to dim, and that is what the skeleton rows are for.
+ *
+ * A cell can be waiting on its own, and the same bar says so: a script hands a
+ * table a promise or a function where a value would go, and the row is drawn
+ * with everything it already has. A cell is asked for when it is drawn, which is
+ * what makes the second half of a five-hundred-row table cost nothing until it
+ * is looked at.
  */
-Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
+Canvas.Table = function ({ id, block, view, onView, onPull, onCells }: TableProps) {
   const shown = tableWindow(block, view);
   const controls = hasControls(block);
   const busy = useDelayed(block.loading === true, TABLE_LOADING_DELAY_MS);
@@ -363,6 +404,7 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   // prevent.
   const stale = shown.pending && shown.held.length > 0;
   const drawn = stale ? shown.held : shown.rows;
+  const drawnIndices = stale ? shown.heldIndices : shown.indices;
   const holding = busy && stale;
   const skeleton = busy && shown.pending && drawn.length === 0;
   // A search bound for the source is debounced; one that filters what is loaded
@@ -376,6 +418,19 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
   useEffect(() => {
     if (needed) onPull(id, search, want);
   }, [needed, id, search, want, onPull]);
+
+  // The cells on screen ask for themselves. The list is read through a ref and
+  // the effect keyed on what is in it, so a repaint that changes nothing about
+  // which cells are waiting doesn't ask again — and asking twice would be free
+  // anyway: a cell is started once, and the table is what knows that.
+  const waiting = pendingCells(block, drawnIndices);
+  const waitingRef = useRef(waiting);
+  waitingRef.current = waiting;
+  const waitingKey = cellsKey(waiting);
+
+  useEffect(() => {
+    if (waitingRef.current.length > 0) onCells(id, waitingRef.current);
+  }, [waitingKey, id, onCells]);
 
   return (
     <div className="overflow-hidden rounded-lg border border-border" aria-busy={busy || undefined}>
@@ -495,13 +550,15 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
                     // 26px rhythm the whole grid is read down.
                     <tr key={rowIndex} className="last:[&>td]:border-b-0">
                       {row.map((cell, cellIndex) => (
-                        <td
+                        <Canvas.TableCell
                           key={cellIndex}
-                          className={cn("h-[26px] max-w-[48ch] truncate border-b border-border/50 px-3 text-foreground", numeric[cellIndex] && "text-right")}
-                          title={cell.length > 48 ? cell : undefined}
-                        >
-                          {cell}
-                        </td>
+                          cell={cell}
+                          column={cellIndex}
+                          numeric={numeric[cellIndex]}
+                          status={cellStatus(block, drawnIndices[rowIndex], cellIndex)}
+                          expired={block.expired === true}
+                          onRetry={() => onCells(id, [{ row: drawnIndices[rowIndex], column: cellIndex, retry: true }])}
+                        />
                       ))}
                     </tr>
                   ))}
@@ -547,6 +604,73 @@ Canvas.Table = function ({ id, block, view, onView, onPull }: TableProps) {
         </div>
       )}
     </div>
+  );
+};
+
+interface TableCellProps {
+  cell: string;
+  column: number;
+  numeric: boolean;
+  // What the cell is doing instead of holding a value, if it isn't holding one.
+  status?: CellStatus;
+  expired: boolean;
+  onRetry: () => void;
+}
+
+/**
+ * One cell, in one of three states. A value is drawn as itself; a cell that
+ * isn't here yet is the same bar a skeleton row draws, so a waiting cell and a
+ * waiting page read as one thing; a cell that stopped is a dim `—` with the
+ * message on hover — a column of numbers with `429 Too Many Requests` in the
+ * middle of it stops being a column, and the width is 12ch on a good day.
+ *
+ * Two deliberate differences from the page loader. **No shimmer**: cells fill in
+ * one at a time and that is movement enough, where fifty bars pulsing on their
+ * own would be a light show. **No delay**: the bar arrives with the row rather
+ * than replacing something that was on screen, so there is nothing to flash.
+ */
+Canvas.TableCell = function ({ cell, column, numeric, status, expired, onRetry }: TableCellProps) {
+  const className = cn("h-[26px] max-w-[48ch] truncate border-b border-border/50 px-3 text-foreground", numeric && "text-right");
+
+  if (status === undefined) {
+    return (
+      <td className={className} title={cell.length > 48 ? cell : undefined}>
+        {cell}
+      </td>
+    );
+  }
+
+  if (status.error === undefined) {
+    // A run read back has lost the closure that would have filled this, which is
+    // the state the table already says: run it again to load the rest.
+    if (expired) {
+      return (
+        <td className={cn(className, "text-muted-foreground")} title="Run to load">
+          —
+        </td>
+      );
+    }
+    return (
+      <td className={className}>
+        <div className="h-2 rounded-full bg-foreground/10" style={{ width: SKELETON_WIDTHS[column % SKELETON_WIDTHS.length] }} />
+      </td>
+    );
+  }
+
+  // Asking again is only offered where it could work: a function can be called
+  // again, a promise is finished whatever it settled as.
+  const retry = status.retry === true && !expired;
+  return (
+    <td className={cn(className, "text-destructive")} title={retry ? `${status.error} · click to retry` : status.error}>
+      {retry ? (
+        <button type="button" className={cn("group/cell flex h-full w-full items-center gap-1", numeric && "justify-end")} aria-label="Retry" onClick={onRetry}>
+          <span>—</span>
+          <RotateCw size={11} className="opacity-0 transition-opacity group-hover/cell:opacity-100" />
+        </button>
+      ) : (
+        "—"
+      )}
+    </td>
   );
 };
 

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -14,7 +14,7 @@ import { JsonViewerHandle } from "./JsonViewer";
 import { RunLog } from "./RunLog";
 import { callRows, ConsoleItem, ConsoleTab, ConsoleView, defaultView, followSelection, LogFloor, printedCounts, RunGroup, RunSelection } from "./runs";
 import { runShortcutLabel } from "./RunButton";
-import { TableView } from "./tableView";
+import { CellRef, TableView } from "./tableView";
 
 export type { ConsoleItem } from "./runs";
 
@@ -44,6 +44,7 @@ interface ConsoleProps {
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
+  onTableCells: (blockId: string, cells: CellRef[]) => void;
   onClear?: () => void;
 }
 
@@ -57,7 +58,18 @@ interface ConsoleProps {
  * this is the only thing in the window that subscribes to it. A thousand calls
  * repaint the console, and nothing else.
  */
-export function Console({ fileId, reserveTrafficLights, onAnswer, onCancelAsk, onDecide, tableViews, onTableView, onTablePull, onClear }: ConsoleProps) {
+export function Console({
+  fileId,
+  reserveTrafficLights,
+  onAnswer,
+  onCancelAsk,
+  onDecide,
+  tableViews,
+  onTableView,
+  onTablePull,
+  onTableCells,
+  onClear,
+}: ConsoleProps) {
   useSyncExternalStore(
     useCallback((notify: () => void) => (fileId === undefined ? () => {} : consoles.subscribeFile(fileId, notify)), [fileId]),
     useCallback(() => consoles.fileVersion(fileId), [fileId]),
@@ -263,6 +275,7 @@ export function Console({ fileId, reserveTrafficLights, onAnswer, onCancelAsk, o
       tableViews={tableViews}
       onTableView={onTableView}
       onTablePull={onTablePull}
+      onTableCells={onTableCells}
     />
   );
 

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -23,10 +23,29 @@ export interface CodeBlock {
  * plain JSON because a block is stored as itself — the source that fills a live
  * table lives beside it, in the Kaja instance, keyed by the block's id.
  */
+/**
+ * What a cell is doing instead of holding a value. No error means it is still
+ * coming; an error means it stopped, and `retry` says whether asking again is
+ * something that could work — a function can be called again, a promise can't.
+ *
+ * Whether the work has actually *started* is not in here: that is the closure
+ * side's business, exactly as a live table's source is. A thunk nobody has
+ * reached and a promise still in flight are the same sentence to the canvas, and
+ * it is the true one — the cell isn't here yet.
+ */
+export interface CellStatus {
+  error?: string;
+  retry?: boolean;
+}
+
 export interface TableBlock {
   kind: "table";
   columns: string[];
   rows: string[][];
+  // The cells that aren't values, by row and then column. Sparse at both levels
+  // and absent from a table that has none, so a table of plain cells is stored
+  // exactly as it was before any of this existed.
+  cells?: { [row: number]: { [column: number]: CellStatus } };
   // Rows come from a source that is still open, so paging forward pulls more.
   live?: boolean;
   // A pull is in flight. The table says so; the run does not, because the run is
@@ -106,6 +125,39 @@ export interface ApproveBlock {
 export type ApproveGesture = "approved" | "all" | "rejected";
 
 export type Block = TextBlock | CodeBlock | TableBlock | AskBlock | ApproveBlock;
+
+/** What a cell is doing, or nothing at all if it is simply a value. */
+export function cellStatus(block: TableBlock, row: number, column: number): CellStatus | undefined {
+  return block.cells?.[row]?.[column];
+}
+
+/**
+ * The same map with one cell set, or cleared once its value is here. A new
+ * object at every level, on the same rule the rows follow: the canvas compares
+ * what it was handed against what it holds, and a map written in place is
+ * invisible to it. An empty map is dropped rather than kept as `{}`, so a table
+ * whose cells have all landed is stored as the plain table it has become.
+ */
+export function withCellStatus(block: TableBlock, row: number, column: number, status: CellStatus | undefined): TableBlock["cells"] {
+  const cells = { ...(block.cells ?? {}) };
+  const inRow = { ...(cells[row] ?? {}) };
+  if (status === undefined) delete inRow[column];
+  else inRow[column] = status;
+  if (Object.keys(inRow).length === 0) delete cells[row];
+  else cells[row] = inRow;
+  return Object.keys(cells).length === 0 ? undefined : cells;
+}
+
+/**
+ * …and with a whole row's cells cleared, which is what rewriting a row does: the
+ * cells that were on their way answered the row as it was.
+ */
+export function withoutRowStatus(block: TableBlock, row: number): TableBlock["cells"] {
+  if (block.cells?.[row] === undefined) return block.cells;
+  const cells = { ...block.cells };
+  delete cells[row];
+  return Object.keys(cells).length === 0 ? undefined : cells;
+}
 
 let sequence = 0;
 

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -1,9 +1,23 @@
 import { IMessageType } from "@protobuf-ts/runtime";
 import { Method, Service } from "./apps";
 import { parseInteger } from "./ask";
-import { ApproveBlock, ApproveGesture, AskBlock, Block, CodeBlock, formatCell, newBlockId, TableBlock, TextBlock } from "./blocks";
+import {
+  ApproveBlock,
+  ApproveGesture,
+  AskBlock,
+  Block,
+  CellStatus,
+  cellStatus,
+  CodeBlock,
+  formatCell,
+  newBlockId,
+  TableBlock,
+  TextBlock,
+  withCellStatus,
+  withoutRowStatus,
+} from "./blocks";
 import { LogSink } from "./scriptConsole";
-import { pageSizeOf } from "./tableView";
+import { CellRef, pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
 
 // Thrown when the user cancels a `kaja.ask*` prompt. The task runner
@@ -119,7 +133,7 @@ export interface BlockUpdate {
  * the loop to finish would make the interesting part the part you can't watch.
  */
 export interface Table {
-  row(...cells: unknown[]): Row;
+  row(...cells: Cell[]): Row;
   column(name: string): void;
   total(count: number | undefined): void;
 }
@@ -133,8 +147,19 @@ export interface Table {
  * finishes, so the table paints rather than reporting at the end.
  */
 export interface Row {
-  update(...cells: unknown[]): void;
+  update(...cells: Cell[]): void;
 }
+
+/**
+ * A cell the script has, or one it is getting. A **promise** is work already
+ * started; a **function** is work nobody has asked for yet, so the table asks —
+ * when the row is drawn, and again if you retry it. An `Error`, thrown or
+ * returned, is a cell that stopped rather than a value.
+ *
+ * It is `unknown` to TypeScript, which is what it has always been. The alias is
+ * where the rule is written down.
+ */
+export type Cell = unknown | PromiseLike<unknown> | (() => unknown);
 
 /**
  * Rows a table draws. An array is an iterable; so is an async generator, and one
@@ -155,12 +180,31 @@ export interface TableOptions {
   pageSize?: number;
 }
 
+/**
+ * A cell the table is getting rather than holding. The closure beside the
+ * block's `CellStatus`, on the same rule the source is: the block is JSON the
+ * console stores, and a function can't be.
+ */
+interface LiveCell {
+  // The work, while nobody has asked for it — a function that hasn't been
+  // called, or a failed one waiting on Retry. A promise never has one: it was
+  // already running when the script handed it over, and can't be run again.
+  open?: () => unknown;
+  running?: Promise<void>;
+  // The row's revision when this cell was declared. A row rewritten since is not
+  // the row this answers, so the answer is dropped rather than written over it.
+  revision: number;
+}
+
 // What a live table is filled from. The block is the JSON the console stores;
 // this is the closure beside it, which is why it lives on the Kaja instance —
 // that outlives any one run, and a table stays live after the script is over.
 interface LiveTable {
   block: TableBlock;
-  open: (search: string) => Rows;
+  // Absent on a table that was handed its rows outright. Such a table is held
+  // here anyway once it has a cell that isn't a value: what is kept is the
+  // closures, and a cell is one.
+  open?: (search: string) => Rows;
   iterator?: Iterator<unknown[]> | AsyncIterator<unknown[]>;
   // Whether the source can be started again. A function can be; an iterable that
   // is already running cannot, so it has neither a server search nor a retry
@@ -178,12 +222,34 @@ interface LiveTable {
   // held apart from `pulling` because it settles before that one is set, and the
   // run waits for both.
   first?: Promise<void>;
+  // The cells that aren't values, by row and then column, so rewriting a row
+  // lets go of everything that was answering it in one move.
+  cells: Map<number, Map<number, LiveCell>>;
+  // Bumped every time a row is written and never reset — a revision that started
+  // over would let a cell declared before a restart answer the row that replaced
+  // it, which is the one thing this exists to prevent.
+  revision: number;
+  rowRevision: number[];
+  // Every cell still outstanding, which is what the run waits for…
+  running: Set<Promise<void>>;
+  // …and the ones past the gate, which is what the next one waits for. Two sets
+  // rather than a count: a cell waiting for a slot is outstanding but not in
+  // flight, and racing a set that holds the waiters is a race nobody wins.
+  inFlight: Set<Promise<void>>;
 }
 
 // Live sources are closures, so they are held rather than collected. A console
 // that has drawn hundreds of tables lets the oldest go; those tables read as
 // expired, which is a state the canvas already states.
 const MAX_LIVE_TABLES = 24;
+
+/**
+ * How many of a table's cells are fetched at once. A page draw asks for every
+ * cell it can see in one go, and fifty rows must not put fifty requests on the
+ * wire in one frame — they arrive as a rolling handful instead, in the order
+ * they were declared.
+ */
+const MAX_CELLS_IN_FLIGHT = 6;
 
 /**
  * How many calls to one method a run reads remembered values out of. The
@@ -207,8 +273,18 @@ function openIterator(rows: Rows): Iterator<unknown[]> | AsyncIterator<unknown[]
 
 // A row is cells. Anything else a source yields is one cell rather than an
 // error, on the same rule formatCell follows: readable beats correct-or-nothing.
-function toCells(row: unknown): string[] {
-  return Array.isArray(row) ? row.map(formatCell) : [formatCell(row)];
+function toCells(row: unknown): unknown[] {
+  return Array.isArray(row) ? row : [row];
+}
+
+// A cell that is already running. A Call is one of these, so a method handed
+// straight to a table is a cell the table waits for.
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+}
+
+function cellFailure(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 // A row is as wide as the table. Fewer cells than columns draws blanks rather
@@ -435,6 +511,12 @@ export class Kaja {
    *   const result = await check(account);
    *   row.update(account.id, account.name, result.status);
    *
+   * A cell can be a value the script is still getting rather than one it has —
+   * a promise it already started, or a function the table calls when the row is
+   * drawn. The row appears with everything it has and that cell fills in after.
+   *
+   *   table.row(show.id, show.title, () => Ratings.GetRating({ id: show.id }));
+   *
    * The rows can also be given: an array is drawn as it is, and a source is
    * pulled a page at a time as the table is paged through.
    *
@@ -461,10 +543,21 @@ export class Kaja {
   table(columns: string[], rows?: RowSource, options?: TableOptions): Table {
     const blockId = newBlockId();
     const block: TableBlock = { kind: "table", columns: columns.map(formatCell), rows: [], pageSize: options?.pageSize };
-    let live: LiveTable | undefined;
+    const table: LiveTable = {
+      block,
+      restartable: false,
+      search: "",
+      generation: 0,
+      revision: 0,
+      rowRevision: [],
+      cells: new Map(),
+      running: new Set(),
+      inFlight: new Set(),
+    };
+    let live = false;
 
     if (Array.isArray(rows)) {
-      block.rows = rows.map((row) => padCells(toCells(row), block.columns.length));
+      block.rows = rows.map((row, index) => this.#declareRow(blockId, table, index, toCells(row)));
     } else if (rows !== undefined) {
       if (typeof rows !== "function" && !isAsyncIterable(rows) && !isIterable(rows)) {
         throw new Error("kaja.table: rows must be an array, an iterable of rows, or a function returning one");
@@ -475,12 +568,13 @@ export class Kaja {
       // source that ignores it would otherwise be restarted on every keystroke
       // to fetch the same page back.
       const restartable = typeof rows === "function";
-      const open = restartable ? rows : () => rows;
+      table.restartable = restartable;
+      table.open = restartable ? rows : () => rows;
       block.live = true;
       block.serverSearch = restartable && rows.length > 0;
       block.loadedSearch = "";
-      live = { block, open, restartable, search: "", generation: 0 };
-      this.#openTable(blockId, live);
+      live = true;
+      this.#openTable(blockId, table);
     }
 
     this.#onBlockUpdate(blockId, { ...block });
@@ -492,13 +586,13 @@ export class Kaja {
     // before any source body runs. A source reports its total through that
     // handle, from inside its own loop, and pulling here and now would run the
     // loop while the name it reaches for is still in its dead zone.
-    if (live) live.first = Promise.resolve().then(() => void this.pullTable(blockId, "", pageSizeOf(block)));
+    if (live) table.first = Promise.resolve().then(() => void this.pullTable(blockId, "", pageSizeOf(block)));
 
     // A new array each time, at both levels: the canvas compares what it was
     // handed against what it holds, and a row pushed or spliced into the same
     // array is invisible to it.
     const write = (index: number, cells: unknown[]) => {
-      const row = padCells(cells.map(formatCell), block.columns.length);
+      const row = this.#declareRow(blockId, table, index, cells);
       block.rows = block.rows.map((current, at) => (at === index ? row : current));
       this.#onBlockUpdate(blockId, { ...block });
     };
@@ -506,7 +600,7 @@ export class Kaja {
     return {
       row: (...cells: unknown[]): Row => {
         const index = block.rows.length;
-        block.rows = [...block.rows, padCells(cells.map(formatCell), block.columns.length)];
+        block.rows = [...block.rows, this.#declareRow(blockId, table, index, cells)];
         this.#onBlockUpdate(blockId, { ...block });
         return {
           update: (...cells: unknown[]) => {
@@ -552,6 +646,160 @@ export class Kaja {
   }
 
   /**
+   * Write a row's cells and take note of the ones that are not values. A
+   * **promise** is work the script already started, so the table only waits for
+   * it; a **function** is work nobody has asked for yet, so the table asks —
+   * when the row is drawn, and again if a failed one is retried. The row's
+   * revision is stamped here, and it is what an answer arriving late is checked
+   * against.
+   */
+  #declareRow(blockId: string, table: LiveTable, index: number, cells: unknown[]): string[] {
+    const block = table.block;
+    const revision = (table.rowRevision[index] = ++table.revision);
+    // Whatever was on its way answered the row as it was, which is not the row
+    // this is writing.
+    table.cells.delete(index);
+    block.cells = withoutRowStatus(block, index);
+
+    const text = cells.map((cell, column) => {
+      // Thrown or returned, an Error is a cell that stopped — a script that
+      // hands its failures back rather than throwing them is saying the same
+      // thing in the other voice. There is nothing to call again: the script had
+      // the failure, not a way to repeat it.
+      if (cell instanceof Error) {
+        block.cells = withCellStatus(block, index, column, { error: cell.message });
+        return "";
+      }
+      if (typeof cell === "function") return this.#awaitCell(blockId, table, index, column, revision, cell as () => unknown);
+      if (isThenable(cell)) return this.#awaitCell(blockId, table, index, column, revision, undefined, cell);
+      return formatCell(cell);
+    });
+    return padCells(text, block.columns.length);
+  }
+
+  // A cell that is not here yet: blank text, a status saying so, and the closure
+  // beside the block. A table with one is held for the same reason a live one
+  // is — what is kept is the closures.
+  #awaitCell(blockId: string, table: LiveTable, row: number, column: number, revision: number, open?: () => unknown, started?: PromiseLike<unknown>): string {
+    const cell: LiveCell = { revision, open };
+    const byColumn = table.cells.get(row) ?? new Map<number, LiveCell>();
+    byColumn.set(column, cell);
+    table.cells.set(row, byColumn);
+    table.block.cells = withCellStatus(table.block, row, column, {});
+    if (!this.#tables.has(blockId)) this.#openTable(blockId, table);
+
+    if (started !== undefined) {
+      cell.running = this.#hold(
+        table,
+        this.#fillCell(blockId, table, cell, row, column, () => started, false),
+      );
+    } else if (row < pageSizeOf(table.block)) {
+      // The first page is asked for with the table, on the same rule that makes
+      // a live table pull its own: a run nobody is watching still fills one.
+      this.#startCell(blockId, table, row, column);
+    }
+    return "";
+  }
+
+  /**
+   * Start a cell nobody has called yet, or hand back the run it is already in.
+   * Having work to do is what says it hasn't started — `open` is taken when a
+   * cell starts and put back only when a retryable one fails, so a cell that
+   * finished has neither work nor a way to be started twice.
+   */
+  #startCell(blockId: string, table: LiveTable, row: number, column: number): Promise<void> | undefined {
+    const cell = table.cells.get(row)?.get(column);
+    if (cell === undefined) return undefined;
+    const open = cell.open;
+    if (open === undefined) return cell.running;
+    cell.open = undefined;
+
+    if (cellStatus(table.block, row, column)?.error !== undefined) {
+      // Asking again is what clears the last failure: the cell goes back to
+      // waiting rather than reading as stopped while it is being fetched.
+      table.block.cells = withCellStatus(table.block, row, column, {});
+      this.#onBlockUpdate(blockId, { ...table.block });
+    }
+    cell.running = this.#hold(table, this.#fillCell(blockId, table, cell, row, column, open, true));
+    return cell.running;
+  }
+
+  /**
+   * Run a cell's work and write what comes back. A cell that fails writes the
+   * failure rather than throwing it: the loop that drew the row is long over,
+   * and the one place the failure belongs is the cell it happened in.
+   *
+   * `gated` is both halves of what a function is and a promise isn't — it waits
+   * for a slot before starting, and it can be started again.
+   */
+  async #fillCell(blockId: string, table: LiveTable, cell: LiveCell, row: number, column: number, work: () => unknown, gated: boolean): Promise<void> {
+    // A rolling handful rather than a page all at once. The wait is here, past
+    // the point where the cell counts as started, so a second draw of the same
+    // page doesn't queue it twice.
+    while (gated && table.inFlight.size >= MAX_CELLS_IN_FLIGHT) await Promise.race([...table.inFlight]);
+
+    const filling = (async () => {
+      try {
+        const value = await work();
+        if (value instanceof Error) throw value;
+        this.#writeCell(blockId, table, cell, row, column, formatCell(value), undefined);
+      } catch (error) {
+        // Put the work back where a retry finds it. A function can be called
+        // again; a promise is finished, whatever it settled as.
+        if (gated) cell.open = work;
+        this.#writeCell(blockId, table, cell, row, column, undefined, { error: cellFailure(error), retry: gated || undefined });
+      }
+    })();
+
+    if (gated) {
+      table.inFlight.add(filling);
+      void filling.finally(() => table.inFlight.delete(filling));
+    }
+    await filling;
+  }
+
+  #writeCell(blockId: string, table: LiveTable, cell: LiveCell, row: number, column: number, text: string | undefined, status: CellStatus | undefined): void {
+    const block = table.block;
+    // The row this answers can be gone or rewritten — a source that takes the
+    // search is restarted from the top, and a row updated asked a different
+    // question. Either way there is nothing here for the answer to land in.
+    if (table.rowRevision[row] !== cell.revision) return;
+    if (text !== undefined) {
+      block.rows = block.rows.map((current, at) => (at === row ? current.map((value, index) => (index === column ? text : value)) : current));
+    }
+    block.cells = withCellStatus(block, row, column, status);
+    this.#onBlockUpdate(blockId, { ...block });
+  }
+
+  // Everything outstanding, so the run can wait for it.
+  #hold(table: LiveTable, promise: Promise<void>): Promise<void> {
+    table.running.add(promise);
+    void promise.finally(() => table.running.delete(promise));
+    return promise;
+  }
+
+  /**
+   * Start the cells a page is drawing. Asking is what is idempotent, not the
+   * work: the canvas asks for every cell it can see on every frame, and a cell
+   * that has started, finished or stopped is not started again. A failed one is
+   * the exception it has to be — it is asked for only when someone asks.
+   *
+   * Resolves false when the table is gone, and the caller marks it expired on
+   * the same rule a pull that finds no source does.
+   */
+  async pullCells(blockId: string, cells: CellRef[]): Promise<boolean> {
+    const table = this.#tables.get(blockId);
+    if (!table) return false;
+
+    const started = cells
+      .filter((ref) => ref.retry === true || cellStatus(table.block, ref.row, ref.column)?.error === undefined)
+      .map((ref) => this.#startCell(blockId, table, ref.row, ref.column))
+      .filter((promise): promise is Promise<void> => promise !== undefined);
+    await Promise.all(started);
+    return true;
+  }
+
+  /**
    * Fill a live table up to `want` rows, restarting its source first if it takes
    * the search text and the text has changed. Rows are emitted as they arrive,
    * so a page paints while it fills. Resolves false when the source is gone —
@@ -559,7 +807,7 @@ export class Kaja {
    */
   async pullTable(blockId: string, search: string, want: number): Promise<boolean> {
     const table = this.#tables.get(blockId);
-    if (!table) return false;
+    if (!table?.open) return false;
 
     const searched = table.block.serverSearch === true && table.search !== search;
     if (searched || table.restart) {
@@ -573,6 +821,11 @@ export class Kaja {
       table.block.rows = [];
       table.block.exhausted = false;
       table.block.loadedSearch = search;
+      // The cells that were coming belonged to those rows. A revision is never
+      // reused, so the ones still in flight write nothing when they land.
+      table.cells.clear();
+      table.rowRevision = [];
+      table.block.cells = undefined;
       // A total counts a result set, and this is a different one. The source
       // reports the new one as it answers; until it does, the table says how many
       // it has and that there are more, which is what it in fact knows.
@@ -603,7 +856,7 @@ export class Kaja {
     this.#onBlockUpdate(blockId, { ...block });
 
     try {
-      if (!table.iterator) table.iterator = openIterator(table.open(table.search));
+      if (!table.iterator) table.iterator = openIterator(table.open!(table.search));
       while (block.rows.length < want) {
         const next = await table.iterator.next();
         // A restart happened while this was awaiting; its rows answer a search
@@ -613,7 +866,7 @@ export class Kaja {
           block.exhausted = true;
           break;
         }
-        block.rows = [...block.rows, padCells(toCells(next.value), block.columns.length)];
+        block.rows = [...block.rows, this.#declareRow(blockId, table, block.rows.length, toCells(next.value))];
         this.#onBlockUpdate(blockId, { ...block });
       }
     } catch (error) {
@@ -633,12 +886,13 @@ export class Kaja {
   /**
    * Resolves once no table is still filling. A script that draws a live table
    * and ends is not over until its first page has landed — those calls are the
-   * run's, and the run's duration is what they cost.
+   * run's, and the run's duration is what they cost. A cell the script handed
+   * over is the same bargain one column narrower.
    */
   async settleTables(): Promise<void> {
     for (let pass = 0; pass < 8; pass++) {
       const pulling = [...this.#tables.values()]
-        .flatMap((table) => [table.first, table.pulling])
+        .flatMap((table) => [table.first, table.pulling, ...table.running])
         .filter((promise): promise is Promise<void> => promise !== undefined);
       if (pulling.length === 0) return;
       await Promise.all(pulling);

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -76,15 +76,40 @@ export interface ListValue {
   values: Value[];
 }
 
+/**
+ * A cell a table draws. Anything is a value and is rendered as text — but a
+ * value you do not have yet is one of these two instead, and the cell draws as
+ * loading until it arrives:
+ *
+ *   () => Ratings.GetRating({ id })   a function: nothing has been called yet,
+ *                                     so it is called when the row is drawn —
+ *                                     the rows you never page to cost nothing —
+ *                                     and can be called again if it fails.
+ *   ratings.then((r) => r[id])        a promise: work already under way, which
+ *                                     the table only waits for.
+ *
+ * An Error, thrown or returned, is a cell that stopped: it draws as "—" with the
+ * message on hover, and the rest of the table carries on filling.
+ */
+export type Cell = unknown;
+
 /** A table being filled in on the run's canvas. */
 export interface Table {
   /**
-   * Append a row. It appears at once, so a loop paints as it runs. A cell can be
-   * anything; it is rendered as text. Fewer cells than there are columns leaves
-   * the rest blank, so a row can be written before the work that fills it is
-   * done — the handle it hands back is how you finish it.
+   * Append a row. It appears at once, so a loop paints as it runs. Fewer cells
+   * than there are columns leaves the rest blank, so a row can be written before
+   * the work that fills it is done — the handle it hands back is how you finish
+   * it.
+   *
+   * A cell that isn't a value yet is a promise or a function (see Cell), which
+   * is how a row is drawn from what you already have while the rest of it is
+   * fetched:
+   *
+   *   for (const show of shows) {
+   *     table.row(show.id, show.title, () => Ratings.GetRating({ id: show.id }));
+   *   }
    */
-  row(...cells: unknown[]): Row;
+  row(...cells: Cell[]): Row;
   /**
    * Add a column, once the run knows it needs one. The rows already drawn grow a
    * blank cell for it.
@@ -119,8 +144,11 @@ export interface Row {
    *
    *   const row = table.row(account.id, "checking…");
    *   row.update(account.id, await check(account));
+   *
+   * Cells that were still on their way when a row is rewritten are dropped: they
+   * answered the row as it was.
    */
-  update(...cells: unknown[]): void;
+  update(...cells: Cell[]): void;
 }
 
 /**
@@ -239,6 +267,15 @@ export declare const kaja: {
    *   }));
    *   for (const { account, row } of rows) {
    *     row.update(account.id, account.name, await check(account));
+   *   }
+   *
+   * A cell whose value comes from somewhere else can be handed over as a promise
+   * or a function instead, and draws as loading until it lands. The rows appear
+   * with everything they already have:
+   *
+   *   const ratings = Ratings.GetRatings({ ids });
+   *   for (const show of shows) {
+   *     table.row(show.id, show.title, ratings.then((r) => r.byId[show.id]));
    *   }
    *
    * The rows can be given instead — an array, or a source that yields them as

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -318,3 +318,192 @@ describe("kaja.table", () => {
     expect(only().live).toBe(true);
   });
 });
+
+// A value the script has and one it is getting are the same cell to everything
+// downstream: the row is drawn with what it already has, and the rest lands in
+// place. Which of the two it is decided by what the cell is — a promise is work
+// already started, a function is work nobody has asked for yet.
+describe("kaja.table cells", () => {
+  it("draws the row at once and fills a promise in when it lands", async () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id", "rating"]);
+    table.row(1, Promise.resolve(4.6));
+
+    expect(only().rows).toEqual([["1", ""]]);
+    expect(only().cells).toEqual({ 0: { 1: {} } });
+
+    await kaja.settleTables();
+    expect(only().rows).toEqual([["1", "4.6"]]);
+    // A table whose cells have all landed is the plain table it has become.
+    expect(only().cells).toBeUndefined();
+  });
+
+  // The run is not over until the cells it handed over are here: they are work
+  // the script started, on the same rule a live table's first page is.
+  it("waits for the cells the script handed over", async () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id"]);
+    table.row(new Promise((resolve) => setTimeout(() => resolve("late"), 5)));
+
+    await kaja.settleTables();
+    expect(only().rows).toEqual([["late"]]);
+  });
+
+  /**
+   * The whole reason a function is worth having beside a promise: it is work
+   * nobody has asked for. The first page is asked for with the table, so a run
+   * nobody is watching still fills one; everything past it costs a call only if
+   * you page to it.
+   */
+  it("calls a function when its row is drawn, and not before", async () => {
+    const { kaja, only, id } = draw();
+    const called: number[] = [];
+    const table = kaja.table(["n"], undefined, { pageSize: 2 });
+    for (const row of [0, 1, 2, 3]) {
+      table.row(() => {
+        called.push(row);
+        return `row-${row}`;
+      });
+    }
+
+    await kaja.settleTables();
+    expect(called).toEqual([0, 1]);
+    expect(only().rows).toEqual([["row-0"], ["row-1"], [""], [""]]);
+
+    // The second page is drawn: its cells ask for themselves.
+    expect(
+      await kaja.pullCells(id(), [
+        { row: 2, column: 0 },
+        { row: 3, column: 0 },
+      ]),
+    ).toBe(true);
+    expect(called).toEqual([0, 1, 2, 3]);
+    expect(only().rows).toEqual([["row-0"], ["row-1"], ["row-2"], ["row-3"]]);
+  });
+
+  // The canvas asks for every cell it can see on every frame it draws, so asking
+  // is what has to be idempotent — not the work.
+  it("starts a cell once, however often it is asked for", async () => {
+    const { kaja, id } = draw();
+    let called = 0;
+    const table = kaja.table(["n"]);
+    table.row(() => ++called);
+
+    await kaja.pullCells(id(), [{ row: 0, column: 0 }]);
+    await kaja.pullCells(id(), [{ row: 0, column: 0 }]);
+    await kaja.settleTables();
+    expect(called).toBe(1);
+  });
+
+  it("keeps a cell that stopped, and fills it when it is retried", async () => {
+    const { kaja, only, id } = draw();
+    let attempt = 0;
+    const table = kaja.table(["id", "rating"]);
+    table.row(1, () => {
+      if (attempt++ === 0) throw new Error("429 Too Many Requests");
+      return 4.1;
+    });
+    await kaja.settleTables();
+
+    expect(only().rows).toEqual([["1", ""]]);
+    expect(only().cells).toEqual({ 0: { 1: { error: "429 Too Many Requests", retry: true } } });
+
+    // Drawing it again must not retry it: that is a loop, not a retry.
+    await kaja.pullCells(id(), [{ row: 0, column: 1 }]);
+    expect(attempt).toBe(1);
+
+    await kaja.pullCells(id(), [{ row: 0, column: 1, retry: true }]);
+    await kaja.settleTables();
+    expect(only().rows).toEqual([["1", "4.1"]]);
+    expect(only().cells).toBeUndefined();
+  });
+
+  // A promise is finished, whatever it settled as. Retry is offered only where
+  // it could work.
+  it("has nothing to call again when a promise rejects", async () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["id", "rating"]);
+    table.row(1, Promise.reject(new Error("upstream is down")));
+    await kaja.settleTables();
+
+    expect(only().cells).toEqual({ 0: { 1: { error: "upstream is down" } } });
+  });
+
+  // Thrown or returned, an Error is a cell that stopped — a script that hands
+  // its failures back rather than throwing them says the same thing.
+  it("reads a returned Error as a failure", async () => {
+    const { kaja, only } = draw();
+    const table = kaja.table(["a", "b", "c"]);
+    table.row(new Error("as a value"), () => new Error("from a function"), Promise.resolve(new Error("from a promise")));
+    await kaja.settleTables();
+
+    expect(only().rows).toEqual([["", "", ""]]);
+    expect(only().cells).toEqual({
+      0: { 0: { error: "as a value" }, 1: { error: "from a function", retry: true }, 2: { error: "from a promise" } },
+    });
+  });
+
+  // A row rewritten is a different row: what was on its way answered the one
+  // that was there.
+  it("drops a cell whose row has been rewritten", async () => {
+    const { kaja, only } = draw();
+    let land: (value: string) => void = () => {};
+    const table = kaja.table(["id", "status"]);
+    const row = table.row(1, new Promise<string>((resolve) => (land = resolve)));
+
+    row.update(1, "settled");
+    expect(only().cells).toBeUndefined();
+
+    land("late");
+    await kaja.settleTables();
+    expect(only().rows).toEqual([["1", "settled"]]);
+    expect(only().cells).toBeUndefined();
+  });
+
+  // A source that takes the search is restarted from the top, and the cells of
+  // the rows it had belong to a question nobody is asking any more.
+  it("drops the cells of a source that is restarted", async () => {
+    const { kaja, only, id } = draw();
+    let land = () => {};
+    kaja.table(["n"], async function* (search: string) {
+      yield [search === "" ? new Promise<string>((resolve) => (land = () => resolve("late"))) : `${search}-1`];
+    });
+    // The rows, without waiting for the cell: settling waits for a cell the
+    // script handed over, and this one is deliberately still out there.
+    await kaja.pullTable(id(), "", 50);
+    expect(only().cells).toEqual({ 0: { 0: {} } });
+
+    await kaja.pullTable(id(), "vera", 50);
+    land();
+    await kaja.settleTables();
+
+    expect(only().rows).toEqual([["vera-1"]]);
+    expect(only().cells).toBeUndefined();
+  });
+
+  // A page draw asks for every cell it can see at once, and fifty rows must not
+  // put fifty requests on the wire in one frame.
+  it("fetches a handful of cells at a time", async () => {
+    const { kaja } = draw();
+    let running = 0;
+    let most = 0;
+    const table = kaja.table(["n"], undefined, { pageSize: 30 });
+    for (let row = 0; row < 20; row++) {
+      table.row(async () => {
+        running++;
+        most = Math.max(most, running);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        running--;
+        return row;
+      });
+    }
+    await kaja.settleTables();
+
+    expect(most).toBe(6);
+  });
+
+  it("reports a table whose cells it no longer holds", async () => {
+    const { kaja } = draw();
+    expect(await kaja.pullCells("block-gone", [{ row: 0, column: 0 }])).toBe(false);
+  });
+});

--- a/ui/src/tableView.test.ts
+++ b/ui/src/tableView.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { TableBlock } from "./blocks";
-import { bodyMinHeight, hasControls, numericColumns, pullNeeded, tableSummary, tableWindow, totalOf } from "./tableView";
+import { bodyMinHeight, cellsKey, hasControls, numericColumns, pendingCells, pullNeeded, tableSummary, tableWindow, totalOf } from "./tableView";
 
 function table(rows: number, extra: Partial<TableBlock> = {}): TableBlock {
   return {
@@ -20,6 +20,26 @@ describe("tableWindow", () => {
     expect(shown.rows[0][0]).toBe("10");
     expect([shown.from, shown.to, shown.total]).toEqual([11, 20, 25]);
     expect([shown.hasPrevious, shown.hasNext]).toEqual([true, true]);
+  });
+
+  // A cell is addressed by where its row sits in the table, which is arithmetic
+  // until a local filter takes rows out of the middle.
+  it("says where the drawn rows sit in the table", () => {
+    expect(tableWindow(table(25), { page: 1, search: "" }).indices).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+
+    const filtered = tableWindow(table(25), { page: 0, search: "show 2" });
+    expect(filtered.rows.map((row) => row[0])).toEqual(["2", "20", "21", "22", "23", "24"]);
+    expect(filtered.indices).toEqual([2, 20, 21, 22, 23, 24]);
+  });
+
+  // The page held on screen while the next one is fetched is drawn from the same
+  // cells as any other page, so it is addressed the same way.
+  it("says where the page it is holding sits too", () => {
+    const shown = tableWindow(table(10, { live: true }), { page: 1, search: "" });
+
+    expect(shown.held).toHaveLength(10);
+    expect(shown.heldIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(tableWindow(table(25), { page: 1, search: "" }).heldIndices).toEqual([]);
   });
 
   it("has no next page on the last page of a static table", () => {
@@ -226,6 +246,37 @@ describe("hasControls", () => {
   it("is true for a table that can still grow, or could have", () => {
     expect(hasControls(table(3, { live: true }))).toBe(true);
     expect(hasControls(table(3, { expired: true }))).toBe(true);
+  });
+});
+
+describe("pendingCells", () => {
+  const waiting = { 1: { 1: {} }, 12: { 0: {}, 1: { error: "429 Too Many Requests", retry: true } } };
+
+  // A cell is asked for when it is drawn: the rows you never page to cost
+  // nothing, which is the whole reason a cell can be a function.
+  it("asks for the cells of the rows being drawn, and no others", () => {
+    const block = table(25, { cells: waiting });
+
+    expect(pendingCells(block, tableWindow(block, { page: 0, search: "" }).indices)).toEqual([{ row: 1, column: 1 }]);
+    expect(pendingCells(block, tableWindow(block, { page: 1, search: "" }).indices)).toEqual([{ row: 12, column: 0 }]);
+  });
+
+  // The canvas draws a failed cell on every frame, so asking on sight would be a
+  // loop rather than a retry. It is asked for when someone asks.
+  it("never asks again for a cell that stopped", () => {
+    expect(pendingCells(table(25, { cells: waiting }), [12]).map((cell) => cell.column)).toEqual([0]);
+  });
+
+  // A run read back has lost the closures, which is a state the table already
+  // says rather than a row of bars that will never fill.
+  it("asks nothing of a table whose source is gone", () => {
+    expect(pendingCells(table(25, { cells: waiting, expired: true }), [1, 12])).toEqual([]);
+    expect(pendingCells(table(25), [1, 12])).toEqual([]);
+  });
+
+  it("keys a set of cells by what is in it", () => {
+    expect(cellsKey(pendingCells(table(25, { cells: waiting }), [1, 12]))).toBe("1:1,12:0");
+    expect(cellsKey([])).toBe("");
   });
 });
 

--- a/ui/src/tableView.ts
+++ b/ui/src/tableView.ts
@@ -78,6 +78,10 @@ export function totalOf(block: TableBlock): TableTotal {
 export interface TableWindow {
   // The rows to draw, and where they sit in what the table has.
   rows: string[][];
+  // Where each drawn row sits in `block.rows`, which is what a cell that isn't
+  // here yet is addressed by. Arithmetic but for a local filter, which is
+  // exactly what makes it worth carrying rather than recomputing.
+  indices: number[];
   page: number;
   from: number;
   to: number;
@@ -97,6 +101,7 @@ export interface TableWindow {
   // dimmed rather than thrown away. Empty when there is nothing to hold — the
   // first draw of a table, or a source restarted by a search.
   held: string[][];
+  heldIndices: number[];
   // How many rows this page holds once it is here. A total the source reported
   // is what makes a short last page reserve the room it will actually take.
   expected: number;
@@ -109,7 +114,10 @@ export interface TableWindow {
 export function tableWindow(block: TableBlock, view: TableView): TableWindow {
   const size = pageSizeOf(block);
   const filtered = searchesLocally(block) && view.search.trim() !== "";
-  const rows = filtered ? block.rows.filter((row) => matchesSearch(row, view.search)) : block.rows;
+  // A filter keeps the rows it matched *and* where they came from: a cell is
+  // addressed by its place in the table, not by where it landed on the page.
+  const matched = filtered ? block.rows.flatMap((row, index) => (matchesSearch(row, view.search) ? [index] : [])) : undefined;
+  const rows = matched ? matched.map((index) => block.rows[index]) : block.rows;
   // The last page of what is loaded — plus one while the source is open, since
   // paging into rows that aren't here yet is exactly how they are asked for.
   const loadedPages = Math.max(0, Math.ceil(rows.length / size) - 1);
@@ -128,8 +136,12 @@ export function tableWindow(block: TableBlock, view: TableView): TableWindow {
   // zero and back on every click.
   const to = pending ? start + expected : start + shown.length;
 
+  const at = (from: number, count: number) => (matched ? matched.slice(from, from + count) : Array.from({ length: count }, (_, offset) => from + offset));
+  const held = pending && page > 0 ? rows.slice(start - size, start) : [];
+
   return {
     rows: shown,
+    indices: at(start, shown.length),
     page,
     from: to === 0 ? 0 : start + 1,
     to,
@@ -137,7 +149,8 @@ export function tableWindow(block: TableBlock, view: TableView): TableWindow {
     loaded: block.rows.length,
     filtered,
     pending,
-    held: pending && page > 0 ? rows.slice(start - size, start) : [],
+    held,
+    heldIndices: at(start - size, held.length),
     expected,
     hasPrevious: page > 0,
     // No lookahead: pulling one row past the page to light the button up would
@@ -183,6 +196,41 @@ export function pullNeeded(block: TableBlock, view: TableView): { needed: boolea
   // Searching what is loaded must not pull an API dry to find three rows.
   if (searchesLocally(block) && view.search.trim() !== "") return { needed: false, want };
   return { needed: canGrow(block) && block.rows.length < want, want };
+}
+
+/** One cell of one row, which is what a cell that isn't here yet is asked for by. */
+export interface CellRef {
+  row: number;
+  column: number;
+  // Ask again for a cell that stopped. The canvas draws a failed cell on every
+  // frame, so retrying on sight would be a loop rather than a retry — this is
+  // the click and nothing else.
+  retry?: boolean;
+}
+
+/**
+ * Which cells the drawn rows are waiting for. A cell is asked for when it is
+ * drawn, so a table of five hundred rows costs five hundred calls only if you
+ * page through all of it — the same bargain the pager makes for the rows
+ * themselves. Asking for one already running is free: the table starts a cell
+ * once, and knows which ones it has started.
+ */
+export function pendingCells(block: TableBlock, indices: number[]): CellRef[] {
+  // A source that is gone took its cells with it, and what is left is a state
+  // the table already says: run it again to load the rest.
+  if (block.cells === undefined || block.expired === true) return [];
+  const refs: CellRef[] = [];
+  for (const row of indices) {
+    for (const [column, status] of Object.entries(block.cells[row] ?? {})) {
+      if (status.error === undefined) refs.push({ row, column: Number(column) });
+    }
+  }
+  return refs;
+}
+
+/** What identifies a set of cells to an effect that must not fire twice for it. */
+export function cellsKey(cells: CellRef[]): string {
+  return cells.map(({ row, column }) => `${row}:${column}`).join(",");
 }
 
 /**


### PR DESCRIPTION
A table cell can now be a promise or a function rather than a value, so a row is drawn with everything the script already has and the cells that come from a second call fill in after it. A cell that fails draws as `—` with the message on hover, and offers Retry where calling again could work.

```ts
for (const show of shows) {
  table.row(show.id, show.title, () => Ratings.GetRating({ id: show.id }));
}
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01XA9VmZPZGxJFwQ8U13sPvT)_