### PR TITLE
Made concurrent runs isolated from one another

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,42 @@ service*), and it never ran again: whatever you got on day one you kept forever.
 with everything it produced under it. One script can make three calls, and three
 unrelated rows say nothing about the thing you actually pressed.
 
+**And there is more than one run at a time, because there is nothing to stop
+there being.** ⌘⏎ twice, Run on a second file, a `kaja://` link arriving while a
+script is going, an agent calling `run_script` — none of them asks what else is
+running. So the run is **lexical, not ambient**: `beginRun` mints the run *and*
+the `Kaja` its script is handed (`KajaHost.run`, `RunContext`), and every callback
+that run will ever fire is a closure over it. There is no "current run" to read,
+so there is nothing to read wrongly. Everything that used to stand in for one is
+gone — `currentRunRef`, `openRun`, `pullRunRef`, `Client.kaja`, and the MCP
+collectors; the abort signal, the standing approvals and `kaja.input` are fields
+of one run's `Kaja` rather than of the app's. A client is shared by every run
+that imports it, so its methods are **bound per run** (`Client.methodsFor(kaja)`,
+memoized in a `WeakMap`) rather than pointed at whichever run assigned itself
+last. That single assignment was what made two scripts report their calls into
+each other's console, and made one script's `kaja.approve("every CreateShow")`
+send another script's writes without asking.
+
+- **What belongs to the app rather than to a run lives on `KajaHost`**: the
+  workspace's variables, and `LiveTables`. Both are shared on purpose —
+  `kaja.variables` is the same for a run in flight and one started after it, and
+  `MAX_LIVE_TABLES` is a budget for the app, not one each run gets its own copy
+  of.
+- **A page fetched from a canvas belongs to the run that drew the table**, which
+  is now structural rather than arranged: the host routes a block id to its
+  owning `Kaja` and the calls land in that run's log however long ago it ended.
+  `settleTables` waits for that run's tables alone, so one script's duration
+  can't cover another's work.
+- **A run's context lives exactly as long as something can call into it.**
+  `settleIfQuiet` asks every run in flight — they finish in whatever order their
+  work does, and the second one pressed is routinely the first one over — and
+  dropping the settled record releases that run's `Kaja`, its approvals, its
+  sampled methods and its bound clients. The one thing that can hold it past
+  that is a live table the canvas can still page, and that registry is bounded.
+- **Stop is about one run**: it aborts the runs of the file the button is on and
+  cancels only the questions those runs are parked on. Cancelling every prompt
+  on screen was how one Stop used to end a script nobody had pointed at.
+
 **And a run has two views of that, because they want opposite things.** The
 **log** is the flat audit log — one row per call, in wall order, always
 complete; that is what makes it scannable at two hundred rows and lets every row

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,7 +22,7 @@ import { Destination, Finder } from "./Finder";
 import { Splitter } from "./Splitter";
 import { answerPlaceholder, answerProblem, normalizeAnswer } from "./ask";
 import { ApproveBlock, ApproveGesture, AskBlock, Block, blockLabel, CellStatus, TableBlock } from "./blocks";
-import { ApprovalRejectedError, ApproveDecision, AskCancelledError, Kaja, MethodCall } from "./kaja";
+import { ApprovalRejectedError, ApproveDecision, AskCancelledError, Kaja, KajaHost, MethodCall } from "./kaja";
 import { CellRef, TableView } from "./tableView";
 import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, Service, updateAppRef } from "./apps";
@@ -155,6 +155,31 @@ function applyAppRename(app: AppModel, newConfig: ConfigurationApp): AppModel {
   };
 }
 
+/**
+ * A run in flight, and the `Kaja` its script is running against. The two are
+ * made together and let go together: once a run has settled and nothing it
+ * started is still in the air, dropping this record is what releases the run's
+ * approvals, its sampled methods, its bound clients and its console closures.
+ * The only thing that can hold the `Kaja` past that is a live table the canvas
+ * can still page, and that registry is bounded at MAX_LIVE_TABLES — so a run's
+ * context lives exactly as long as something can call into it.
+ */
+interface LiveRun {
+  run: Run;
+  kaja: Kaja;
+  controller?: AbortController;
+  // The script itself has returned. Its calls may still be landing.
+  settled: boolean;
+}
+
+// Where a run being watched over MCP collects what it did, so the report is
+// built from this run's own calls and blocks rather than from whatever was in
+// flight when it finished.
+interface RunCollector {
+  calls: MethodCall[];
+  blocks: Map<string, Block>;
+}
+
 export function App() {
   const [configuration, setConfiguration] = useState<Configuration>();
   // The running kaja, as opposed to the workspace it serves. It arrives alongside
@@ -212,10 +237,6 @@ export function App() {
    * Only the console subscribes to it, and only on the frame.
    */
   useSyncExternalStore(subscribeConsoleFlags, consoleFlagsVersion);
-  // The run calls are being attributed to. Cleared once the run settles, so a
-  // stray call afterwards starts one of its own rather than joining a run that
-  // is over.
-  const currentRunRef = useRef<Run | null>(null);
   // Whether the finder is open, and where it opened: ⌘P lands on the previous
   // file so ⌘P⏎ goes back, a click on the trigger on the first row.
   const [finder, setFinder] = useState<"first" | "previous">();
@@ -241,12 +262,6 @@ export function App() {
   // Whether an agent is using the server right now, which the footer's plug
   // shows. It outlives the request that set it (see MCP_ACTIVITY_LINGER_MS).
   const [mcpActive, setMcpActive] = useState(false);
-  // While an MCP run_script call is in flight, the method calls it makes are
-  // collected here so they can be returned to the agent.
-  const mcpRunCollectorRef = useRef<MethodCall[] | null>(null);
-  // And what it drew, keyed by block id — a table arrives once per row, so the
-  // last state of each block is what the agent is told about.
-  const mcpBlockCollectorRef = useRef<Map<string, Block> | null>(null);
   const appsRef = useRef(apps);
   appsRef.current = apps;
   const [fileError, setFileError] = useState<string | undefined>();
@@ -293,12 +308,20 @@ export function App() {
   const [bulkScratches, setBulkScratches] = useState<{ verb: "save" | "discard"; scratches: Scratch[] } | null>(null);
   // A `kaja://run/…` link that arrived and is waiting to be let through.
   const [linkPrompt, setLinkPrompt] = useState<{ script: Script; input: { [key: string]: string } } | null>(null);
-  // The run in flight, if any: which view issued it, when it started, and the
-  // controller its Stop button aborts. `settled` marks the script itself as
-  // finished — the run is only over once its calls have landed too.
-  const [activeRun, setActiveRun] = useState<{ runId: string; fileId?: string; startedAt: number; controller?: AbortController; settled: boolean } | null>(
-    null,
-  );
+  /**
+   * The runs in flight. There is more than one because there is nothing to stop
+   * there being: ⌘⏎ twice, Run on a second file, a `kaja://` link arriving while
+   * a script is going, an agent calling `run_script` — all of them start a run
+   * without asking what else is going. So a run is a member of a list rather
+   * than the contents of a slot, and each carries the `Kaja` its script is
+   * running against, which is what keeps two of them from meeting.
+   *
+   * `settled` marks the script itself as finished — the run is only over once
+   * its calls have landed too, which is what `settleIfQuiet` waits for.
+   */
+  const [activeRuns, setActiveRuns] = useState<LiveRun[]>([]);
+  const activeRunsRef = useRef(activeRuns);
+  activeRunsRef.current = activeRuns;
   // A discarded scratch, held long enough to take it back. Nothing was on disk,
   // so discarding is undoable rather than confirmed.
   const [discarded, setDiscarded] = useState<{ scratch: Scratch; runs?: FileConsole } | null>(null);
@@ -397,135 +420,18 @@ export function App() {
     [disposeView, persistViews],
   );
 
-  // One press of Run opens a run; everything the script does lands under it, in
-  // the console of the file it was pressed on. Nothing else creates one, except
-  // a call that arrives with no run open — which gets a run of its own rather
-  // than joining one that is over, under the file the last run came from.
-  const lastRunFileIdRef = useRef<string | undefined>(undefined);
-  const beginRun = useCallback((title: string, fileId?: string, controller?: AbortController, of?: Pick<Run, "origin">): Run => {
-    const run: Run = { id: newRunId(), title, fileId, startedAt: Date.now(), ...of };
-    currentRunRef.current = run;
-    if (fileId) lastRunFileIdRef.current = fileId;
-    consoles.startRun(run, run.startedAt);
-    setActiveRun({ runId: run.id, fileId, startedAt: run.startedAt, controller, settled: false });
-    return run;
-  }, []);
-
-  const beginRunRef = useRef(beginRun);
-  beginRunRef.current = beginRun;
-
-  // A call arriving with no run open gets one, under the file the last run came
-  // from — that is where a late call almost certainly belongs. A run with no
-  // file at all (an agent running code that was never saved) has no console to
-  // land in and is not kept; the agent still gets its results.
-  const openRun = useCallback(
-    (title: string): Run => {
-      const current = currentRunRef.current;
-      if (current) return current;
-      // Paging a live table fetches after its run is over, and those rows belong
-      // to the run whose canvas asked for them rather than to a run of their own.
-      // A script running at the same time outranks it: that one is definitely
-      // making the call being reported.
-      const pulling = pullRunRef.current;
-      if (pulling) return pulling;
-      return beginRun(title, lastRunFileIdRef.current);
-    },
-    [beginRun],
-  );
-
-  const onMethodCallUpdate = useCallback(
-    (methodCall: MethodCall) => {
-      const collector = mcpRunCollectorRef.current;
-      if (collector) {
-        const i = collector.findIndex((m) => m.id === methodCall.id);
-        if (i > -1) collector[i] = methodCall;
-        else collector.push(methodCall);
-      }
-      // A call a script actually made counts as much as one picked out of the
-      // tree, and more of them are made this way once you are working.
-      recordUse(methodUse(methodCall.appName, methodCall.service, methodCall.method));
-      const run = openRun(methodCall.method.name);
-      consoles.recordCall(run.fileId, run.id, methodCall, Date.now());
-    },
-    [openRun],
-  );
-
-  /**
-   * A line the script printed. It lands in the run it was printed in, so it can
-   * be read against the calls around it, and in kaja.log with its origin
-   * attached — the file is what a TestFlight user can actually send back.
-   *
-   * It is not a verdict: an error-level line says something went wrong in the
-   * script's own reckoning, not that the run failed, so it never colours the
-   * run's dot. Only `onScriptError` below does that.
-   */
-  const onScriptLog = useCallback(
-    (level: LogLevel, message: string) => {
-      logScriptLine(logFileLevel(level), message);
-      const run = openRun("Script output");
-      consoles.recordPrinted(run.fileId, run.id, level, message, Date.now());
-    },
-    [openRun],
-  );
-
-  // Show a failed script run in the console; a script that dies silently looks
-  // like it succeeded. Mirrored to console.error so it also lands in kaja.log.
-  const onScriptError = useCallback(
-    (error: unknown) => {
-      console.error("Script error:", error);
-      const message = error instanceof Error ? (error.name === "Error" ? error.message : `${error.name}: ${error.message}`) : String(error);
-      const run = openRun("Script error");
-      consoles.recordLogs(run.fileId, run.id, [{ level: LogLevel.LEVEL_ERROR, message }], Date.now());
-    },
-    [openRun],
-  );
-
-  // Something the script drew. Blocks arrive more than once — a table paints row
-  // by row — so they are recorded against their own id rather than appended.
-  const onBlockUpdate = useCallback(
-    (blockId: string, block: Block) => {
-      // A run made for the MCP server draws on a canvas nobody is watching, so
-      // what it drew is collected here and reported back as the receipt.
-      mcpBlockCollectorRef.current?.set(blockId, block);
-      const run = openRun("Script output");
-      consoles.recordBlock(run.fileId, run.id, blockId, block, Date.now());
-    },
-    [openRun],
-  );
-
   /**
    * A `kaja.ask*` is answered, and a `kaja.approve(...)` decided, on the canvas
    * of the run it came from — so both promises wait here keyed by the block they
    * were drawn as. One map, because both are the same thing to the run: it is
    * parked until someone says something. A run with no console has no canvas to
-   * draw on — an agent running code that was never saved — and falls back to a
-   * dialog, which needs no surface of its own.
+   * draw on and falls back to a dialog, which needs no surface of its own.
+   *
+   * Each entry remembers which run is parked on it, because Stop is about one
+   * run: cancelling every question on screen would stop a script the button was
+   * never pointing at.
    */
-  const pendingPromptsRef = useRef(new Map<string, { resolve: (answer: string) => void; reject: (error: unknown) => void }>());
-
-  const onAsk = useCallback((question: AskBlock, blockId: string) => {
-    return new Promise<string>((resolve, reject) => {
-      if (!currentRunRef.current?.fileId) {
-        // A select opens on its first option, since the dialog has one field and
-        // it has to hold something.
-        setAskPrompt({ question, value: question.answerType === "select" ? (question.choices?.[0] ?? "") : "", resolve, reject });
-        return;
-      }
-      pendingPromptsRef.current.set(blockId, { resolve, reject });
-    });
-  }, []);
-
-  const onApprove = useCallback((call: ApproveBlock, blockId: string) => {
-    return new Promise<ApproveDecision>((resolve, reject) => {
-      if (!currentRunRef.current?.fileId) {
-        setApprovePrompt({ call, resolve, reject });
-        return;
-      }
-      // The gesture rides back on the same map an answer does — there is one
-      // thing to say, and which of the two approvals it was is the whole of it.
-      pendingPromptsRef.current.set(blockId, { resolve: (gesture) => resolve(gesture === "all" ? "all" : "approved"), reject });
-    });
-  }, []);
+  const pendingPromptsRef = useRef(new Map<string, { runId: string; resolve: (answer: string) => void; reject: (error: unknown) => void }>());
 
   const settlePrompt = useCallback((blockId: string, settle: (pending: { resolve: (answer: string) => void; reject: (error: unknown) => void }) => void) => {
     const pending = pendingPromptsRef.current.get(blockId);
@@ -533,6 +439,132 @@ export function App() {
     pendingPromptsRef.current.delete(blockId);
     settle(pending);
   }, []);
+
+  // What every run is built from and what outlives them all: the workspace's
+  // variables, and the live tables, which are paged from the canvas long after
+  // the run that drew them has ended.
+  const hostRef = useRef<KajaHost>(null);
+  if (!hostRef.current) {
+    hostRef.current = new KajaHost();
+  }
+  const host = hostRef.current;
+
+  /**
+   * Open a run, and with it the `Kaja` its script will be handed.
+   *
+   * This is the one place a run is created, and everything the script goes on to
+   * do — a call, a printed line, a block, a question — is routed by a closure
+   * over the run made here. That is the whole of how two scripts running at once
+   * stay apart: there is no "current run" to read, so there is nothing to read
+   * wrongly. A page fetched from a table's canvas long after the run ended goes
+   * through the same closures, which is why it still lands in the right log.
+   */
+  const beginRun = useCallback(
+    (
+      title: string,
+      fileId?: string,
+      controller?: AbortController,
+      options?: { origin?: Run["origin"]; input?: { [key: string]: string }; collect?: RunCollector },
+    ): LiveRun => {
+      const run: Run = { id: newRunId(), title, fileId, startedAt: Date.now(), origin: options?.origin };
+      consoles.startRun(run, run.startedAt);
+
+      const collect = options?.collect;
+      const kaja = host.run({
+        input: options?.input,
+        onMethodCallUpdate: (methodCall: MethodCall) => {
+          // A run being watched by an agent rather than a person reports its
+          // calls back as well as recording them; the collector is this run's,
+          // so a second run in flight cannot write into it.
+          if (collect) {
+            const i = collect.calls.findIndex((m) => m.id === methodCall.id);
+            if (i > -1) collect.calls[i] = methodCall;
+            else collect.calls.push(methodCall);
+          }
+          // A call a script actually made counts as much as one picked out of the
+          // tree, and more of them are made this way once you are working.
+          recordUse(methodUse(methodCall.appName, methodCall.service, methodCall.method));
+          consoles.recordCall(run.fileId, run.id, methodCall, Date.now());
+        },
+        /**
+         * A line the script printed. It lands in the run it was printed in, so it
+         * can be read against the calls around it, and in kaja.log with its
+         * origin attached — the file is what a TestFlight user can actually send
+         * back.
+         *
+         * It is not a verdict: an error-level line says something went wrong in
+         * the script's own reckoning, not that the run failed, so it never
+         * colours the run's dot. Only `reportScriptError` does that.
+         */
+        onLog: (level: LogLevel, message: string) => {
+          logScriptLine(logFileLevel(level), message);
+          consoles.recordPrinted(run.fileId, run.id, level, message, Date.now());
+        },
+        // Something the script drew. Blocks arrive more than once — a table
+        // paints row by row — so they are recorded against their own id rather
+        // than appended.
+        onBlockUpdate: (blockId: string, block: Block) => {
+          collect?.blocks.set(blockId, block);
+          consoles.recordBlock(run.fileId, run.id, blockId, block, Date.now());
+        },
+        onAsk: (question: AskBlock, blockId: string) =>
+          new Promise<string>((resolve, reject) => {
+            if (!run.fileId) {
+              // A select opens on its first option, since the dialog has one
+              // field and it has to hold something.
+              setAskPrompt({ question, value: question.answerType === "select" ? (question.choices?.[0] ?? "") : "", resolve, reject });
+              return;
+            }
+            pendingPromptsRef.current.set(blockId, { runId: run.id, resolve, reject });
+          }),
+        onApprove: (call: ApproveBlock, blockId: string) =>
+          new Promise<ApproveDecision>((resolve, reject) => {
+            if (!run.fileId) {
+              setApprovePrompt({ call, resolve, reject });
+              return;
+            }
+            // The gesture rides back on the same map an answer does — there is one
+            // thing to say, and which of the two approvals it was is the whole of it.
+            pendingPromptsRef.current.set(blockId, {
+              runId: run.id,
+              resolve: (gesture) => resolve(gesture === "all" ? "all" : "approved"),
+              reject,
+            });
+          }),
+      });
+
+      const live: LiveRun = { run, kaja, controller, settled: false };
+      setActiveRuns((runs) => [...runs, live]);
+      return live;
+    },
+    [host],
+  );
+
+  const beginRunRef = useRef(beginRun);
+  beginRunRef.current = beginRun;
+
+  // The script has returned. Its calls may still be landing, so this is not the
+  // run being over — `settleIfQuiet` decides that once nothing it started is in
+  // the air.
+  const markSettled = useCallback((runId: string) => {
+    setActiveRuns((runs) => runs.map((live) => (live.run.id === runId ? { ...live, settled: true } : live)));
+  }, []);
+
+  const markSettledRef = useRef(markSettled);
+  markSettledRef.current = markSettled;
+
+  // Show a failed script run in the console; a script that dies silently looks
+  // like it succeeded. Mirrored to console.error so it also lands in kaja.log.
+  // It takes the run rather than finding one: the script that failed is the one
+  // whose error this is, however many others are going.
+  const reportScriptError = useCallback(
+    (run: Run) => (error: unknown) => {
+      console.error("Script error:", error);
+      const message = error instanceof Error ? (error.name === "Error" ? error.message : `${error.name}: ${error.message}`) : String(error);
+      consoles.recordLogs(run.fileId, run.id, [{ level: LogLevel.LEVEL_ERROR, message }], Date.now());
+    },
+    [],
+  );
 
   const onAnswerAsk = useCallback((blockId: string, answer: string) => settlePrompt(blockId, (pending) => pending.resolve(answer)), [settlePrompt]);
   const onCancelAsk = useCallback((blockId: string) => settlePrompt(blockId, (pending) => pending.reject(new AskCancelledError())), [settlePrompt]);
@@ -559,11 +591,6 @@ export function App() {
     setAskPrompt(null);
   }, [askPrompt]);
 
-  const kajaRef = useRef<Kaja>(null);
-  if (!kajaRef.current) {
-    kajaRef.current = new Kaja(onMethodCallUpdate, onAsk, onApprove, onBlockUpdate, onScriptLog);
-  }
-
   /**
    * Where each table is paged and searched. This is view state rather than
    * something the run drew, so it is held here instead of in the block — but
@@ -576,30 +603,25 @@ export function App() {
     setTableViews((current) => ({ ...current, [blockId]: view }));
   }, []);
 
-  // The run that a table is being filled for, which is what a call made by the
-  // pull is recorded against.
-  const pullRunRef = useRef<Run | null>(null);
-
   /**
    * Fill a live table further — the next page, or the first page of a new
    * search. A source that is no longer held (a run read back from an earlier
    * session, or one let go to keep the closures bounded) can't be pulled, and
    * the table says so rather than offering a Next that leads nowhere.
+   *
+   * Nothing here says which run the fetch belongs to: the host routes the block
+   * to the `Kaja` that drew it, so the calls are recorded by that run's own
+   * closures however long ago it ended, and a script running right now can't be
+   * mistaken for the one being paged.
    */
   const onTablePull = useCallback(async (blockId: string, search: string, want: number) => {
     const found = consoles.findBlock(blockId);
     const table = found?.block;
     if (!found || table?.kind !== "table") return;
 
-    const previous = pullRunRef.current;
-    pullRunRef.current = found.run;
-    try {
-      const live = await kajaRef.current!.pullTable(blockId, search, want);
-      if (!live) {
-        consoles.recordBlock(found.fileId, found.run.id, blockId, { ...table, live: false, expired: true }, Date.now());
-      }
-    } finally {
-      pullRunRef.current = previous;
+    const live = await hostRef.current!.pullTable(blockId, search, want);
+    if (!live) {
+      consoles.recordBlock(found.fileId, found.run.id, blockId, { ...table, live: false, expired: true }, Date.now());
     }
   }, []);
 
@@ -614,15 +636,9 @@ export function App() {
     const table = found?.block;
     if (!found || table?.kind !== "table") return;
 
-    const previous = pullRunRef.current;
-    pullRunRef.current = found.run;
-    try {
-      const held = await kajaRef.current!.pullCells(blockId, cells);
-      if (!held) {
-        consoles.recordBlock(found.fileId, found.run.id, blockId, { ...table, expired: true }, Date.now());
-      }
-    } finally {
-      pullRunRef.current = previous;
+    const held = await hostRef.current!.pullCells(blockId, cells);
+    if (!held) {
+      consoles.recordBlock(found.fileId, found.run.id, blockId, { ...table, expired: true }, Date.now());
     }
   }, []);
 
@@ -858,20 +874,21 @@ export function App() {
     const variables = configuration?.variables ?? {};
     setVariables(variables);
     registerKajaModule(Object.keys(variables));
-    if (!kajaRef.current) return;
+    if (!hostRef.current) return;
     // Scripts read resolved values, including the ones kaja.json only names.
     // That is the desktop only: its UI runs inside the app's own process, so
     // there is no remote browser being handed a value it shouldn't have. On the
     // web the configuration's own text is all there is — and no scripts to read
-    // it.
+    // it. They belong to the host rather than to a run, so a run in flight reads
+    // the same values as one started afterwards.
     if (isWailsEnvironment()) {
       ResolvedVariables()
         .then((resolved) => {
-          if (kajaRef.current) kajaRef.current.variables = resolved;
+          if (hostRef.current) hostRef.current.variables = resolved;
         })
         .catch((error) => console.error("Failed to read the resolved variables", error));
     } else {
-      kajaRef.current.variables = variables;
+      hostRef.current.variables = variables;
     }
   }, [configuration?.variables]);
 
@@ -1280,16 +1297,17 @@ export function App() {
     try {
       const file = await ReadScriptFile(prompt.script.path);
       if (!file) return;
-      const kaja = kajaRef.current!;
-      kaja.input = prompt.input;
-      const run = beginRun(file.name, file.path);
-      runScript(file.content, kaja, apps, onScriptError)
+      // The link's parameters are what this run was started with, not something
+      // written onto a shared object — so a second link arriving mid-run, or a
+      // Run pressed beside it, cannot take them or leave its own behind.
+      const { run, kaja } = beginRun(file.name, file.path, undefined, { input: prompt.input });
+      runScript(file.content, kaja, apps, reportScriptError(run))
         .then(() => kaja.settleTables())
-        .finally(() => setActiveRun((active) => (active?.runId === run.id ? { ...active, settled: true } : active)));
+        .finally(() => markSettled(run.id));
     } catch (err) {
       showFileError(`Run failed: ${err}`);
     }
-  }, [linkPrompt, apps, showFileError, onScriptError, beginRun]);
+  }, [linkPrompt, apps, showFileError, reportScriptError, beginRun, markSettled]);
 
   // ⏎ runs what the link asked for. The dialog has nothing to type into, and
   // the whole point of a link is that it is one gesture away from a run.
@@ -1503,7 +1521,7 @@ export function App() {
   useEffect(() => {
     if (!isWailsEnvironment()) return;
     const unsub = EventsOn("mcp:runScript", async (payload: { id: string; path: string; code: string }) => {
-      const report = (result: McpRunReport) => MCPScriptResult(payload.id, JSON.stringify(result)).catch(() => {});
+      const reportResult = (result: McpRunReport) => MCPScriptResult(payload.id, JSON.stringify(result)).catch(() => {});
 
       let source = payload.code;
       if (payload.path) {
@@ -1511,7 +1529,7 @@ export function App() {
           const file = await ReadScriptFile(payload.path);
           source = file?.content ?? "";
         } catch (err) {
-          report({ console: [], error: err instanceof Error ? err.message : String(err), methodCalls: [] });
+          reportResult({ console: [], error: err instanceof Error ? err.message : String(err), methodCalls: [] });
           return;
         }
       }
@@ -1521,35 +1539,28 @@ export function App() {
       // agent exploring is not a different kind of event from a person doing it.
       const scratch = payload.path ? undefined : agentScratchRef.current(source);
       const fileId = payload.path || scratch?.id;
-      const collected: MethodCall[] = [];
-      mcpRunCollectorRef.current = collected;
-      const drawn = new Map<string, Block>();
-      mcpBlockCollectorRef.current = drawn;
+      // This run's own receipt. Two agents calling run_script at once each get
+      // what their own script did, because the collector reaches the run through
+      // its closures rather than through a slot the later one would take.
+      const collect: RunCollector = { calls: [], blocks: new Map<string, Block>() };
+      const report = () => ({ methodCalls: collect.calls.map(toMethodCallLog), blocks: [...collect.blocks.values()].map(toBlockLog) });
       let result: McpRunReport;
-      const run = beginRunRef.current(payload.path ? payload.path.split("/").pop()! : (scratch?.title ?? "Agent script"), fileId, undefined, {
+      const { run, kaja } = beginRunRef.current(payload.path ? payload.path.split("/").pop()! : (scratch?.title ?? "Agent script"), fileId, undefined, {
         origin: "agent",
+        collect,
       });
       try {
-        const kaja = kajaRef.current!;
-        kaja.input = {};
         const captured = await runScriptCaptured(source, kaja, appsRef.current);
         // An agent's table has nobody to page it, so its receipt is the first
         // page — which is exactly what it says it is.
         await kaja.settleTables();
-        result = { ...captured, methodCalls: collected.map(toMethodCallLog), blocks: [...drawn.values()].map(toBlockLog) };
+        result = { ...captured, ...report() };
       } catch (err) {
-        result = {
-          console: [],
-          error: err instanceof Error ? err.message : String(err),
-          methodCalls: collected.map(toMethodCallLog),
-          blocks: [...drawn.values()].map(toBlockLog),
-        };
+        result = { console: [], error: err instanceof Error ? err.message : String(err), ...report() };
       } finally {
-        mcpRunCollectorRef.current = null;
-        mcpBlockCollectorRef.current = null;
-        setActiveRun((active) => (active?.runId === run.id ? { ...active, settled: true } : active));
+        markSettledRef.current(run.id);
       }
-      report(result);
+      reportResult(result);
     });
     return () => unsub();
   }, []);
@@ -1826,22 +1837,21 @@ export function App() {
     // Run names reuse the derived script names, so the console and the sidebar
     // speak the same language.
     const title = view.type === "script" ? view.script.name : (deriveScratchTitle(code) ?? viewIdentity(view, scratchesRef.current).name);
-    beginRun(title, view.type === "script" ? view.script.path : view.scratchId, controller);
-    // Pressing Run carries no input, so whatever a link left behind goes: the
-    // last link's parameters must not ride along on the next run.
-    kajaRef.current!.input = {};
+    // Pressing Run carries no input, and this run's Kaja was born without any —
+    // there is nothing a previous link could have left behind to clear.
+    const { run, kaja } = beginRun(title, view.type === "script" ? view.script.path : view.scratchId, controller);
     // A live table draws its first page itself, and those calls are the run's:
     // the script is not over until they have landed, or the run would report a
     // duration that stops before the work it started.
-    runScript(code, kajaRef.current!, apps, onScriptError, controller.signal)
-      .then(() => kajaRef.current!.settleTables())
-      .finally(() => setActiveRun((run) => (run?.controller === controller ? { ...run, settled: true } : run)));
+    runScript(code, kaja, apps, reportScriptError(run), controller.signal)
+      .then(() => kaja.settleTables())
+      .finally(() => markSettled(run.id));
     // A run is the punctuation that settles a scratch: it is when the title is
     // re-read from the code, rather than jittering as you type.
     if (view.type === "scratch") {
       updateScratch(view.scratchId, (scratch) => markRun(scratch, code, Date.now()));
     }
-  }, [apps, beginRun, onScriptError, updateScratch]);
+  }, [apps, beginRun, reportScriptError, updateScratch, markSettled]);
 
   /**
    * A generated method-call script issues its call without awaiting it, so the
@@ -1853,29 +1863,31 @@ export function App() {
    * It hangs off the store rather than off a render, because the alternative is
    * asking the question again for every call a run makes.
    */
-  const activeRunRef = useRef(activeRun);
-  activeRunRef.current = activeRun;
-
   const settleIfQuiet = useCallback(() => {
-    const run = activeRunRef.current;
-    if (!run?.settled) return;
-    if (consoles.hasWorkInFlight(run.fileId, run.runId)) return;
+    // Every run in flight is asked, because they finish in whatever order their
+    // work does — the second one pressed is routinely the first one over.
+    const done = activeRunsRef.current.filter((live) => live.settled && !consoles.hasWorkInFlight(live.run.fileId, live.run.id));
+    if (done.length === 0) return;
 
-    if (run.fileId) {
-      const now = Date.now();
-      if (consoles.settleRun(run.fileId, run.runId, now - run.startedAt, now)) {
+    const now = Date.now();
+    for (const { run } of done) {
+      if (!run.fileId) continue;
+      if (consoles.settleRun(run.fileId, run.id, now - run.startedAt, now)) {
         const settled = consoles.file(run.fileId);
         saveRuns(run.fileId, settled.runs, settled.allItems(), now);
       }
     }
-    if (currentRunRef.current?.id === run.runId) currentRunRef.current = null;
-    setActiveRun(null);
+    // Letting the record go is what releases the run's `Kaja` — its approvals,
+    // its sampled methods and its bound clients with it. A live table it drew
+    // holds it past this point, and nothing else can.
+    const over = new Set(done.map((live) => live.run.id));
+    setActiveRuns((runs) => runs.filter((live) => !over.has(live.run.id)));
   }, []);
 
   useEffect(() => consoles.subscribeQuiet(settleIfQuiet), [settleIfQuiet]);
   // The script returning is the other half: a run whose calls all landed while
   // it was still going has nothing left to report it.
-  useEffect(settleIfQuiet, [activeRun, settleIfQuiet]);
+  useEffect(settleIfQuiet, [activeRuns, settleIfQuiet]);
 
   // Which file the console is reporting on. Everything below the editor is that
   // file's: its runs, where it was left pointing, and what it was showing.
@@ -1888,17 +1900,26 @@ export function App() {
     consoles.adoptStoredRuns(currentFileId, loadRuns(currentFileId), Date.now());
   }, [currentFileId]);
 
-  // Stop aborts the calls the run has in flight; the script itself stops at the
-  // call it was awaiting. A run parked on a question — or on a call waiting to
-  // be approved — is awaiting the user rather than a call, so Stop has to end
-  // that too or the script never returns.
+  /**
+   * Stop aborts the calls the run has in flight; the script itself stops at the
+   * call it was awaiting. A run parked on a question — or on a call waiting to
+   * be approved — is awaiting the user rather than a call, so Stop has to end
+   * that too or the script never returns.
+   *
+   * It reaches the runs of the file the button is on and no others. Cancelling
+   * every question on screen was how one Stop used to end a script nobody had
+   * pointed at.
+   */
   const onStopActiveRun = useCallback(() => {
-    for (const blockId of [...pendingPromptsRef.current.keys()]) onCancelAsk(blockId);
-    setActiveRun((run) => {
-      run?.controller?.abort();
-      return null;
-    });
-  }, [onCancelAsk]);
+    const stopping = activeRunsRef.current.filter((live) => live.run.fileId === currentFileId);
+    if (stopping.length === 0) return;
+    const ids = new Set(stopping.map((live) => live.run.id));
+    for (const [blockId, pending] of [...pendingPromptsRef.current.entries()]) {
+      if (ids.has(pending.runId)) onCancelAsk(blockId);
+    }
+    for (const live of stopping) live.controller?.abort();
+    setActiveRuns((runs) => runs.filter((live) => !ids.has(live.run.id)));
+  }, [onCancelAsk, currentFileId]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -2233,18 +2254,15 @@ export function App() {
     [bulkScratches, scripts],
   );
 
-  // Stop aborts what the button is showing, so it tracks the active run rather
+  // Stop aborts what the button is showing, so it tracks this file's runs rather
   // than the file's in-flight state — a run started elsewhere says so in the
-  // sidebar instead.
-  const running = currentFileId !== undefined && activeRun?.fileId === currentFileId;
+  // sidebar instead. The counter reads from the oldest of them, so pressing Run
+  // again while one is going extends the count rather than restarting it.
+  const runsHere = currentFileId === undefined ? [] : activeRuns.filter((live) => live.run.fileId === currentFileId);
+  const running = runsHere.length > 0;
+  const runningSince = running ? Math.min(...runsHere.map((live) => live.run.startedAt)) : undefined;
   const action = currentIsEditor ? (
-    <RunButton
-      onRun={onRunCurrentTab}
-      onStop={onStopActiveRun}
-      running={running}
-      startedAt={running ? activeRun?.startedAt : undefined}
-      error={syntaxErrors.first}
-    />
+    <RunButton onRun={onRunCurrentTab} onStop={onStopActiveRun} running={running} startedAt={runningSince} error={syntaxErrors.first} />
   ) : jsonView ? (
     <IconButton
       icon={Code}

--- a/ui/src/approve.test.ts
+++ b/ui/src/approve.test.ts
@@ -8,16 +8,16 @@ import { ApprovalRejectedError, ApproveDecision, Call, Kaja } from "./kaja";
 function held(decide: (call: ApproveBlock) => Promise<ApproveDecision>) {
   const blocks = new Map<string, Block>();
   const asked: string[] = [];
-  const kaja = new Kaja(
-    () => {},
-    () => Promise.reject(new Error("not asked")),
-    (call) => {
+  const kaja = new Kaja({
+    onMethodCallUpdate: () => {},
+    onAsk: () => Promise.reject(new Error("not asked")),
+    onApprove: (call) => {
       asked.push(call.method);
       return decide(call);
     },
-    (blockId, block) => void blocks.set(blockId, block),
-    () => {},
-  );
+    onBlockUpdate: (blockId, block) => void blocks.set(blockId, block),
+    onLog: () => {},
+  });
   const approvals = (): ApproveBlock[] => [...blocks.values()].filter((block): block is ApproveBlock => block.kind === "approve");
   const only = (): ApproveBlock => {
     const block = approvals()[0];

--- a/ui/src/apps.ts
+++ b/ui/src/apps.ts
@@ -114,9 +114,19 @@ export interface Clients {
   [key: string]: Client;
 }
 
+export interface Methods {
+  [key: string]: (input: any) => Call<any>;
+}
+
 export interface Client {
-  kaja?: Kaja;
-  methods: { [key: string]: (input: any) => Call<any> };
+  /**
+   * The service's methods, bound to one run. A client is built once per app and
+   * shared by every run that imports it, so the run cannot be a field on it —
+   * that field is what used to make two scripts running at once report their
+   * calls to each other. Binding is memoized per `Kaja`, so the ten imports of
+   * one run share one object.
+   */
+  methodsFor(kaja: Kaja): Methods;
 }
 
 export function serviceId(service: Service): string {

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -3,7 +3,7 @@ import type { IMessageType } from "@protobuf-ts/runtime";
 import type { MethodInfo, RpcMetadata, RpcOptions, ServerStreamingCall, UnaryCall } from "@protobuf-ts/runtime-rpc";
 import { TwirpFetchTransport } from "@protobuf-ts/twirp-transport";
 import { appHeaders, transportHeaders } from "./appTypes";
-import { Call, MethodCall, MethodCallHeaders } from "./kaja";
+import { Call, Kaja, MethodCall, MethodCallHeaders } from "./kaja";
 import {
   UPSTREAM_ERROR_TRAILER,
   UPSTREAM_REQUEST_HEADERS_TRAILER,
@@ -11,7 +11,7 @@ import {
   parseUpstreamError,
   parseUpstreamHeaders,
 } from "./upstreamHeaders";
-import { Client, AppRef, Service, serviceId, Transport } from "./apps";
+import { Client, AppRef, Methods, Service, serviceId, Transport } from "./apps";
 import { getBaseUrlForTarget } from "./server/connection";
 import { WailsTransport } from "./server/wails-transport";
 import { Stub } from "./sources";
@@ -69,8 +69,6 @@ function applyErrorMetadata(methodCall: MethodCall, error: unknown): void {
 }
 
 export function createClient(service: Service, stub: Stub, appRef: AppRef): Client {
-  const client: Client = { methods: {} };
-
   const isTwirp = appRef.protocol === Transport.TWIRP;
 
   let transport;
@@ -123,98 +121,119 @@ export function createClient(service: Service, stub: Stub, appRef: AppRef): Clie
     ],
   };
 
-  for (const method of service.methods) {
-    const isServerStreaming = method.serverStreaming && !method.clientStreaming;
-    const inputType: IMessageType<any> | undefined = (clientStub.methods as MethodInfo[] | undefined)?.find((m) => m.name === method.name)?.I;
+  // What a method needs that the run has no say in, resolved once rather than
+  // per run: everything below this is the same for every script that calls it.
+  const prepared = service.methods.map((method) => ({
+    method,
+    isServerStreaming: method.serverStreaming && !method.clientStreaming,
+    inputType: (clientStub.methods as MethodInfo[] | undefined)?.find((m) => m.name === method.name)?.I as IMessageType<any> | undefined,
+  }));
 
-    const send = async (input: any) => {
-      // Capture request headers from appRef at request time. They are shown as
-      // configured, with their ${NAME} references intact - the Headers view
-      // reads better that way, and the values behind them stay outside the
-      // browser.
-      const requestHeaders: { [key: string]: string } = appHeaders(appRef.configuration);
+  // Bound methods are kept per run rather than rebuilt per import, and weakly,
+  // so a run's bindings go when the run's Kaja does.
+  const bound = new WeakMap<Kaja, Methods>();
 
-      const methodCall: MethodCall = {
-        id: crypto.randomUUID(),
-        appName: appRef.configuration.name,
-        service,
-        method,
-        input,
-        requestHeaders,
-        url: isTwirp ? `${appRef.target.replace(/\/$/, "")}/twirp/${serviceId(service)}/${method.name}` : undefined,
-        timestamp: Date.now(),
-      };
-      client.kaja?._internal.methodCallUpdate(methodCall);
+  const bind = (kaja: Kaja): Methods => {
+    const methods: Methods = {};
+    for (const { method, isServerStreaming, inputType } of prepared) {
+      const send = async (input: any) => {
+        // Capture request headers from appRef at request time. They are shown as
+        // configured, with their ${NAME} references intact - the Headers view
+        // reads better that way, and the values behind them stay outside the
+        // browser.
+        const requestHeaders: { [key: string]: string } = appHeaders(appRef.configuration);
 
-      const startedAt = performance.now();
-      const elapsed = () => Math.round(performance.now() - startedAt);
+        const methodCall: MethodCall = {
+          id: crypto.randomUUID(),
+          appName: appRef.configuration.name,
+          service,
+          method,
+          input,
+          requestHeaders,
+          url: isTwirp ? `${appRef.target.replace(/\/$/, "")}/twirp/${serviceId(service)}/${method.name}` : undefined,
+          timestamp: Date.now(),
+        };
+        kaja._internal.methodCallUpdate(methodCall);
 
-      try {
-        // The run's abort signal is read here rather than captured with the
-        // client, so every call a script makes joins the run that issued it.
-        const abort = client.kaja?._internal.abortSignal;
-        // A request is a hand-written object literal, so it is routinely partial:
-        // a deleted field, or a oneof left unset, reaches the serializer as
-        // `undefined` and fails there with an error that names neither. create()
-        // fills those in with the zero values the wire format omits anyway. The
-        // literal itself stays on the method call, so the console and the value
-        // completions keep showing what was actually written.
-        const message = inputType ? inputType.create(input) : input;
-        const call = clientStub[lcfirst(method.name)](message, abort ? { ...options, abort } : options);
+        const startedAt = performance.now();
+        const elapsed = () => Math.round(performance.now() - startedAt);
 
-        if (isServerStreaming) {
-          const streamCall = call as ServerStreamingCall<any, any>;
-          methodCall.inputTypeName = streamCall.method?.I?.typeName;
-          methodCall.inputType = streamCall.method?.I;
-          methodCall.outputTypeName = streamCall.method?.O?.typeName;
-          methodCall.outputType = streamCall.method?.O;
-          methodCall.streamOutputs = [];
+        try {
+          // The signal is the one belonging to the run these methods were bound
+          // for, so Stop reaches the calls of that run and no others.
+          const abort = kaja._internal.abortSignal;
+          // A request is a hand-written object literal, so it is routinely partial:
+          // a deleted field, or a oneof left unset, reaches the serializer as
+          // `undefined` and fails there with an error that names neither. create()
+          // fills those in with the zero values the wire format omits anyway. The
+          // literal itself stays on the method call, so the console and the value
+          // completions keep showing what was actually written.
+          const message = inputType ? inputType.create(input) : input;
+          const call = clientStub[lcfirst(method.name)](message, abort ? { ...options, abort } : options);
 
-          for await (const message of streamCall.responses) {
-            // Appended, not copied: the console holds this object rather than a
-            // snapshot of it, so rebuilding the array per message would be a
-            // quadratic cost for a stream nothing is reading differently.
-            methodCall.streamOutputs.push(message);
-            methodCall.output = message;
-            client.kaja?._internal.methodCallUpdate(methodCall);
+          if (isServerStreaming) {
+            const streamCall = call as ServerStreamingCall<any, any>;
+            methodCall.inputTypeName = streamCall.method?.I?.typeName;
+            methodCall.inputType = streamCall.method?.I;
+            methodCall.outputTypeName = streamCall.method?.O?.typeName;
+            methodCall.outputType = streamCall.method?.O;
+            methodCall.streamOutputs = [];
+
+            for await (const message of streamCall.responses) {
+              // Appended, not copied: the console holds this object rather than a
+              // snapshot of it, so rebuilding the array per message would be a
+              // quadratic cost for a stream nothing is reading differently.
+              methodCall.streamOutputs.push(message);
+              methodCall.output = message;
+              kaja._internal.methodCallUpdate(methodCall);
+            }
+            methodCall.streamComplete = true;
+            methodCall.durationMs = elapsed();
+
+            const [headers, trailers] = await Promise.all([streamCall.headers, streamCall.trailers]);
+            collectResponseHeaders(methodCall, headers, trailers);
+          } else {
+            const [response, headers, trailers] = await Promise.all([call.response, call.headers, call.trailers]);
+            methodCall.durationMs = elapsed();
+            methodCall.output = response;
+            methodCall.inputTypeName = call.method?.I?.typeName;
+            methodCall.inputType = call.method?.I;
+            methodCall.outputTypeName = call.method?.O?.typeName;
+            methodCall.outputType = call.method?.O;
+
+            // Capture response headers and trailers
+            collectResponseHeaders(methodCall, headers, trailers);
           }
-          methodCall.streamComplete = true;
+        } catch (error: any) {
           methodCall.durationMs = elapsed();
-
-          const [headers, trailers] = await Promise.all([streamCall.headers, streamCall.trailers]);
-          collectResponseHeaders(methodCall, headers, trailers);
-        } else {
-          const [response, headers, trailers] = await Promise.all([call.response, call.headers, call.trailers]);
-          methodCall.durationMs = elapsed();
-          methodCall.output = response;
-          methodCall.inputTypeName = call.method?.I?.typeName;
-          methodCall.inputType = call.method?.I;
-          methodCall.outputTypeName = call.method?.O?.typeName;
-          methodCall.outputType = call.method?.O;
-
-          // Capture response headers and trailers
-          collectResponseHeaders(methodCall, headers, trailers);
+          methodCall.error = callError(error);
+          applyErrorMetadata(methodCall, error);
         }
-      } catch (error: any) {
-        methodCall.durationMs = elapsed();
-        methodCall.error = callError(error);
-        applyErrorMetadata(methodCall, error);
-      }
 
-      client.kaja?._internal.methodCallUpdate(methodCall);
+        kaja._internal.methodCallUpdate(methodCall);
 
-      return methodCall.output;
-    };
+        return methodCall.output;
+      };
 
-    // A call is handed back rather than made: it goes out when the script awaits
-    // it, or at the end of the tick if nothing has claimed it. `kaja.approve` is
-    // what claims one, and holding it back is the only reason the gap exists —
-    // everything above happens when the call starts, including the row it puts
-    // in the log, so a call that was never approved was never anywhere.
-    client.methods[method.name] = (input: any) => new Call(`${service.name}.${method.name}`, input, () => send(input));
-  }
+      // A call is handed back rather than made: it goes out when the script awaits
+      // it, or at the end of the tick if nothing has claimed it. `kaja.approve` is
+      // what claims one, and holding it back is the only reason the gap exists —
+      // everything above happens when the call starts, including the row it puts
+      // in the log, so a call that was never approved was never anywhere.
+      methods[method.name] = (input: any) => new Call(`${service.name}.${method.name}`, input, () => send(input));
+    }
+    return methods;
+  };
 
-  return client;
+  return {
+    methodsFor(kaja: Kaja): Methods {
+      const held = bound.get(kaja);
+      if (held) return held;
+      const methods = bind(kaja);
+      bound.set(kaja, methods);
+      return methods;
+    },
+  };
 }
 
 function lcfirst(str: string): string {

--- a/ui/src/defaultInput.test.ts
+++ b/ui/src/defaultInput.test.ts
@@ -138,13 +138,13 @@ test("defaultInput generates a request that serializes", () => {
   // The generated code calls the kaja builders, which a script gets from the
   // runtime object; supply the real one so what is serialized is what a run sends.
   const generated = new Function("kaja", `return ${expr.replace(/;\s*$/, "")}`)(
-    new Kaja(
-      () => {},
-      async () => "",
-      async () => "approved" as const,
-      () => {},
-      () => {},
-    ),
+    new Kaja({
+      onMethodCallUpdate: () => {},
+      onAsk: async () => "",
+      onApprove: async () => "approved" as const,
+      onBlockUpdate: () => {},
+      onLog: () => {},
+    }),
   );
 
   expect(() => request.toBinary(generated)).not.toThrow();

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -358,25 +358,135 @@ function toListValue(input: JsonValue[]): ListValue {
   return { values: input.map((item) => toValue(item)) };
 }
 
+/**
+ * Where one run's output goes, and what it was given to start with. A `Kaja` is
+ * built from one of these per run, so a script's calls, blocks, questions and
+ * log lines are addressed to the run that made them before it makes any — which
+ * is what lets two scripts run at once without either being able to reach the
+ * other's console. Nothing here is reassigned once the run has begun.
+ */
+export interface RunContext {
+  onMethodCallUpdate: MethodCallUpdate;
+  onAsk: AskRequest;
+  onApprove: ApproveRequest;
+  onBlockUpdate: BlockUpdate;
+  onLog: LogSink;
+  /**
+   * The query a `kaja://run/<script>?...` link carried. It is given at the start
+   * rather than assigned afterwards, so one link's parameters can never be found
+   * by the next run — the two runs are different objects.
+   */
+  input?: { [key: string]: string };
+}
+
+/**
+ * The one `Kaja` per run holds what belongs to that run. This holds what
+ * outlives it: the workspace's variables, and the live tables — which are paged
+ * long after the run that drew them is over, and must stay bounded across all
+ * runs rather than per run.
+ */
+export class KajaHost {
+  // The resolved values, including the ones kaja.json only names and this
+  // machine holds - scripts are the desktop only, where there is no remote
+  // browser being handed a value it shouldn't have.
+  variables: { [key: string]: string } = {};
+  readonly tables = new LiveTables();
+
+  /** A fresh run, with its output already addressed. */
+  run(context: RunContext): Kaja {
+    return new Kaja(context, this);
+  }
+
+  /**
+   * Whether this block's source is still held, which is what Next depends on. It
+   * is asked of the host rather than of a run, because the canvas asking has
+   * only a block id and no idea which run drew it.
+   */
+  hasLiveTable(blockId: string): boolean {
+    return this.tables.has(blockId);
+  }
+
+  /**
+   * Page a table by its block, from the canvas rather than from a script. The
+   * run that drew it is the one that fetches — its Kaja still holds the source,
+   * so the calls land in that run's log however long ago it ended.
+   */
+  pullTable(blockId: string, search: string, want: number): Promise<boolean> {
+    return this.tables.owner(blockId)?.pullTable(blockId, search, want) ?? Promise.resolve(false);
+  }
+
+  /** Start a table's cells, on the same rule as a pull. */
+  pullCells(blockId: string, cells: CellRef[]): Promise<boolean> {
+    return this.tables.owner(blockId)?.pullCells(blockId, cells) ?? Promise.resolve(false);
+  }
+}
+
+/**
+ * Every live table, whoever drew it. It is one map rather than one per run for
+ * two reasons: `MAX_LIVE_TABLES` is a budget for the app, not for a run, and a
+ * page fetched from the canvas arrives knowing only a block id. Holding the
+ * owner beside each table is also what keeps a finished run's `Kaja` — and so
+ * its console, its approvals and its bound clients — alive exactly as long as
+ * something can still call into it, and no longer.
+ */
+export class LiveTables {
+  #entries = new Map<string, { table: LiveTable; owner: Kaja }>();
+
+  open(blockId: string, table: LiveTable, owner: Kaja): void {
+    if (this.#entries.size >= MAX_LIVE_TABLES) {
+      const oldest = this.#entries.keys().next();
+      if (!oldest.done) this.#entries.delete(oldest.value);
+    }
+    this.#entries.set(blockId, { table, owner });
+  }
+
+  get(blockId: string): LiveTable | undefined {
+    return this.#entries.get(blockId)?.table;
+  }
+
+  has(blockId: string): boolean {
+    return this.#entries.has(blockId);
+  }
+
+  owner(blockId: string): Kaja | undefined {
+    return this.#entries.get(blockId)?.owner;
+  }
+
+  ownedBy(owner: Kaja): LiveTable[] {
+    return [...this.#entries.values()].filter((entry) => entry.owner === owner).map((entry) => entry.table);
+  }
+}
+
 export class Kaja {
   readonly _internal: KajaInternal;
   // The query a `kaja://run/<script>?...` link carried, readable as
   // `kaja.input.<name>`. Empty when the script is run any other way.
-  input: { [key: string]: string } = {};
-  // User-defined variables, readable as `kaja.variables.<name>`. These are the
-  // resolved values, including the ones kaja.json only names and this machine
-  // holds - scripts are the desktop only, where there is no remote browser
-  // being handed a value it shouldn't have.
-  variables: { [key: string]: string } = {};
+  readonly input: { [key: string]: string };
+  #host: KajaHost;
   #onAsk: AskRequest;
   #onApprove: ApproveRequest;
   #onBlockUpdate: BlockUpdate;
 
-  constructor(onMethodCallUpdate: MethodCallUpdate, onAsk: AskRequest, onApprove: ApproveRequest, onBlockUpdate: BlockUpdate, onLog: LogSink) {
-    this._internal = new KajaInternal(onMethodCallUpdate, onLog);
-    this.#onAsk = onAsk;
-    this.#onApprove = onApprove;
-    this.#onBlockUpdate = onBlockUpdate;
+  constructor(context: RunContext, host: KajaHost = new KajaHost()) {
+    this._internal = new KajaInternal(context.onMethodCallUpdate, context.onLog);
+    this.#host = host;
+    this.input = context.input ?? {};
+    this.#onAsk = context.onAsk;
+    this.#onApprove = context.onApprove;
+    this.#onBlockUpdate = context.onBlockUpdate;
+  }
+
+  /**
+   * The workspace's variables, readable as `kaja.variables.<name>`. They belong
+   * to the app rather than to the run, so this reads through to the host and
+   * every run in flight sees the same values.
+   */
+  get variables(): { [key: string]: string } {
+    return this.#host.variables;
+  }
+
+  set variables(variables: { [key: string]: string }) {
+    this.#host.variables = variables;
   }
 
   /**
@@ -630,19 +740,14 @@ export class Kaja {
     };
   }
 
-  #tables = new Map<string, LiveTable>();
-
-  #openTable(blockId: string, table: LiveTable): void {
-    if (this.#tables.size >= MAX_LIVE_TABLES) {
-      const oldest = this.#tables.keys().next();
-      if (!oldest.done) this.#tables.delete(oldest.value);
-    }
-    this.#tables.set(blockId, table);
+  // Every run's tables, so the budget is the app's and a page can find its way
+  // back to the run that drew it.
+  get #tables(): LiveTables {
+    return this.#host.tables;
   }
 
-  /** Whether this block's source is still held, which is what Next depends on. */
-  hasLiveTable(blockId: string): boolean {
-    return this.#tables.has(blockId);
+  #openTable(blockId: string, table: LiveTable): void {
+    this.#tables.open(blockId, table, this);
   }
 
   /**
@@ -891,14 +996,17 @@ export class Kaja {
    */
   async settleTables(): Promise<void> {
     for (let pass = 0; pass < 8; pass++) {
-      const pulling = [...this.#tables.values()]
+      // This run's tables only. Another run's first page is its own to wait for,
+      // and waiting on it here would make one script's duration cover another's.
+      const mine = this.#tables.ownedBy(this);
+      const pulling = mine
         .flatMap((table) => [table.first, table.pulling, ...table.running])
         .filter((promise): promise is Promise<void> => promise !== undefined);
       if (pulling.length === 0) return;
       await Promise.all(pulling);
       // The first pull is over once it has been awaited; leaving it here would
       // make every later pass find work that is already done.
-      for (const table of this.#tables.values()) table.first = undefined;
+      for (const table of mine) table.first = undefined;
     }
   }
 
@@ -987,8 +1095,10 @@ class KajaInternal {
    * The scope is the method rather than the run because that is what the button
    * can honestly say: a script that loops over one call is the case this exists
    * for, and one that also writes somewhere else asks again for that. And the
-   * lifetime is the run because anything longer is a policy — cleared by
-   * `runScript`, so the guard is back the next time Run is pressed.
+   * lifetime is the run because anything longer is a policy — this set belongs
+   * to one run's `Kaja` and goes when it does, so the guard is back the next
+   * time Run is pressed and a second script running at the same time can never
+   * be let through on an approval it was not given.
    */
   readonly approvedMethods = new Set<string>();
   /**
@@ -996,14 +1106,13 @@ class KajaInternal {
    * Remembering walks a request and a response with their schemas, and it feeds
    * a completion list that keeps five values per field — so a loop calling one
    * method a thousand times is nine hundred and ninety-five walks for a list
-   * that was full after the first few. Cleared with the approvals, by the run.
+   * that was full after the first few. Per run, like the approvals.
    */
   readonly sampledMethods = new Map<string, number>();
   /**
-   * Where a line the script printed goes. It is here rather than passed into
-   * `runScript` because both doors — the editor's Run and the MCP server's — hold
-   * the one `Kaja`, and the sink outlives any single run the way the rest of this
-   * does.
+   * Where a line the script printed goes — this run's console, since the `Kaja`
+   * it hangs off is this run's. Both doors, the editor's Run and the MCP
+   * server's, build one of these per run and hand it the sink.
    */
   readonly onLog: LogSink;
   #onMethodCallUpdate: MethodCallUpdate;

--- a/ui/src/kajaTable.test.ts
+++ b/ui/src/kajaTable.test.ts
@@ -7,13 +7,13 @@ import { bodyMinHeight, tableSummary, tableWindow } from "./tableView";
 // is: a block that keeps being handed back with more in it.
 function draw() {
   const blocks = new Map<string, Block>();
-  const kaja = new Kaja(
-    () => {},
-    () => Promise.reject(new Error("not asked")),
-    () => Promise.reject(new Error("not approved")),
-    (blockId, block) => void blocks.set(blockId, block),
-    () => {},
-  );
+  const kaja = new Kaja({
+    onMethodCallUpdate: () => {},
+    onAsk: () => Promise.reject(new Error("not asked")),
+    onApprove: () => Promise.reject(new Error("not approved")),
+    onBlockUpdate: (blockId, block) => void blocks.set(blockId, block),
+    onLog: () => {},
+  });
   const only = (): TableBlock => {
     const block = [...blocks.values()].find((block) => block.kind === "table");
     if (block?.kind !== "table") throw new Error("no table was drawn");

--- a/ui/src/runIsolation.test.ts
+++ b/ui/src/runIsolation.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "bun:test";
+import { Block } from "./blocks";
+import { Call, Kaja, KajaHost } from "./kaja";
+import { LogLevel } from "./server/api";
+
+/**
+ * Two runs at once is the ordinary case, not the exotic one: ⌘⏎ twice, Run on a
+ * second file, a `kaja://` link arriving mid-script, an agent calling
+ * run_script. Each of these tests is a way one run used to be able to reach
+ * another when there was one `Kaja` for the window and the run was read off an
+ * ambient ref.
+ */
+
+// A run, and everything it produced, kept apart from every other run's.
+function run(host: KajaHost, name: string) {
+  const blocks = new Map<string, Block>();
+  const logs: string[] = [];
+  const calls: string[] = [];
+  const asked: string[] = [];
+  const kaja = host.run({
+    onMethodCallUpdate: (methodCall) => void calls.push(`${name}:${methodCall.method.name}`),
+    onAsk: () => Promise.reject(new Error("not asked")),
+    onApprove: (call) => {
+      asked.push(`${name}:${call.method}`);
+      return Promise.resolve("all" as const);
+    },
+    onBlockUpdate: (blockId, block) => void blocks.set(blockId, block),
+    onLog: (_level: LogLevel, message: string) => void logs.push(`${name}:${message}`),
+  });
+  return { kaja, blocks, logs, calls, asked };
+}
+
+function stub(method: string): { call: Call<string>; sends: number } {
+  const state = { sends: 0 };
+  const call = new Call(method, {}, async () => {
+    state.sends++;
+    return "sent";
+  });
+  return {
+    call,
+    get sends() {
+      return state.sends;
+    },
+  };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("two runs at once", () => {
+  it("does not let one run's standing approval send another's call", async () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+    const b = run(host, "b");
+
+    // A grants "every CreateShow this run".
+    const first = stub("Shows.CreateShow");
+    await a.kaja.approve(first.call);
+    expect(a.asked).toEqual(["a:Shows.CreateShow"]);
+
+    // B's call to the same method is B's to decide, and must be asked about.
+    const second = stub("Shows.CreateShow");
+    await b.kaja.approve(second.call);
+    expect(b.asked).toEqual(["b:Shows.CreateShow"]);
+
+    // And A's own second call still rides its standing approval.
+    const third = stub("Shows.CreateShow");
+    await a.kaja.approve(third.call);
+    expect(a.asked).toEqual(["a:Shows.CreateShow"]);
+  });
+
+  it("does not let a run starting revoke an approval another run was given", async () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+
+    await a.kaja.approve(stub("Shows.CreateShow").call);
+    // Starting a second run is what used to clear the shared set out from under
+    // the first one, so its loop began asking again halfway through.
+    run(host, "b");
+
+    await a.kaja.approve(stub("Shows.CreateShow").call);
+    expect(a.asked).toEqual(["a:Shows.CreateShow"]);
+  });
+
+  it("keeps each run's blocks and printed lines to itself", () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+    const b = run(host, "b");
+
+    a.kaja.text("from a");
+    b.kaja.text("from b");
+    a.kaja._internal.onLog(LogLevel.LEVEL_INFO, "a said so");
+    b.kaja._internal.onLog(LogLevel.LEVEL_INFO, "b said so");
+
+    expect(a.blocks.size).toBe(1);
+    expect(b.blocks.size).toBe(1);
+    expect(a.logs).toEqual(["a:a said so"]);
+    expect(b.logs).toEqual(["b:b said so"]);
+  });
+
+  it("gives each run its own input, and never the other's", () => {
+    const host = new KajaHost();
+    const linked = host.run({ ...sink(), input: { url: "https://example.test" } });
+    const pressed = host.run(sink());
+
+    expect(linked.input).toEqual({ url: "https://example.test" });
+    // Pressing Run carries no input. It used to be able to find the last link's.
+    expect(pressed.input).toEqual({});
+  });
+
+  it("aborts only the run that was stopped", () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+    const b = run(host, "b");
+    const stopping = new AbortController();
+    a.kaja._internal.abortSignal = stopping.signal;
+
+    stopping.abort();
+
+    expect(a.kaja._internal.abortSignal?.aborted).toBe(true);
+    expect(b.kaja._internal.abortSignal).toBeUndefined();
+  });
+
+  it("shares the workspace's variables, which belong to no run", () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+    const b = run(host, "b");
+
+    a.kaja.variables = { TOKEN: "secret" };
+
+    expect(b.kaja.variables.TOKEN).toBe("secret");
+    expect(host.variables.TOKEN).toBe("secret");
+  });
+});
+
+describe("a table outlives the run that drew it", () => {
+  it("pages through the run that drew it, however many others are going", async () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+    const b = run(host, "b");
+
+    // A draws a live table whose source fetches a row at a time. Every fetch is
+    // a call, and it must be recorded against A whenever the reader pages —
+    // which is long after A has finished.
+    a.kaja.table(
+      ["id"],
+      async function* () {
+        for (let i = 0; i < 100; i++) {
+          await a.kaja._internal.methodCallUpdate({
+            id: `call-${i}`,
+            appName: "shows",
+            service: { name: "Shows" },
+            method: { name: "ListShows" },
+            input: {},
+            timestamp: 0,
+          } as never);
+          yield [String(i)];
+        }
+      },
+      { pageSize: 2 },
+    );
+    await a.kaja.settleTables();
+
+    const blockId = [...a.blocks.keys()][0];
+    const afterFirstPage = a.calls.length;
+    expect(afterFirstPage).toBeGreaterThan(0);
+
+    // B is running now. Paging A's table is still A's work.
+    b.kaja.text("b is busy");
+    expect(await host.pullTable(blockId, "", afterFirstPage + 2)).toBe(true);
+
+    expect(a.calls.length).toBeGreaterThan(afterFirstPage);
+    expect(a.calls.every((call) => call.startsWith("a:"))).toBe(true);
+    expect(b.calls).toEqual([]);
+  });
+
+  it("waits only for its own tables when it settles", async () => {
+    const host = new KajaHost();
+    const a = run(host, "a");
+    const b = run(host, "b");
+
+    let released = false;
+    // B's source never finishes until the test lets it.
+    b.kaja.table(["id"], async function* () {
+      await new Promise<void>((resolve) => {
+        const wait = () => (released ? resolve() : setTimeout(wait, 1));
+        wait();
+      });
+      yield ["b"];
+    });
+
+    a.kaja.table(["id"], [["a"]]);
+    // A's settle must not be held open by a table B is still filling.
+    await a.kaja.settleTables();
+
+    released = true;
+    await b.kaja.settleTables();
+    expect(true).toBe(true);
+  });
+
+  it("keeps one budget for live tables across every run", async () => {
+    const host = new KajaHost();
+    const blockIds: string[] = [];
+
+    // Thirty live tables spread over three runs is still thirty against one
+    // budget — a map per run would have let each run hold its own MAX, so the
+    // closures the app is keeping would scale with how many scripts you ran.
+    for (let i = 0; i < 3; i++) {
+      const each = run(host, `r${i}`);
+      for (let j = 0; j < 10; j++) {
+        each.kaja.table(["id"], async function* () {
+          yield ["row"];
+        });
+      }
+      await each.kaja.settleTables();
+      for (const blockId of each.blocks.keys()) if (!blockIds.includes(blockId)) blockIds.push(blockId);
+    }
+
+    expect(blockIds.length).toBe(30);
+    expect(blockIds.filter((blockId) => host.hasLiveTable(blockId)).length).toBeLessThanOrEqual(24);
+    // And the ones let go are the oldest, so the table you just drew is the one
+    // that can still be paged.
+    expect(host.hasLiveTable(blockIds[blockIds.length - 1])).toBe(true);
+    expect(host.hasLiveTable(blockIds[0])).toBe(false);
+  });
+});
+
+function sink() {
+  return {
+    onMethodCallUpdate: () => {},
+    onAsk: () => Promise.reject(new Error("not asked")),
+    onApprove: () => Promise.reject(new Error("not approved")),
+    onBlockUpdate: () => {},
+    onLog: () => {},
+  };
+}
+
+// A call that is never claimed sends itself at the end of the tick, which is what
+// makes the approval tests above about approval rather than about timing.
+describe("the tick", () => {
+  it("still sends an unclaimed call", async () => {
+    const stubbed = stub("Shows.Ping");
+    await tick();
+    expect(stubbed.sends).toBe(1);
+  });
+});

--- a/ui/src/scriptRunner.test.ts
+++ b/ui/src/scriptRunner.test.ts
@@ -5,13 +5,13 @@ import { runScriptCaptured } from "./scriptRunner";
 import { LogLevel } from "./server/api";
 
 function makeKaja(answer: (question: AskBlock) => string = () => ""): Kaja {
-  return new Kaja(
-    () => {},
-    async (question) => answer(question),
-    async () => "approved" as const,
-    () => {},
-    () => {},
-  );
+  return new Kaja({
+    onMethodCallUpdate: () => {},
+    onAsk: async (question) => answer(question),
+    onApprove: async () => "approved" as const,
+    onBlockUpdate: () => {},
+    onLog: () => {},
+  });
 }
 
 describe("kaja.variables injection", () => {
@@ -247,13 +247,13 @@ describe("kaja.value", () => {
 describe("the console a script sees", () => {
   function withSink(): { kaja: Kaja; lines: { level: LogLevel; message: string }[] } {
     const lines: { level: LogLevel; message: string }[] = [];
-    const kaja = new Kaja(
-      () => {},
-      async () => "",
-      async () => "approved" as const,
-      () => {},
-      (level, message) => void lines.push({ level, message }),
-    );
+    const kaja = new Kaja({
+      onMethodCallUpdate: () => {},
+      onAsk: async () => "",
+      onApprove: async () => "approved" as const,
+      onBlockUpdate: () => {},
+      onLog: (level, message) => void lines.push({ level, message }),
+    });
     return { kaja, lines };
   }
 

--- a/ui/src/scriptRunner.ts
+++ b/ui/src/scriptRunner.ts
@@ -85,10 +85,10 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
           const service = app.services.find((s) => s.name === name && s.sourcePath === source.importPath);
           if (service) {
             const client = app.clients[serviceId(service)];
-            if (client) {
-              client.kaja = kaja;
-              args[alias] = client.methods;
-            }
+            // Bound to this run's Kaja, not assigned onto the shared client:
+            // two scripts running at once import the same client and must not
+            // be able to take each other's run out from under it.
+            if (client) args[alias] = client.methodsFor(kaja);
           } else if (source.enums[name]) {
             args[alias] = source.enums[name].object;
           }
@@ -105,15 +105,12 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
 // runScript runs a script and resolves once it settles, so the caller can show it
 // as running. Passing a signal lets the caller abort the calls it makes.
 export function runScript(code: string, kaja: Kaja, apps: App[], onError: (error: unknown) => void, signal?: AbortSignal): Promise<void> {
-  const clearSignal = () => {
-    if (kaja._internal.abortSignal === signal) {
-      kaja._internal.abortSignal = undefined;
-    }
-  };
+  // A standing approval covers the run it was given in and nothing further, and
+  // that is now the shape of the thing rather than a rule to remember: the Kaja
+  // is this run's, so its approvals and its signal are born and die with it.
+  // Clearing them here used to be the only guard, and it was the wrong one — it
+  // revoked whatever another run in flight had been granted.
   kaja._internal.abortSignal = signal;
-  // A standing approval covers the run it was given in and nothing further.
-  kaja._internal.approvedMethods.clear();
-  kaja._internal.sampledMethods.clear();
 
   let result: any;
   try {
@@ -136,21 +133,18 @@ export function runScript(code: string, kaja: Kaja, apps: App[], onError: (error
 
     result = func(...Object.values(args), scriptConsole(kaja._internal.onLog, deviceConsole));
   } catch (err) {
-    clearSignal();
     onError(err);
     return Promise.resolve();
   }
-  return Promise.resolve(result)
-    .then(
-      () => {},
-      (err: unknown) => {
-        // A cancelled prompt, a call that wasn't approved, or an aborted run
-        // simply stops the script; surface everything else.
-        if (err instanceof AskCancelledError || err instanceof ApprovalRejectedError || signal?.aborted) return;
-        onError(err);
-      },
-    )
-    .finally(clearSignal);
+  return Promise.resolve(result).then(
+    () => {},
+    (err: unknown) => {
+      // A cancelled prompt, a call that wasn't approved, or an aborted run
+      // simply stops the script; surface everything else.
+      if (err instanceof AskCancelledError || err instanceof ApprovalRejectedError || signal?.aborted) return;
+      onError(err);
+    },
+  );
 }
 
 export interface CapturedRun {
@@ -172,9 +166,6 @@ export async function runScriptCaptured(code: string, kaja: Kaja, apps: App[]): 
     lines.push(message);
     kaja._internal.onLog(level, message);
   }, deviceConsole);
-
-  kaja._internal.approvedMethods.clear();
-  kaja._internal.sampledMethods.clear();
 
   try {
     const { args, runCode } = prepareTask(code, kaja, apps);


### PR DESCRIPTION
Runs were kept apart by ambient state, so two at once — ⌘⏎ twice, Run on a second file, a `kaja://` link mid-script, an agent's `run_script` — read each other's slots: calls landed in the wrong console, the first run never settled, Stop reached only one, and a standing `kaja.approve` in one script sent another's writes without asking.

The run is now lexical: `beginRun` mints the run and the `Kaja` its script is handed, clients bind their methods per run, and what belongs to the app rather than a run (variables, live tables) moved to a `KajaHost` that routes a canvas page back to the run that drew the table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dvk3YvkY6jGEU2maeyf8sr)_