### PR TITLE
Made the chrome hold together on a phone

### DIFF
--- a/ui/src/AppForm.tsx
+++ b/ui/src/AppForm.tsx
@@ -16,6 +16,7 @@ import { VariableSuggestInput } from "./VariableSuggestInput";
 import { ConfigurationApp } from "./server/api";
 import { OpenDirectoryDialog, OpenFileDialog } from "./wailsjs/go/main/App";
 import { formatJson } from "./formatter";
+import { codeFontSize } from "./monacoTheme";
 import { APP_CONFIG_JSON_URI } from "./jsonSchemas";
 import { getVariables } from "./variableExpansion";
 import { isWailsEnvironment } from "./wails";
@@ -301,6 +302,7 @@ export function AppForm({ mode, initialData, allApps, variables, readOnly = fals
         editorRef.current = monaco.editor.create(editorContainerRef.current, {
           model: monacoModelRef.current,
           automaticLayout: true,
+          fontSize: codeFontSize(),
           padding: { top: 16, bottom: 16 },
           minimap: { enabled: false },
           renderLineHighlight: "none",

--- a/ui/src/CommandRow.tsx
+++ b/ui/src/CommandRow.tsx
@@ -28,15 +28,24 @@ interface CommandRowProps {
 // the file's own save/discard · spacer · action · hairline · search · layout.
 // Nothing else may be added to it — new controls go in the sidebar header or the
 // console header.
+//
+// As the row narrows, things leave in order of what they are worth, the way the
+// console header's do: the keyboard hint on Run first (there is no keyboard on
+// the screen this narrows for), then the search icon, whose verb the trigger
+// beside it already carries. The finder truncates through all of it, because
+// with the sidebar collapsed it is the only thing saying where you are.
 export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finder, fileActions, action, onSearch, layout, onToggleLayout }: CommandRowProps) {
   const modifier = navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+";
 
   return (
     <div
-      className="flex h-[40px] shrink-0 items-center gap-2 border-b border-border bg-chrome px-3"
+      className="@container flex h-[40px] shrink-0 items-center gap-2 border-b border-border bg-chrome px-3"
       style={{ paddingLeft: leftInset, "--wails-draggable": "drag" } as React.CSSProperties}
     >
-      <div className="flex min-w-0 items-center gap-2" style={{ "--wails-draggable": "no-drag" } as React.CSSProperties}>
+      {/* The left side is what may shrink, and the finder inside it is what
+          truncates: the right side is buttons, and a button that has given up
+          room is a button drawn over its neighbour. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2" style={{ "--wails-draggable": "no-drag" } as React.CSSProperties}>
         <SimpleTooltip text={sidebarCollapsed ? `Show sidebar (${modifier}B)` : `Hide sidebar (${modifier}B)`} side="bottom">
           <IconButton
             icon={sidebarCollapsed ? PanelLeftOpen : PanelLeftClose}
@@ -44,19 +53,28 @@ export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finde
             onClick={onToggleSidebar}
             size="sm"
             variant="ghost"
-            className="size-[26px]"
+            className="size-[26px] shrink-0"
             tooltip={false}
           />
         </SimpleTooltip>
         {finder}
         {fileActions}
       </div>
-      <div className="flex-1" />
       <div className="flex shrink-0 items-center gap-2" style={{ "--wails-draggable": "no-drag" } as React.CSSProperties}>
         {action}
         {action && <Hairline />}
+        {/* The trigger beside it opens the same finder, so on a row this narrow
+            the icon is the one thing here that says nothing new. */}
         <SimpleTooltip text={`Find a file (${modifier}K)`} side="bottom">
-          <IconButton icon={Search} aria-label="Find a file" onClick={onSearch} size="sm" variant="ghost" className="size-[26px]" tooltip={false} />
+          <IconButton
+            icon={Search}
+            aria-label="Find a file"
+            onClick={onSearch}
+            size="sm"
+            variant="ghost"
+            className="size-[26px] @max-[380px]:hidden"
+            tooltip={false}
+          />
         </SimpleTooltip>
         <SimpleTooltip text={layout === "vertical" ? "Side-by-side layout" : "Top-bottom layout"} side="bottom">
           <IconButton

--- a/ui/src/CompileStatus.tsx
+++ b/ui/src/CompileStatus.tsx
@@ -36,10 +36,10 @@ const stateClass: Record<CompileState, string> = {
 };
 
 function StateIcon({ state }: { state: CompileState }) {
-  if (state === "loading" || state === "compiling") return <Spinner size="sm" className="size-[14px] text-current" />;
-  if (state === "failed") return <CircleX size={ICON_SIZE} />;
-  if (state === "warning") return <TriangleAlert size={ICON_SIZE} />;
-  return <Check size={ICON_SIZE} />;
+  if (state === "loading" || state === "compiling") return <Spinner size="sm" className="size-[14px] shrink-0 text-current" />;
+  if (state === "failed") return <CircleX size={ICON_SIZE} className="shrink-0" />;
+  if (state === "warning") return <TriangleAlert size={ICON_SIZE} className="shrink-0" />;
+  return <Check size={ICON_SIZE} className="shrink-0" />;
 }
 
 // AppRow is the app as the popover states it: what it is, where it points, and
@@ -157,12 +157,16 @@ export function CompileStatus({ apps, configurationLoaded, onShowLog, onRecompil
           type="button"
           aria-label={`${label}, open app status`}
           className={cn(
-            "flex h-6 items-center gap-1.5 rounded px-1.5 text-xs transition-colors hover:bg-accent",
+            "flex h-6 min-w-0 items-center gap-1.5 rounded px-1.5 text-xs transition-colors hover:bg-accent",
             settled ? "text-emerald-600 dark:text-emerald-400" : stateClass[summary.state],
           )}
         >
           <StateIcon state={settled ? "ready" : summary.state} />
-          <span aria-live="polite">{label}</span>
+          {/* Truncates rather than wraps: the bar is 30px, so a second line is
+              drawn under the bottom of the window. */}
+          <span aria-live="polite" className="truncate">
+            {label}
+          </span>
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" side="top" className="w-[360px] p-1">

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -5,6 +5,7 @@ import { formatTypeScript, formatTypeScriptWithCursor } from "./formatter";
 import { findTimestamps, timestampToDate, formatDateForDisplay } from "./timestampPicker";
 import { TimestampPickerContentWidget } from "./TimestampPickerWidget";
 import { kajaModuleDeclaration } from "./kajaModule";
+import { codeFontSize } from "./monacoTheme";
 import { suggestValues } from "./valueCompletions";
 
 self.MonacoEnvironment = {
@@ -294,6 +295,7 @@ export function Editor({ model, onMount, onGoToDefinition, readOnly = false, sta
         model,
         language: "typescript",
         automaticLayout: true,
+        fontSize: codeFontSize(),
         padding: {
           top: 16,
           bottom: 16,

--- a/ui/src/Finder.tsx
+++ b/ui/src/Finder.tsx
@@ -115,7 +115,10 @@ export function Finder({ recent, elsewhere, errorCount, open, onOpenChange, high
           aria-controls="finder"
           aria-label={current ? `${current.name} — go to another file` : "Go to a file"}
           className={cn(
-            "relative flex h-[26px] shrink-0 items-center gap-2 rounded-md border bg-card px-2.5 hover:bg-accent",
+            // It gives up room before anything else in the row does — a label
+            // that truncates is read; a button that shrinks is one drawn over
+            // the button next to it.
+            "relative flex h-[26px] min-w-0 items-center gap-2 rounded-md border bg-card px-2.5 hover:bg-accent",
             open && "bg-accent",
             errorCount > 0 ? "border-destructive" : "border-border",
           )}
@@ -260,7 +263,14 @@ function TriggerContent({ destination, errorCount }: { destination?: Destination
       >
         {destination.name}
       </span>
-      {qualifier && !dropLabel && <span className={cn("shrink-0 text-xs", errorCount > 0 ? "text-destructive" : "text-muted-foreground")}>{qualifier}</span>}
+      {/* The probe drops it when the name alone fills the trigger; the container
+          query drops it when the row is too narrow for the trigger to be that
+          wide in the first place, which the probe measures nothing about. Either
+          way the qualifier goes before the name truncates — a name cut to its
+          last letter says less than no qualifier does. */}
+      {qualifier && !dropLabel && (
+        <span className={cn("shrink-0 text-xs @max-[340px]:hidden", errorCount > 0 ? "text-destructive" : "text-muted-foreground")}>{qualifier}</span>
+      )}
     </>
   );
 }

--- a/ui/src/JsonViewer.tsx
+++ b/ui/src/JsonViewer.tsx
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
-import "./monacoTheme";
+import { codeFontSize } from "./monacoTheme";
 import { drawnText, printJson } from "./payloadText";
 
 // A private language rather than the built-in "json" one: that language is wired
@@ -70,6 +70,7 @@ export const JsonViewer = forwardRef<JsonViewerHandle, JsonViewerProps>(function
       value: jsonTextRef.current,
       language: LANGUAGE_ID,
       automaticLayout: true,
+      fontSize: codeFontSize(),
       // Read-only configuration
       readOnly: true,
       domReadOnly: true,

--- a/ui/src/RunButton.tsx
+++ b/ui/src/RunButton.tsx
@@ -41,7 +41,9 @@ export function RunButton({ onRun, onStop, running, startedAt, error }: RunButto
       {running ? (
         <span className="font-mono text-xs tabular-nums text-muted-foreground">{(elapsedMs / 1000).toFixed(1)}s</span>
       ) : (
-        !disabled && <span className="font-mono text-xs opacity-70">{runShortcutLabel}</span>
+        // The hint is the first thing to go as the command row narrows: the
+        // screens that narrow it that far have no keyboard to press.
+        !disabled && <span className="font-mono text-xs opacity-70 @max-[380px]:hidden">{runShortcutLabel}</span>
       )}
     </button>
   );

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -31,6 +31,7 @@ import { isUntouched, Scratch } from "./scratches";
 import { titleParts } from "./scratchTitle";
 import { appWarnings, firstErrorMessage } from "./compileSummary";
 import { getPersistedValue, setPersistedValue } from "./storage";
+import { useMediaQuery } from "./useMediaQuery";
 import {
   appNodeId,
   Fold,
@@ -251,6 +252,11 @@ export function Sidebar({
   const [scratchMenu, setScratchMenu] = useState<{ scratch: Scratch; top: number; left: number } | null>(null);
   const scratchMenuAnchorRef = useRef<HTMLDivElement>(null);
   const [hoveredScratch, setHoveredScratch] = useState<string | null>(null);
+  // A row's verbs are revealed by the cursor, and a finger has none: on a touch
+  // screen there is no hover to wait for and no right-click behind it either, so
+  // the row simply carries them. Nothing moves under the pointer that way —
+  // there is no pointer.
+  const touch = useMediaQuery("(hover: none)");
 
   useEffect(() => {
     setPersistedValue("scriptsExpanded", scriptsExpanded);
@@ -424,7 +430,7 @@ export function Sidebar({
             {scriptsExpanded && (
               <TreeView leaf aria-label="Scripts">
                 {(scripts ?? []).map((script) => {
-                  const active = (hoveredScript === script.path || scriptMenu?.script.path === script.path) && hasScriptMenu;
+                  const active = (touch || hoveredScript === script.path || scriptMenu?.script.path === script.path) && hasScriptMenu;
                   return (
                     <TreeView.Item
                       id={`script-${script.path}`}
@@ -478,7 +484,7 @@ export function Sidebar({
                   );
                 })}
                 {(scratches ?? []).slice(0, RECENT_SCRATCHES).map((scratch) => {
-                  const active = hoveredScratch === scratch.id || scratchMenu?.scratch.id === scratch.id;
+                  const active = touch || hoveredScratch === scratch.id || scratchMenu?.scratch.id === scratch.id;
                   return (
                     <TreeView.Item
                       id={`scratch-${scratch.id}`}
@@ -559,6 +565,8 @@ export function Sidebar({
           const treeApp = treeApps[appIndex];
           const appId = appNodeId(appName);
           const isExpanded = isOpen(folds, appId);
+          // The row's own highlight stays the cursor's; only the verb on it is
+          // unconditional where there is no cursor to reveal it with.
           const active = hoveredApp === appName || appMenu?.appName === appName;
 
           return (
@@ -588,7 +596,7 @@ export function Sidebar({
                 <span className="truncate">{appName}</span>
                 <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
                 <span className="ml-auto flex w-6 shrink-0 items-center justify-center">
-                  {active && (
+                  {(touch || active) && (
                     <RowAction icon={Ellipsis} label={`Actions for ${appName}`} onClick={(e) => setAppMenu({ appName, top: e.clientY, left: e.clientX })} />
                   )}
                 </span>
@@ -637,7 +645,7 @@ export function Sidebar({
                                       {/* Adding a call to the scratch you already have open is
                                           deliberate, so it gets its own target rather than
                                           happening because you clicked in the wrong mood. */}
-                                      {hoveredMethod === mId && (
+                                      {(touch || hoveredMethod === mId) && (
                                         <RowAction
                                           icon={PlusIcon}
                                           label={`Add ${method.name} to the open scratch`}

--- a/ui/src/StatusBar.tsx
+++ b/ui/src/StatusBar.tsx
@@ -271,17 +271,21 @@ export function StatusBar({
 
   // The right padding is 11, not 12: these glyphs are smaller than the rest of the
   // chrome's, so they need one pixel less to land on the same 16px right line.
+  //
+  // sticky left keeps the bar where the window is on a screen too narrow to hold
+  // the panes side by side: the app pans horizontally there, and a footer that
+  // pans with it takes its own buttons off the screen.
   return (
-    <div className="flex h-[30px] shrink-0 items-center border-t border-border bg-chrome pl-3 pr-[11px]">
-      <div className="flex items-center gap-2">
+    <div className="sticky left-0 flex h-[30px] shrink-0 items-center border-t border-border bg-chrome pl-3 pr-[11px]">
+      <div className="flex min-w-0 items-center gap-2">
         {leftItems.map((item, index) => (
           <Fragment key={index}>
-            {index > 0 && <div className="h-3 w-px bg-border" />}
+            {index > 0 && <div className="h-3 w-px shrink-0 bg-border" />}
             {item}
           </Fragment>
         ))}
       </div>
-      <div className="ml-auto flex items-center gap-3">
+      <div className="ml-auto flex shrink-0 items-center gap-3 pl-2">
         {mcpInfo?.enabled && mcpInfo.url && <MCPStatus info={mcpInfo} active={mcpActive} />}
         {mcpInfo?.error && <MCPError message={mcpInfo.error} />}
         <IconButton size="xs" variant="ghost" icon={MessagesSquare} aria-label="Feedback" onClick={openFeedback} className={statusBarIconClass} />

--- a/ui/src/Variables.tsx
+++ b/ui/src/Variables.tsx
@@ -12,6 +12,7 @@ import { IconButton } from "./components/icon-button";
 import { Input } from "./components/input";
 import { SimpleTooltip } from "./components/tooltip";
 import { formatJson } from "./formatter";
+import { codeFontSize } from "./monacoTheme";
 import { VARIABLES_JSON_URI } from "./jsonSchemas";
 import { VariableSource, VariableStatus } from "./server/api";
 import { SECRET_SOURCE, VariableKind, environmentReferences, storedEnvName, variableKind, variableNameError, variableValueError } from "./variableExpansion";
@@ -268,6 +269,7 @@ export function Variables({
     editorRef.current = monaco.editor.create(editorContainerRef.current, {
       model: modelRef.current,
       automaticLayout: true,
+      fontSize: codeFontSize(),
       padding: { top: 12, bottom: 12 },
       minimap: { enabled: false },
       lineNumbers: "off",

--- a/ui/src/monacoTheme.ts
+++ b/ui/src/monacoTheme.ts
@@ -104,3 +104,16 @@ export function monacoTheme(colorMode: ColorMode): string {
 export function surfaceColor(colorMode: ColorMode): string {
   return surfaces[colorMode].background;
 }
+
+/**
+ * How big the code is. Monaco's own default everywhere there is a pointer, and
+ * 16px where there is a finger — iOS zooms the page in when a field under 16px
+ * takes focus and never zooms back out, so tapping into the code would leave the
+ * window narrower than the layout, which is what a phone reads as the chrome
+ * overlapping itself. Monaco copies this onto its hidden input, which is the
+ * field iOS is actually deciding about, so it is set here rather than fought
+ * with a stylesheet.
+ */
+export function codeFontSize(): number | undefined {
+  return typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches ? 16 : undefined;
+}

--- a/ui/src/tailwind.css
+++ b/ui/src/tailwind.css
@@ -155,4 +155,18 @@
     background-color: var(--background);
     color: var(--foreground);
   }
+
+  /* iOS zooms the page in when a field smaller than 16px takes focus, and never
+     zooms back out — the window is then narrower than the layout, which is what
+     a phone reads as the chrome overlapping itself. So on a touch screen a
+     field is 16px; the density that costs is a density no finger wanted. The
+     editor's hidden input is the same field to iOS and is set the same way, in
+     Monaco's own options (see codeFontSize). */
+  @media (pointer: coarse) {
+    input:not([type="checkbox"]):not([type="radio"]),
+    textarea,
+    select {
+      font-size: 16px;
+    }
+  }
 }


### PR DESCRIPTION
Fixed Run being drawn on top of the finder trigger on a narrow window, and the status bar wrapping a line off the bottom and panning its buttons off the screen. Fields and the editor go to 16px on a touch screen so iOS stops zooming in on focus, and a row's verbs are drawn where there is no hover to reveal them with.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUhgqcxrAtJRLWavwBg1y3)_