### PR TITLE
Unified the Scripts section, its font, and the word "draft"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,13 @@ labelled groups, and four rules hold the whole thing together.
    generated call) are cleared without asking; edited ones are never removed
    without a confirm that names them.
 
-**"Scratch" is the name in the code**, where it says precisely which storage tier
-this is (`scratches.ts`, `Scratch`, IndexedDB, unlimited, web and desktop alike);
-the UI says **Draft**, everywhere.
+**One word, in the code and in the UI alike: a draft** (`drafts.ts`, `Draft`,
+`draftTitle.ts`, IndexedDB, unlimited, web and desktop alike). "Scratch" was the
+name in the code while the storage tier was the thing worth naming; the tier is
+an implementation detail and the draft is the object, so the object's word won
+and the second vocabulary is gone. The persisted keys moved with it (`drafts`,
+`agentDraftId`, a view of `type: "draft"`) and the old ones are still **read**
+once — a rename is not a reason to lose somebody's work.
 
 - **Five verbs, each on exactly one object.** You **name** a draft, **save** a
   file, **clear** drafts, **delete** a file, and **revert** a file to saved.
@@ -80,7 +84,7 @@ the UI says **Draft**, everywhere.
   would otherwise sit on one line. The editor wraps rather than scrolling
   sideways — the pane is short on purpose, and horizontal scrolling is worse
   than vertical.
-- **A draft names itself from its own code** (`scratchTitle.ts`), which Kaja
+- **A draft names itself from its own code** (`draftTitle.ts`), which Kaja
   can do better than a chat app names conversations: the content is typed code
   against a known schema, so the title is a formatting job rather than a
   summarization one, and it comes out the same every time. `ListShows`,
@@ -109,12 +113,34 @@ the UI says **Draft**, everywhere.
   alone — they just stop compiling. Only a *rename* is followed, so the imports
   keep resolving.
 
-### The two groups
+### One section, two groups
 
 `ScriptsRegion.tsx` is the whole region; `Sidebar.tsx` is the API's catalog below
 the hairline and hands the region in as a node, because the two are different
 lists that share nothing but the panel.
 
+- **The section says its own name once, at the top.** Drafts and Files are two
+  halves of one question — what you run — and two headers floating above the app
+  tree left that to be worked out. So the region opens with **Scripts**, a 22px
+  row at `text-[13px] font-medium text-foreground`: the same register the app
+  rows below use, so Scripts and an app read as peers across the hairline. It is
+  a **title, not a node** — no chevron, and it names the `nav` through
+  `aria-labelledby` rather than repeating itself as a label. Both groups already
+  fold, so a third chevron would only be a shortcut for pressing those two, and
+  nothing indents: the title sits at 8px, left of the group chevrons, and no row
+  moves.
+- **One list of names, in one font.** Mono on a file row was doing double duty as
+  the tell for "this one is on disk"; the group label carries that now, and mono
+  inside a nav list reads as code, which is the wrong register. So every row in
+  the region — draft, file, folder, and the app tree below — is the UI font, and
+  only the **extension** is dimmed (`scriptNameParts`, `text-muted-foreground`),
+  so a file still looks like a file without shouting. Dropping `.ts` altogether
+  was the other candidate and gives up the last cue that these are things on
+  disk; keeping mono for the extension alone puts two fonts inside one word,
+  which sits unevenly at 13px. The UI font is narrower, so truncation improves
+  as well. **Mono belongs to content** — the editor, the payload panes, variable
+  values, the naming field — not to navigation, which is why the counts beside
+  the group labels are `tabular-nums` rather than mono too.
 - **Group headers are 22px rows too**, at `text-xs`, their chevrons in the same
   column as the app rows' below, and their rows indent to 24px so the group label
   and the row text share a left edge. Both groups collapse, and a collapsed one
@@ -163,17 +189,21 @@ lists that share nothing but the panel.
   one, not the one you fall into. Either way the bar offers an undo.
 - **The pile is capped, not scrolled.** Drafts draws `VISIBLE_DRAFTS` (8) rows,
   most recently opened first, with **edited ones pinned above the browsing
-  buffers** (`orderScratches`) so work never hides behind generated calls; the
+  buffers** (`orderDrafts`) so work never hides behind generated calls; the
   rest are `n more…`, which expands in place. That is what keeps the region a
   predictable share of the panel: its height is bounded by folder depth in Files,
   not by draft accumulation.
-- **The sweep is what makes unlimited work.** `pruneScratches` drops drafts that
+- **The sweep is what makes unlimited work.** `pruneDrafts` drops drafts that
   were never run and never edited past their generated form after `SWEEP_DAYS`
   (7), never touches one that is on screen, never touches the agent's row, and is
   off entirely when `sweepDrafts` is off. Anything run or edited is kept forever.
-- **A filter appears when the region earns one** — past ~15 rows. It matches names
-  and folder paths, **flattens** both groups (a tree of one match per branch is a
-  worse answer than a list), and shows the folder as a dim suffix on each hit.
+- **A filter appears when the region earns one** — past ~15 rows
+  (`FILTER_THRESHOLD`). It belongs to the **section** rather than to either
+  group, which is why it sits directly under the Scripts title and searches
+  both: it matches names and folder paths, **flattens** them (a tree of one
+  match per branch is a worse answer than a list), and shows the folder as a dim
+  suffix on each hit. Below the threshold the list is the answer, and a search
+  box is a control you have to go looking past.
 - **Empty states.** Zero drafts hides the Drafts group entirely rather than
   showing an empty label — there is nothing there and nothing to say about it.
   Zero files keeps its header and says one line: where files come from.
@@ -254,7 +284,7 @@ this".
   `clientInfo.name`, else `Agent` — captured in `desktop/mcp/server.go` and
   carried into the run), so the row reads `Claude` rather than "MCP workspace": an
   actor you recognise instead of a mechanism you translate. `agentClient` on the
-  `Scratch` is the whole of it, and `isAgentScratch` is what pins the row,
+  `Draft` is the whole of it, and `isAgentDraft` is what pins the row,
   excludes it from the count and spares it from the sweep. The `Plug` icon is
   already MCP in the status bar.
 - **The emerald dot is the only live indicator in the sidebar.** It goes out the
@@ -266,7 +296,7 @@ this".
   new one.
 - **Naming it works the same way** and does the same thing — a name and a folder —
   except the file is yours from then on. `create_script` also consumes it when
-  what was saved is exactly what was last run (`consumeAgentScratch`), on the same
+  what was saved is exactly what was last run (`consumeAgentDraft`), on the same
   rule a person's Name follows: the buffer became the file, so it doesn't linger
   as a copy, and its console follows it to the path.
 
@@ -641,7 +671,7 @@ selection, the tab and the view as they were left.
 - **Two extra channels on every row, and no third.** The **loop key**
   (`loopKey.ts`) is the identifying value read off the request — the only thing
   making two hundred identical method names tellable apart — and it shares its
-  field list with `scratchTitle` so "what identifies a call" is defined once. The
+  field list with `draftTitle` so "what identifies a call" is defined once. The
   **duration bar** is drawn against the slowest call in the run, so finding the
   slow one is a shape you see rather than four digits you read; a run with
   nothing to compare gets no bars.
@@ -1264,7 +1294,7 @@ shared between them but the protocol's name.
 - **The canvas is the output; `console.log` is where an agent probes.** Both channels exist, but they are not a pair to pick from: a script is a file someone opens and presses Run on, so what it has to say goes on the canvas, and the transcript is read by the agent that asked for the run and by nobody else. Naming them side by side is what taught an agent to end every script with `console.log(response)` — so the guide's first example draws with `kaja.text`, `runtimeNote` states the canvas first and gives `console.log` its scope (probe with it, leave it out of a script you keep), and both say the thing that makes it unnecessary: **`run_script` already reports every call's request and response**, so the only value worth printing is one the script computed. It is not removed and not discouraged in a snippet — that is the one place it is the right tool.
 - **A run reports what it drew.** An agent's run has a canvas and nobody looking at it, so `RunResult.Blocks` is the receipt — each block's kind, and a table's columns and row count (`toBlockLog` in `App.tsx`, collected through `mcpBlockCollectorRef` as the blocks are emitted). The contents are not echoed: the agent produced them.
 - **The guide is not the only channel.** `initialize` returns `instructions` (the embedded `guide.md`) and `kaja://guide` is a resource, but a client may drop or summarise either. So the script runtime contract an agent would otherwise discover by probing — top-level `await` works, there is **no return value**, `kaja.text`/`kaja.code`/`kaja.table` are the canvas a script draws its output on and `console.log` is the transcript to probe with, imports are `<app>/<path>` and **named imports only**, `prompt`/`alert`/`confirm` do nothing — is repeated in `run_script`'s **tool description**, which no client can drop.
-- **An inline run is not anonymous.** An agent probing with small snippets is the right behaviour — declarations say what the shape is, and only a real call says what the data is — so `run_script` with `code` stays cheap. What it may not be is *invisible*: an inline snippet is run in **the agent's draft** (`agentScratch` in `App.tsx`), so it has a file, and therefore a title read off its own code, a row pinned at the top of Drafts under the client's own name, and a console its runs land in beside the user's. **One buffer, reused**: eight tries at a call are eight runs of one draft, which is what makes them comparable, rather than eight rows. It is an ordinary draft in every other way — nameable, discardable — except that it is outside the count and outside the sweep; if it is cleared the next snippet starts another. `create_script` **consumes** it when what was saved is exactly what was last run (`consumeAgentScratch`, matched on content), on the same rule a person's Name follows: the buffer became the file, so it doesn't linger as a copy, and its console follows it to the path. The client's name arrives with the run (`RunScript(ctx, path, code, client)`), read off the `initialize` handshake — see **The agent's draft**.
+- **An inline run is not anonymous.** An agent probing with small snippets is the right behaviour — declarations say what the shape is, and only a real call says what the data is — so `run_script` with `code` stays cheap. What it may not be is *invisible*: an inline snippet is run in **the agent's draft** (`agentDraft` in `App.tsx`), so it has a file, and therefore a title read off its own code, a row pinned at the top of Drafts under the client's own name, and a console its runs land in beside the user's. **One buffer, reused**: eight tries at a call are eight runs of one draft, which is what makes them comparable, rather than eight rows. It is an ordinary draft in every other way — nameable, discardable — except that it is outside the count and outside the sweep; if it is cleared the next snippet starts another. `create_script` **consumes** it when what was saved is exactly what was last run (`consumeAgentDraft`, matched on content), on the same rule a person's Name follows: the buffer became the file, so it doesn't linger as a copy, and its console follows it to the path. The client's name arrives with the run (`RunScript(ctx, path, code, client)`), read off the `initialize` handshake — see **The agent's draft**.
 - **The footer says when the server is being used.** An agent works in a window nobody is watching, so the plug in the status bar is the one thing that reports it: while a request is being served it goes emerald and a ring pings out of it (`animate-signal`, sized to stay inside the 30px bar rather than Tailwind's own `ping`, which doubles the element). The **server** counts requests in flight and reports each change through `Bridge.Activity`, which the desktop emits as `mcp:activity`; the **UI** decides how long it lingers, because that is a question about being seen rather than about the protocol. A `ping` is a keepalive and doesn't count. Calls arrive in bursts of a few milliseconds, so the mark holds for `MCP_ACTIVITY_LINGER_MS` (2.5s) after the last one is answered — without it a whole burst would come and go inside one frame — and it stays lit for the whole of a long `run_script` rather than expiring under it.
 - **Nothing yet stops an agent writing.** Visibility is the whole of it for now: a snippet's calls are shown, not gated, and the `read`/`write` mark in `list_services` plus the guide's "confirm before running a write" are advice an agent may ignore. A gate belongs at the one place every call goes through (`client.ts`), keyed on something the run carries — that is where to put it when it is wanted.
 - **A failure says what to do about it.** `ui/src/callFailure.ts` classifies a call error while it still has its shape — an HTTP status, a gRPC/Twirp code, or neither — into `INVALID_REQUEST` / `UNAUTHORIZED` / `NOT_FOUND` / `RATE_LIMITED` / `SERVER` / `TRANSPORT`. Neither a status nor a code means the exchange itself broke, which is the one case where retrying with a different request is guaranteed waste. `run.go` turns each kind into the sentence that says so. **A rejected call does not throw** — it is reported and the script carries on with `undefined` in place of the response — so a script that stopped stopped on its own, usually on that `undefined` a line later, and the report says as much.

--- a/desktop/mcp/catalog.go
+++ b/desktop/mcp/catalog.go
@@ -72,7 +72,7 @@ type CatalogMethod struct {
 	HTTP      string `json:"http,omitempty"`
 	Streaming string `json:"streaming,omitempty"`
 	// The call Kaja writes for this method — the same code clicking it in the tree
-	// puts in a scratch.
+	// puts in a draft.
 	Example string `json:"example"`
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,20 +29,20 @@ import { appHeaders, appParameters, appType, buildApp } from "./appTypes";
 import { createPendingApp, getDefaultMethod, Method, App as AppModel, Script, scriptName, Service, updateAppRef } from "./apps";
 import {
   appendCall,
-  createScratch,
-  editedScratches,
+  createDraft,
+  editedDrafts,
   findUntouched,
-  isAgentScratch,
+  isAgentDraft,
   isUntouched,
   markRun,
-  pruneScratches,
+  pruneDrafts,
   reopen,
-  Scratch,
+  Draft,
   takeOver,
-  untouchedScratches,
+  untouchedDrafts,
   withCode,
-} from "./scratches";
-import { deriveScratchTitle, proposeFileName, proposeFileNames } from "./scratchTitle";
+} from "./drafts";
+import { deriveDraftTitle, proposeFileName, proposeFileNames } from "./draftTitle";
 import { methodUse, recordUse } from "./treeExpansion";
 import { generateMethodEditorCode } from "./appLoader";
 import { buildMcpCatalog } from "./mcpCatalog";
@@ -65,6 +65,7 @@ import { Configuration, ConfigurationApp, LogLevel, Runtime, VariableStatus } fr
 import { getApiClient } from "./server/connection";
 import {
   dropView,
+  persistedDraftId,
   PersistedViewState,
   restoreViews,
   serializeViews,
@@ -73,7 +74,7 @@ import {
   showAppForm,
   showCompiler,
   showDefinition,
-  showScratch,
+  showDraft,
   showScript,
   showVariables,
   View,
@@ -107,7 +108,7 @@ import { MCPScriptResult, MCPServerInfo, MCPSetCatalog, ResolvedVariables, Scrip
 import { main } from "./wailsjs/go/models";
 import { runScript, runScriptCaptured } from "./scriptRunner";
 
-// How long a discarded scratch is held before it is really gone. Nothing was on
+// How long a discarded draft is held before it is really gone. Nothing was on
 // disk, so this is undo rather than a confirmation.
 const UNDO_DISCARD_MS = 8000;
 
@@ -116,11 +117,23 @@ const UNDO_DISCARD_MS = 8000;
 // the indicator would be gone before it was seen.
 const MCP_ACTIVITY_LINGER_MS = 2500;
 
-// Scratch ids the last session had open, so start-up pruning can't drop one
+// Draft ids the last session had open, so start-up pruning can't drop one
 // that is about to reopen.
-function openScratchIds(): string[] {
+function openDraftIds(): string[] {
   const persisted = getPersistedValue<PersistedViewState>("views");
-  return (persisted?.views ?? []).flatMap((view) => ("scratchId" in view ? [view.scratchId] : []));
+  return (persisted?.views ?? []).flatMap((view) => {
+    const id = persistedDraftId(view);
+    return id === undefined ? [] : [id];
+  });
+}
+
+/**
+ * The pile, read back. Drafts were called scratches in the code until the UI's
+ * word won, so the key they were written under is read once more: a rename is
+ * not a reason to lose somebody's work.
+ */
+function persistedDrafts(): Draft[] {
+  return getPersistedValue<Draft[]>("drafts") ?? getPersistedValue<Draft[]>("scratches") ?? [];
 }
 
 // Vertical padding the editor reserves around the code (see Editor.tsx).
@@ -204,7 +217,7 @@ interface NameSheet {
   folder: string;
   // The draft being named, and its code.
   content?: string;
-  scratchId?: string;
+  draftId?: string;
   // The file being renamed or moved.
   script?: Script;
 }
@@ -238,21 +251,19 @@ export function App() {
   const variablesStateRef = useRef(variablesState);
   variablesStateRef.current = variablesState;
   const [apps, setApps] = useState<AppModel[]>([]);
-  // Every scratch ever made, newest activity first — unlimited, kept in the
+  // Every draft ever made, newest activity first — unlimited, kept in the
   // app, named from its own code. Independent of what is open: closing a view
-  // puts a scratch away, it doesn't throw it out.
+  // puts a draft away, it doesn't throw it out.
   // The weekly sweep of untouched drafts. It is what keeps an unlimited pile —
   // one row per method clicked — at a steady size, and it is read here before
   // anything else because start-up is when it runs.
   const [sweepDrafts, setSweepDrafts] = usePersistedState("sweepDrafts", true);
-  const [scratches, setScratches] = useState<Scratch[]>(() =>
-    pruneScratches(getPersistedValue<Scratch[]>("scratches") ?? [], Date.now(), new Set(openScratchIds()), getPersistedValue<boolean>("sweepDrafts") ?? true),
+  const [drafts, setDrafts] = useState<Draft[]>(() =>
+    pruneDrafts(persistedDrafts(), Date.now(), new Set(openDraftIds()), getPersistedValue<boolean>("sweepDrafts") ?? true),
   );
   // The open files, most-recently-visited first: views[0] is what the window is
   // showing. Nothing else records which file is current.
-  const [views, setViews] = useState<View[]>(() =>
-    restoreViews(getPersistedValue<PersistedViewState>("views"), getPersistedValue<Scratch[]>("scratches") ?? []),
-  );
+  const [views, setViews] = useState<View[]>(() => restoreViews(getPersistedValue<PersistedViewState>("views"), persistedDrafts()));
   // A tree of names at 22px a row needs less width than one of icons at 34px.
   const [sidebarWidth, setSidebarWidth] = usePersistedState("sidebarWidth", 240);
   const [sidebarCollapsed, setSidebarCollapsed] = usePersistedState("sidebarCollapsed", false);
@@ -285,11 +296,11 @@ export function App() {
   const [finder, setFinder] = useState<"first" | "previous">();
   const viewsRef = useRef(views);
   viewsRef.current = views;
-  const scratchesRef = useRef(scratches);
-  scratchesRef.current = scratches;
+  const draftsRef = useRef(drafts);
+  draftsRef.current = drafts;
   const editorRegistryRef = useRef(new Map<string, monaco.editor.IStandaloneCodeEditor>());
   const hasViewMemory = useRef(getPersistedValue<PersistedViewState>("views") !== undefined);
-  const viewsRestoredRef = useRef(views.some((view) => view.type === "scratch"));
+  const viewsRestoredRef = useRef(views.some((view) => view.type === "draft"));
   const [scripts, setScripts] = useState<Script[]>();
   const scriptsRef = useRef(scripts);
   scriptsRef.current = scripts;
@@ -357,7 +368,7 @@ export function App() {
   // Clearing the pile of drafts, confirmed only when it costs something: the
   // dialog appears when work would go, and names it. Nothing here can reach a
   // file.
-  const [clearDrafts, setClearDrafts] = useState<{ all: Scratch[]; edited: Scratch[] } | null>(null);
+  const [clearAllPrompt, setClearAllPrompt] = useState<{ all: Draft[]; edited: Draft[] } | null>(null);
   // A `kaja://run/…` link that arrived and is waiting to be let through.
   const [linkPrompt, setLinkPrompt] = useState<{ script: Script; input: { [key: string]: string } } | null>(null);
   /**
@@ -374,9 +385,9 @@ export function App() {
   const [activeRuns, setActiveRuns] = useState<LiveRun[]>([]);
   const activeRunsRef = useRef(activeRuns);
   activeRunsRef.current = activeRuns;
-  // A discarded scratch, held long enough to take it back. Nothing was on disk,
+  // A discarded draft, held long enough to take it back. Nothing was on disk,
   // so discarding is undoable rather than confirmed.
-  const [discarded, setDiscarded] = useState<{ scratches: { scratch: Scratch; runs?: FileConsole }[]; label: string } | null>(null);
+  const [discarded, setDiscarded] = useState<{ drafts: { draft: Draft; runs?: FileConsole }[]; label: string } | null>(null);
   const discardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Pending debounced disk writes for open script views, keyed by view id.
   const scriptSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
@@ -384,8 +395,8 @@ export function App() {
   // refreshOpenScriptEditors) or text that just came off disk, not a user edit —
   // skip the debounced disk save.
   const suppressScriptSave = useRef(new Set<string>());
-  // Pending debounced writes of scratch text back to the store, keyed by scratch id.
-  const scratchSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  // Pending debounced writes of draft text back to the store, keyed by draft id.
+  const draftSaveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
   const showFileError = useCallback((message: string) => {
     setFileError(message);
@@ -399,26 +410,26 @@ export function App() {
     );
   }, []);
 
-  // Every change to a scratch goes through here: the list is kept newest-first
-  // and written straight through, because a scratch has no save step — it is
+  // Every change to a draft goes through here: the list is kept newest-first
+  // and written straight through, because a draft has no save step — it is
   // already kept.
-  const applyScratches = useCallback((update: (scratches: Scratch[]) => Scratch[]) => {
-    const next = update(scratchesRef.current);
-    if (next === scratchesRef.current) return;
+  const applyDrafts = useCallback((update: (drafts: Draft[]) => Draft[]) => {
+    const next = update(draftsRef.current);
+    if (next === draftsRef.current) return;
     const ordered = [...next].sort((a, b) => b.updatedAt - a.updatedAt);
-    scratchesRef.current = ordered;
-    setScratches(ordered);
-    setPersistedValue("scratches", ordered);
+    draftsRef.current = ordered;
+    setDrafts(ordered);
+    setPersistedValue("drafts", ordered);
   }, []);
 
-  const updateScratch = useCallback(
-    (id: string, change: (scratch: Scratch) => Scratch) => {
-      applyScratches((list) => {
-        const index = list.findIndex((scratch) => scratch.id === id);
-        return index === -1 ? list : list.map((scratch, i) => (i === index ? change(scratch) : scratch));
+  const updateDraft = useCallback(
+    (id: string, change: (draft: Draft) => Draft) => {
+      applyDrafts((list) => {
+        const index = list.findIndex((draft) => draft.id === id);
+        return index === -1 ? list : list.map((draft, i) => (i === index ? change(draft) : draft));
       });
     },
-    [applyScratches],
+    [applyDrafts],
   );
 
   // Flush a script view's pending debounced write immediately (e.g. before its
@@ -437,7 +448,7 @@ export function App() {
 
   const disposeView = useCallback(
     (view: View) => {
-      if (view.type !== "scratch" && view.type !== "script") return;
+      if (view.type !== "draft" && view.type !== "script") return;
       flushScriptWrite(view);
       editorRegistryRef.current.delete(view.id);
       setEditorContentHeights(({ [view.id]: _removed, ...rest }) => rest);
@@ -453,7 +464,7 @@ export function App() {
     (update: (views: View[]) => View[]) => {
       const previous = viewsRef.current;
       const current = previous[0];
-      if (current?.type === "scratch" || current?.type === "script") {
+      if (current?.type === "draft" || current?.type === "script") {
         const editor = editorRegistryRef.current.get(current.id);
         if (editor) current.viewState = editor.saveViewState() ?? undefined;
       }
@@ -768,9 +779,9 @@ export function App() {
   }, []);
 
   // Refresh open task editors to trigger re-validation
-  const refreshOpenScratchEditors = useCallback(() => {
+  const refreshOpenDraftEditors = useCallback(() => {
     viewsRef.current.forEach((view) => {
-      if (view.type === "scratch") {
+      if (view.type === "draft") {
         const value = view.model.getValue();
         view.model.setValue(value);
       }
@@ -888,19 +899,19 @@ export function App() {
       setApps((prevApps) => {
         const { updatedApps, renames } = syncAppsFromConfiguration(newConfiguration, prevApps, previousVariables);
 
-        // A scratch isn't bound to an app — deleting one leaves the scratch
+        // A draft isn't bound to an app — deleting one leaves the draft
         // alone, it just stops compiling. Only a rename needs following, so the
         // imports keep resolving.
         if (renames.size > 0) {
           viewsRef.current.forEach((view) => {
-            if (view.type !== "scratch") return;
+            if (view.type !== "draft") return;
             let value = view.model.getValue();
             for (const [oldName, newName] of renames) {
               value = remapEditorCode(value, oldName, newName);
             }
             if (value !== view.model.getValue()) {
               view.model.setValue(value);
-              updateScratch(view.scratchId, (scratch) => ({ ...scratch, code: value }));
+              updateDraft(view.draftId, (draft) => ({ ...draft, code: value }));
             }
           });
         }
@@ -908,7 +919,7 @@ export function App() {
         return updatedApps;
       });
     },
-    [syncAppsFromConfiguration, updateScratch],
+    [syncAppsFromConfiguration, updateDraft],
   );
 
   // Toggling the Apps preview adds or removes the configured apps from the sidebar
@@ -970,15 +981,15 @@ export function App() {
     document.documentElement.classList.toggle("dark", colorMode === "night");
   }, [colorMode]);
 
-  // A scratch names itself from its own code, so the window follows the list
+  // A draft names itself from its own code, so the window follows the list
   // rather than the view: running or appending re-derives the title without the
   // view itself changing, and reading it through a ref would leave the window on
   // the name the row has already stopped showing.
   useEffect(() => {
     const current = views[0];
     let title = "Kaja";
-    if (current?.type === "scratch") {
-      title = `${viewIdentity(current, scratches).name} - Kaja`;
+    if (current?.type === "draft") {
+      title = `${viewIdentity(current, drafts).name} - Kaja`;
     } else if (current?.type === "script") {
       title = `${current.script.name} - Kaja`;
     }
@@ -986,7 +997,7 @@ export function App() {
     if (isWailsEnvironment()) {
       WindowSetTitle(title);
     }
-  }, [views, scratches]);
+  }, [views, drafts]);
 
   // Load the global scripts directory. Scripts are independent of apps; they
   // bind to an app at run time via their import paths. The folder is read
@@ -1033,7 +1044,7 @@ export function App() {
       // A blank script — the other half of "pick a call and Kaja writes one".
       if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "n") {
         e.preventDefault();
-        onNewScratchRef.current();
+        onNewDraftRef.current();
         return;
       }
       // The same key as the </> button in the command row, on every file that
@@ -1116,11 +1127,11 @@ export function App() {
         return;
       }
 
-      // Restored scratches were created before the source models existed, so
+      // Restored drafts were created before the source models existed, so
       // poke their editors to revalidate now that the imports resolve.
       if (viewsRestoredRef.current) {
         viewsRestoredRef.current = false;
-        refreshOpenScratchEditors();
+        refreshOpenDraftEditors();
         return;
       }
 
@@ -1146,10 +1157,10 @@ export function App() {
   });
 
   /**
-   * Clicking a method never asks what to do with it. The current scratch
+   * Clicking a method never asks what to do with it. The current draft
    * decides: an untouched one is a browsing buffer and gets taken over, a
-   * worked-in one is left alone and the call starts a new scratch — unless an
-   * untouched scratch already holds exactly this call, which is reopened rather
+   * worked-in one is left alone and the call starts a new draft — unless an
+   * untouched draft already holds exactly this call, which is reopened rather
    * than made a second time. Appending to what you already have is the
    * deliberate gesture (⌥click, or the + on the row), so it can't happen by
    * drifting.
@@ -1168,41 +1179,41 @@ export function App() {
       recordUse(methodUse(originAppName, service, method));
       const now = Date.now();
       const current = viewsRef.current[0];
-      const currentScratch = current?.type === "scratch" ? scratchesRef.current.find((s) => s.id === current.scratchId) : undefined;
+      const currentDraft = current?.type === "draft" ? draftsRef.current.find((s) => s.id === current.draftId) : undefined;
 
-      if (mode === "append" && current?.type === "scratch" && currentScratch) {
+      if (mode === "append" && current?.type === "draft" && currentDraft) {
         const merged = await formatTypeScript(appendCall(current.model.getValue(), code));
         current.model.setValue(merged);
-        updateScratch(currentScratch.id, (scratch) => withCode(scratch, merged, now));
+        updateDraft(currentDraft.id, (draft) => withCode(draft, merged, now));
         return;
       }
 
-      // An untouched scratch holding exactly this call is the buffer this click
+      // An untouched draft holding exactly this call is the buffer this click
       // would produce, so it is reopened instead. This is decided before the
       // takeover, which would otherwise be the thing that made the duplicate.
-      const held = findUntouched(scratchesRef.current, code, originAppName);
+      const held = findUntouched(draftsRef.current, code, originAppName);
       if (held) {
-        updateScratch(held.id, (scratch) => reopen(scratch, now));
-        applyViews((views) => showScratch(views, held));
+        updateDraft(held.id, (draft) => reopen(draft, now));
+        applyViews((views) => showDraft(views, held));
         return;
       }
 
-      if (currentScratch && isUntouched(currentScratch)) {
-        current.type === "scratch" && current.model.setValue(code);
-        updateScratch(currentScratch.id, (scratch) => takeOver(scratch, code, originAppName, now));
+      if (currentDraft && isUntouched(currentDraft)) {
+        current.type === "draft" && current.model.setValue(code);
+        updateDraft(currentDraft.id, (draft) => takeOver(draft, code, originAppName, now));
         return;
       }
 
-      const scratch = createScratch(code, originAppName, now);
-      applyScratches((list) => [scratch, ...list]);
-      applyViews((views) => showScratch(views, scratch));
+      const draft = createDraft(code, originAppName, now);
+      applyDrafts((list) => [draft, ...list]);
+      applyViews((views) => showDraft(views, draft));
     },
-    [applyScratches, applyViews, updateScratch],
+    [applyDrafts, applyViews, updateDraft],
   );
 
-  const onScratchSelect = useCallback(
-    (scratch: Scratch) => {
-      applyViews((views) => showScratch(views, scratch));
+  const onDraftSelect = useCallback(
+    (draft: Draft) => {
+      applyViews((views) => showDraft(views, draft));
     },
     [applyViews],
   );
@@ -1213,55 +1224,55 @@ export function App() {
    * the same mechanism for one row and for a sweep of the whole pile, because
    * they cost the same — nothing.
    */
-  const clearScratches = useCallback(
-    (list: Scratch[], label: string) => {
+  const discardDrafts = useCallback(
+    (list: Draft[], label: string) => {
       if (list.length === 0) return;
-      const ids = new Set(list.map((scratch) => scratch.id));
-      applyViews((views) => views.filter((view) => !(view.type === "scratch" && ids.has(view.scratchId))));
-      applyScratches((current) => current.filter((scratch) => !ids.has(scratch.id)));
+      const ids = new Set(list.map((draft) => draft.id));
+      applyViews((views) => views.filter((view) => !(view.type === "draft" && ids.has(view.draftId))));
+      applyDrafts((current) => current.filter((draft) => !ids.has(draft.id)));
       // The console goes with the draft, and is held alongside it so taking the
       // discard back brings the runs back too.
-      const held = list.map((scratch) => ({ scratch, runs: consoles.takeFile(scratch.id) }));
-      for (const scratch of list) dropStoredFile(scratch.id);
+      const held = list.map((draft) => ({ draft, runs: consoles.takeFile(draft.id) }));
+      for (const draft of list) dropStoredFile(draft.id);
       if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
-      setDiscarded({ scratches: held, label });
+      setDiscarded({ drafts: held, label });
       discardTimerRef.current = setTimeout(() => setDiscarded(null), UNDO_DISCARD_MS);
     },
-    [applyScratches, applyViews],
+    [applyDrafts, applyViews],
   );
 
-  const onDiscardScratch = useCallback((scratch: Scratch) => clearScratches([scratch], `Discarded ${scratch.title}`), [clearScratches]);
+  const onDiscardDraft = useCallback((draft: Draft) => discardDrafts([draft], `Discarded ${draft.title}`), [discardDrafts]);
 
   const onUndoDiscard = useCallback(() => {
     if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
     setDiscarded((held) => {
       if (held) {
-        applyScratches((list) => [...held.scratches.map((entry) => entry.scratch), ...list]);
-        for (const { scratch, runs } of held.scratches) {
+        applyDrafts((list) => [...held.drafts.map((entry) => entry.draft), ...list]);
+        for (const { draft, runs } of held.drafts) {
           if (!runs) continue;
-          consoles.putFile(scratch.id, runs);
-          saveRuns(scratch.id, runs.runs, runs.allItems());
+          consoles.putFile(draft.id, runs);
+          saveRuns(draft.id, runs.runs, runs.allItems());
         }
       }
       return null;
     });
-  }, [applyScratches]);
+  }, [applyDrafts]);
 
   // A blank script, for when you know what you want to write and don't need a
   // call to start it. The empty state names the key, so it has to exist.
-  const onNewScratch = useCallback(() => {
-    const scratch = createScratch("", undefined, Date.now());
-    applyScratches((list) => [scratch, ...list]);
-    applyViews((views) => showScratch(views, scratch));
-  }, [applyScratches, applyViews]);
-  const onNewScratchRef = useRef(onNewScratch);
-  onNewScratchRef.current = onNewScratch;
+  const onNewDraft = useCallback(() => {
+    const draft = createDraft("", undefined, Date.now());
+    applyDrafts((list) => [draft, ...list]);
+    applyViews((views) => showDraft(views, draft));
+  }, [applyDrafts, applyViews]);
+  const onNewDraftRef = useRef(onNewDraft);
+  onNewDraftRef.current = onNewDraft;
 
   /**
    * The buffer an agent explores in. A snippet it sends has no file of its own,
    * so it is given the same one every time: eight tries at a call are eight runs
-   * of one scratch — which is what makes them comparable in the history — rather
-   * than a trail of eight rows in the sidebar. It is an ordinary scratch in every
+   * of one draft — which is what makes them comparable in the history — rather
+   * than a trail of eight rows in the sidebar. It is an ordinary draft in every
    * other way, titled from its own code and free to be named or discarded; if it
    * goes, the next snippet starts another. Which one it is outlives the window,
    * or every restart would leave one more buffer behind that nothing reuses.
@@ -1270,28 +1281,28 @@ export function App() {
    * name, which pins the row above your drafts, outside the count and outside
    * the sweep, and labels it with an actor you recognise.
    */
-  const agentScratchIdRef = useRef<string | undefined>(getPersistedValue<string>("agentScratchId"));
-  const agentScratch = useCallback(
-    (code: string, client: string): Scratch => {
+  const agentDraftIdRef = useRef<string | undefined>(getPersistedValue<string>("agentDraftId") ?? getPersistedValue<string>("agentScratchId"));
+  const agentDraft = useCallback(
+    (code: string, client: string): Draft => {
       const now = Date.now();
-      const held = scratchesRef.current.find((scratch) => scratch.id === agentScratchIdRef.current);
-      // A run is the punctuation that settles a scratch, and one is about to
+      const held = draftsRef.current.find((draft) => draft.id === agentDraftIdRef.current);
+      // A run is the punctuation that settles a draft, and one is about to
       // happen — so the title is re-read from the code now, as any run does.
       // The client comes with the run, so the row wears the name of whichever
       // agent touched it last.
-      const scratch = { ...markRun(held ?? createScratch(code, undefined, now), code, now), agentClient: client };
-      agentScratchIdRef.current = scratch.id;
-      setPersistedValue("agentScratchId", scratch.id);
-      applyScratches((list) => (held ? list.map((candidate) => (candidate.id === scratch.id ? scratch : candidate)) : [scratch, ...list]));
+      const draft = { ...markRun(held ?? createDraft(code, undefined, now), code, now), agentClient: client };
+      agentDraftIdRef.current = draft.id;
+      setPersistedValue("agentDraftId", draft.id);
+      applyDrafts((list) => (held ? list.map((candidate) => (candidate.id === draft.id ? draft : candidate)) : [draft, ...list]));
       // If the buffer is on screen, it shows what is about to run in it.
-      const view = viewsRef.current.find((candidate) => candidate.type === "scratch" && candidate.scratchId === scratch.id);
-      if (view?.type === "scratch" && view.model.getValue() !== code) view.model.setValue(code);
-      return scratch;
+      const view = viewsRef.current.find((candidate) => candidate.type === "draft" && candidate.draftId === draft.id);
+      if (view?.type === "draft" && view.model.getValue() !== code) view.model.setValue(code);
+      return draft;
     },
-    [applyScratches],
+    [applyDrafts],
   );
-  const agentScratchRef = useRef(agentScratch);
-  agentScratchRef.current = agentScratch;
+  const agentDraftRef = useRef(agentDraft);
+  agentDraftRef.current = agentDraft;
 
   /**
    * The agent saved its buffer as a file, so the buffer goes with it rather than
@@ -1300,20 +1311,20 @@ export function App() {
    * script the agent wrote differently from what it ran is a new one, and the
    * buffer it explored in stays where it is.
    */
-  const consumeAgentScratch = useCallback(
+  const consumeAgentDraft = useCallback(
     (script: Script, content: string) => {
-      const id = agentScratchIdRef.current;
-      const scratch = id ? scratchesRef.current.find((candidate) => candidate.id === id) : undefined;
-      if (!id || !scratch || scratch.code !== content) return;
-      agentScratchIdRef.current = undefined;
-      setPersistedValue("agentScratchId", undefined);
-      const shown = viewsRef.current.find((view) => view.type === "scratch" && view.scratchId === id);
+      const id = agentDraftIdRef.current;
+      const draft = id ? draftsRef.current.find((candidate) => candidate.id === id) : undefined;
+      if (!id || !draft || draft.code !== content) return;
+      agentDraftIdRef.current = undefined;
+      setPersistedValue("agentDraftId", undefined);
+      const shown = viewsRef.current.find((view) => view.type === "draft" && view.draftId === id);
       applyViews((views) => (shown ? dropView(showScript(views, script, content), shown.id) : views));
-      applyScratches((list) => list.filter((candidate) => candidate.id !== id));
+      applyDrafts((list) => list.filter((candidate) => candidate.id !== id));
       consoles.renameFile(id, script.path);
       renameStoredFile(id, script.path);
     },
-    [applyScratches, applyViews],
+    [applyDrafts, applyViews],
   );
 
   /**
@@ -1325,24 +1336,24 @@ export function App() {
    * your own and stops following. The agent keeps its row and carries on.
    */
   const agentViewClient = useCallback(
-    (scratchId: string) => scratchesRef.current.find((scratch) => scratch.id === scratchId && isAgentScratch(scratch))?.agentClient,
+    (draftId: string) => draftsRef.current.find((draft) => draft.id === draftId && isAgentDraft(draft))?.agentClient,
     // The list is read through the ref, so this only has to re-run when it moves.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [scratches],
+    [drafts],
   );
 
   const onTakeOverAgentDraft = useCallback(
-    (scratchId: string) => {
-      const held = scratchesRef.current.find((scratch) => scratch.id === scratchId);
+    (draftId: string) => {
+      const held = draftsRef.current.find((draft) => draft.id === draftId);
       if (!held) return;
       const now = Date.now();
       // A copy of the code, and nothing of the attribution: it is yours from
       // here, and it counts as work rather than as another browsing buffer.
-      const mine = { ...createScratch(held.code, held.originAppName, now), title: held.title, generatedCode: "", ran: false };
-      applyScratches((list) => [mine, ...list]);
-      applyViews((views) => showScratch(views, mine));
+      const mine = { ...createDraft(held.code, held.originAppName, now), title: held.title, generatedCode: "", ran: false };
+      applyDrafts((list) => [mine, ...list]);
+      applyViews((views) => showDraft(views, mine));
     },
-    [applyScratches, applyViews],
+    [applyDrafts, applyViews],
   );
 
   const onScriptSelect = useCallback(
@@ -1528,27 +1539,27 @@ export function App() {
   const onRequestSave = useCallback(() => {
     if (!canWriteScripts()) return;
     const view = viewsRef.current[0];
-    if (view?.type !== "scratch") return;
-    const scratch = scratchesRef.current.find((candidate) => candidate.id === view.scratchId);
+    if (view?.type !== "draft") return;
+    const draft = draftsRef.current.find((candidate) => candidate.id === view.draftId);
     openNameSheet({
       verb: "name",
-      name: proposeFileName(viewIdentity(view, scratchesRef.current).name, takenNames("")),
+      name: proposeFileName(viewIdentity(view, draftsRef.current).name, takenNames("")),
       folder: lastFolderRef.current,
       content: view.model.getValue(),
-      scratchId: view.scratchId,
-      title: scratch && isAgentScratch(scratch) ? `Name what ${scratch.agentClient} wrote` : "Name this draft",
+      draftId: view.draftId,
+      title: draft && isAgentDraft(draft) ? `Name what ${draft.agentClient} wrote` : "Name this draft",
     });
   }, [openNameSheet, takenNames]);
 
-  const onNameScratch = useCallback(
-    (scratch: Scratch) =>
+  const onNameDraft = useCallback(
+    (draft: Draft) =>
       openNameSheet({
         verb: "name",
-        name: proposeFileName(scratch.title, takenNames("")),
+        name: proposeFileName(draft.title, takenNames("")),
         folder: lastFolderRef.current,
-        content: scratch.code,
-        scratchId: scratch.id,
-        title: isAgentScratch(scratch) ? `Name what ${scratch.agentClient} wrote` : "Name this draft",
+        content: draft.code,
+        draftId: draft.id,
+        title: isAgentDraft(draft) ? `Name what ${draft.agentClient} wrote` : "Name this draft",
       }),
     [openNameSheet, takenNames],
   );
@@ -1561,20 +1572,20 @@ export function App() {
    * names the work at stake.
    */
   const onClearUntouched = useCallback(() => {
-    const list = untouchedScratches(scratchesRef.current);
-    if (list.length > 0) clearScratches(list, `${list.length} untouched ${list.length === 1 ? "draft" : "drafts"} cleared`);
-  }, [clearScratches]);
+    const list = untouchedDrafts(draftsRef.current);
+    if (list.length > 0) discardDrafts(list, `${list.length} untouched ${list.length === 1 ? "draft" : "drafts"} cleared`);
+  }, [discardDrafts]);
 
   const onClearAllDrafts = useCallback(() => {
-    const all = scratchesRef.current.filter((scratch) => !isAgentScratch(scratch));
+    const all = draftsRef.current.filter((draft) => !isAgentDraft(draft));
     if (all.length === 0) return;
-    const edited = editedScratches(all);
+    const edited = editedDrafts(all);
     if (edited.length === 0) {
-      clearScratches(all, `${all.length} ${all.length === 1 ? "draft" : "drafts"} cleared`);
+      discardDrafts(all, `${all.length} ${all.length === 1 ? "draft" : "drafts"} cleared`);
       return;
     }
-    setClearDrafts({ all, edited });
-  }, [clearScratches]);
+    setClearAllPrompt({ all, edited });
+  }, [discardDrafts]);
 
   const onRequestSaveRef = useRef(onRequestSave);
   onRequestSaveRef.current = onRequestSave;
@@ -1651,15 +1662,15 @@ export function App() {
       // A saved script runs in its own console under its own name. A snippet has
       // no file, so it is given one: exploration in Kaja is a draft, and an
       // agent exploring is not a different kind of event from a person doing it.
-      const scratch = payload.path ? undefined : agentScratchRef.current(source, payload.client || "Agent");
-      const fileId = payload.path || scratch?.id;
+      const draft = payload.path ? undefined : agentDraftRef.current(source, payload.client || "Agent");
+      const fileId = payload.path || draft?.id;
       // This run's own receipt. Two agents calling run_script at once each get
       // what their own script did, because the collector reaches the run through
       // its closures rather than through a slot the later one would take.
       const collect: RunCollector = { calls: [], blocks: new Map<string, Block>() };
       const report = () => ({ methodCalls: collect.calls.map(toMethodCallLog), blocks: [...collect.blocks.values()].map(toBlockLog) });
       let result: McpRunReport;
-      const { run, kaja } = beginRunRef.current(payload.path ? payload.path.split("/").pop()! : (scratch?.title ?? "Agent script"), fileId, undefined, {
+      const { run, kaja } = beginRunRef.current(payload.path ? payload.path.split("/").pop()! : (draft?.title ?? "Agent script"), fileId, undefined, {
         origin: "agent",
         collect,
       });
@@ -1716,15 +1727,15 @@ export function App() {
         applyViews((views) => {
           const shown = showScript(views, script, content);
           // The draft became the file, so it doesn't linger as a copy.
-          const source = sheet.scratchId && shown.find((view) => view.type === "scratch" && view.scratchId === sheet.scratchId);
+          const source = sheet.draftId && shown.find((view) => view.type === "draft" && view.draftId === sheet.draftId);
           return source ? dropView(shown, source.id) : shown;
         });
-        if (sheet.scratchId) {
-          const id = sheet.scratchId;
-          applyScratches((list) => list.filter((candidate) => candidate.id !== id));
-          if (id === agentScratchIdRef.current) {
-            agentScratchIdRef.current = undefined;
-            setPersistedValue("agentScratchId", undefined);
+        if (sheet.draftId) {
+          const id = sheet.draftId;
+          applyDrafts((list) => list.filter((candidate) => candidate.id !== id));
+          if (id === agentDraftIdRef.current) {
+            agentDraftIdRef.current = undefined;
+            setPersistedValue("agentDraftId", undefined);
           }
           // Naming changes what the file is called, not what it is, so its runs
           // come along to the path it now lives at.
@@ -1749,7 +1760,7 @@ export function App() {
     } catch (err) {
       setNameSheetError(String(err));
     }
-  }, [nameSheet, applyScratches, applyViews, applyScriptRename, flushScriptWrite]);
+  }, [nameSheet, applyDrafts, applyViews, applyScriptRename, flushScriptWrite]);
 
   const onRenameScript = useCallback(
     (script: Script) => openNameSheet({ verb: "rename", name: script.name.replace(/\.ts$/, ""), folder: script.folder, script, title: "Rename file" }),
@@ -1890,7 +1901,7 @@ export function App() {
             const script: Script = { path: payload.path, name: payload.name ?? "", folder: payload.folder ?? "" };
             setScripts((prev) => (prev && !prev.some((s) => s.path === script.path) ? sortScripts([...prev, script]) : prev));
             if (script.folder) setScriptFolders((prev) => (prev.includes(script.folder) ? prev : [...prev, script.folder].sort()));
-            consumeAgentScratch(script, payload.content ?? "");
+            consumeAgentDraft(script, payload.content ?? "");
             break;
           }
           case "rename":
@@ -1905,7 +1916,7 @@ export function App() {
       },
     );
     return () => unsub();
-  }, [applyScriptRename, applyViews, removeScriptFromUI, persistViews, consumeAgentScratch]);
+  }, [applyScriptRename, applyViews, removeScriptFromUI, persistViews, consumeAgentDraft]);
 
   const onGoToDefinition = (model: monaco.editor.ITextModel, startLineNumber: number, startColumn: number) => {
     applyViews((views) => showDefinition(views, model, startLineNumber, startColumn));
@@ -1956,22 +1967,22 @@ export function App() {
         if (!editorInstance.hasTextFocus()) return;
 
         const view = viewsRef.current.find((candidate) => candidate.id === viewId);
-        if (view?.type !== "scratch") return;
-        // A scratch has no save step, so its text is written back as it is
+        if (view?.type !== "draft") return;
+        // A draft has no save step, so its text is written back as it is
         // typed — debounced, because every keystroke would be a store write.
-        const pending = scratchSaveTimers.current.get(view.scratchId);
+        const pending = draftSaveTimers.current.get(view.draftId);
         if (pending) clearTimeout(pending);
-        scratchSaveTimers.current.set(
-          view.scratchId,
+        draftSaveTimers.current.set(
+          view.draftId,
           setTimeout(() => {
-            scratchSaveTimers.current.delete(view.scratchId);
-            updateScratch(view.scratchId, (scratch) => ({ ...scratch, code: view.model.getValue(), updatedAt: Date.now() }));
+            draftSaveTimers.current.delete(view.draftId);
+            updateDraft(view.draftId, (draft) => ({ ...draft, code: view.model.getValue(), updatedAt: Date.now() }));
           }, 400),
         );
       });
       editorInstance.onDidChangeModel(report);
     },
-    [applyViews, updateScratch],
+    [applyViews, updateDraft],
   );
 
   // The </> button in the command row edits the current file as JSON: same
@@ -2000,13 +2011,13 @@ export function App() {
   toggleJsonViewRef.current = toggleJsonView;
   // The file on screen is the one Run runs, so its errors are the ones the row
   // reports — on the trigger, and as Run's reason for being disabled.
-  const syntaxErrors = useSyntaxErrors(currentView?.type === "scratch" || currentView?.type === "script" ? currentView.model : undefined);
+  const syntaxErrors = useSyntaxErrors(currentView?.type === "draft" || currentView?.type === "script" ? currentView.model : undefined);
 
   // Run the current file's editor contents. Triggered by Run in the command
   // row, by ⌘⏎ and by F5.
   const onRunCurrentTab = useCallback(() => {
     const view = viewsRef.current[0];
-    if (!view || (view.type !== "scratch" && view.type !== "script")) {
+    if (!view || (view.type !== "draft" && view.type !== "script")) {
       return;
     }
     const editor = editorRegistryRef.current.get(view.id);
@@ -2017,22 +2028,22 @@ export function App() {
     const controller = new AbortController();
     // Run names reuse the derived script names, so the console and the sidebar
     // speak the same language.
-    const title = view.type === "script" ? view.script.name : (deriveScratchTitle(code) ?? viewIdentity(view, scratchesRef.current).name);
+    const title = view.type === "script" ? view.script.name : (deriveDraftTitle(code) ?? viewIdentity(view, draftsRef.current).name);
     // Pressing Run carries no input, and this run's Kaja was born without any —
     // there is nothing a previous link could have left behind to clear.
-    const { run, kaja } = beginRun(title, view.type === "script" ? view.script.path : view.scratchId, controller);
+    const { run, kaja } = beginRun(title, view.type === "script" ? view.script.path : view.draftId, controller);
     // A live table draws its first page itself, and those calls are the run's:
     // the script is not over until they have landed, or the run would report a
     // duration that stops before the work it started.
     runScript(code, kaja, apps, reportScriptError(run), controller.signal)
       .then(() => kaja.settleTables())
       .finally(() => markSettled(run.id));
-    // A run is the punctuation that settles a scratch: it is when the title is
+    // A run is the punctuation that settles a draft: it is when the title is
     // re-read from the code, rather than jittering as you type.
-    if (view.type === "scratch") {
-      updateScratch(view.scratchId, (scratch) => markRun(scratch, code, Date.now()));
+    if (view.type === "draft") {
+      updateDraft(view.draftId, (draft) => markRun(draft, code, Date.now()));
     }
-  }, [apps, beginRun, reportScriptError, updateScratch, markSettled]);
+  }, [apps, beginRun, reportScriptError, updateDraft, markSettled]);
 
   /**
    * A generated method-call script issues its call without awaiting it, so the
@@ -2072,7 +2083,7 @@ export function App() {
 
   // Which file the console is reporting on. Everything below the editor is that
   // file's: its runs, where it was left pointing, and what it was showing.
-  const currentFileId = currentView?.type === "script" ? currentView.script.path : currentView?.type === "scratch" ? currentView.scratchId : undefined;
+  const currentFileId = currentView?.type === "script" ? currentView.script.path : currentView?.type === "draft" ? currentView.draftId : undefined;
 
   // Reopening a script gives you its code and, if we still hold them, the runs
   // it last made. They are read once and sit underneath anything run since.
@@ -2277,7 +2288,7 @@ export function App() {
     if (response.configuration) {
       applyConfiguration(response.configuration);
       // Refresh remaining editors to show broken import errors
-      refreshOpenScratchEditors();
+      refreshOpenDraftEditors();
     }
   };
 
@@ -2286,7 +2297,7 @@ export function App() {
   // the inset.
   const commandRowInset = isDesktopMac && sidebarCollapsed ? TRAFFIC_LIGHTS_INSET : 12;
 
-  const currentIsEditor = currentView?.type === "scratch" || currentView?.type === "script";
+  const currentIsEditor = currentView?.type === "draft" || currentView?.type === "script";
   const isHorizontalLayout = editorLayout === "horizontal" && currentIsEditor;
 
   const currentEditorContentHeight = currentIsEditor ? editorContentHeights[currentView.id] : undefined;
@@ -2300,7 +2311,7 @@ export function App() {
   // Where you have been, most recent first. This is the mounted-view cache read
   // as history, which is all "recent" ever meant.
   const recent: Destination[] = views.map((view) => ({
-    ...viewIdentity(view, scratches),
+    ...viewIdentity(view, drafts),
     key: view.id,
     go: () => onGoToView(view.id),
   }));
@@ -2308,7 +2319,7 @@ export function App() {
   // Everywhere else you can go. Typing narrows across both, which is what makes
   // the finder the only surface that can search the calls.
   const elsewhere = useMemo<Destination[]>(() => {
-    const shownScratches = new Set(views.filter((view) => view.type === "scratch").map((view) => view.scratchId));
+    const shownDrafts = new Set(views.filter((view) => view.type === "draft").map((view) => view.draftId));
     const shownScripts = new Set(views.filter((view) => view.type === "script").map((view) => view.script.path));
     const destinations: Destination[] = [];
 
@@ -2330,16 +2341,16 @@ export function App() {
       });
     }
 
-    for (const scratch of scratches) {
-      if (shownScratches.has(scratch.id)) continue;
+    for (const draft of drafts) {
+      if (shownDrafts.has(draft.id)) continue;
       destinations.push({
-        key: `scratch:${scratch.id}`,
-        name: scratch.title,
+        key: `draft:${draft.id}`,
+        name: draft.title,
         path: "Drafts",
-        origin: scratch.agentClient ?? scratch.originAppName ?? "",
-        icon: isAgentScratch(scratch) ? Plug : PenLine,
-        provisional: isUntouched(scratch),
-        go: () => onScratchSelect(scratch),
+        origin: draft.agentClient ?? draft.originAppName ?? "",
+        icon: isAgentDraft(draft) ? Plug : PenLine,
+        provisional: isUntouched(draft),
+        go: () => onDraftSelect(draft),
       });
     }
 
@@ -2372,7 +2383,7 @@ export function App() {
     }
 
     return destinations;
-  }, [apps, scratches, scripts, views, onScratchSelect, onScriptSelect, onMethodSelect, onVariablesClick, onShowCompileLog]);
+  }, [apps, drafts, scripts, views, onDraftSelect, onScriptSelect, onMethodSelect, onVariablesClick, onShowCompileLog]);
 
   // Which files have something in the air, so a run started on one script says
   // so while you are looking at another. Three sets the store keeps rather than
@@ -2382,20 +2393,20 @@ export function App() {
   // What the empty state offers instead of an illustration: the last few things
   // you were in. On a first run there are none and the list is simply absent.
   const recentFiles = useMemo<RecentFile[]>(() => {
-    const files: RecentFile[] = scratches.slice(0, 3).map((scratch) => ({
-      key: scratch.id,
-      name: scratch.title,
+    const files: RecentFile[] = drafts.slice(0, 3).map((draft) => ({
+      key: draft.id,
+      name: draft.title,
       icon: PenLine,
-      updatedAt: scratch.updatedAt,
+      updatedAt: draft.updatedAt,
       saved: false,
-      go: () => onScratchSelect(scratch),
+      go: () => onDraftSelect(draft),
     }));
     for (const script of scripts ?? []) {
       if (files.length >= 3) break;
       files.push({ key: script.path, name: script.name, icon: FileCode, saved: true, go: () => void onScriptSelect(script) });
     }
     return files;
-  }, [scratches, scripts, onScratchSelect, onScriptSelect]);
+  }, [drafts, scripts, onDraftSelect, onScriptSelect]);
 
   /**
    * The pair you reach for mid-edit, beside the name of what it acts on: `Name`,
@@ -2403,7 +2414,7 @@ export function App() {
    * buffer with it. Both are absent on a file, which is already on disk and
    * stays there as you type, and on the web, where nothing can write one.
    */
-  const currentDraft = currentView?.type === "scratch" ? scratches.find((scratch) => scratch.id === currentView.scratchId) : undefined;
+  const currentDraft = currentView?.type === "draft" ? drafts.find((draft) => draft.id === currentView.draftId) : undefined;
   const fileActions =
     currentDraft && canWriteScripts() ? (
       <div className="flex shrink-0 items-center gap-1">
@@ -2422,7 +2433,7 @@ export function App() {
           variant="ghost"
           size="sm"
           className="size-6 [&_svg]:size-[13px]"
-          onClick={() => onDiscardScratch(currentDraft)}
+          onClick={() => onDiscardDraft(currentDraft)}
         />
       </div>
     ) : undefined;
@@ -2491,16 +2502,16 @@ export function App() {
                   <ScriptsRegion
                     scripts={scripts ?? []}
                     folders={scriptFolders}
-                    scratches={scratches}
-                    currentScratchId={currentView?.type === "scratch" ? currentView.scratchId : undefined}
+                    drafts={drafts}
+                    currentDraftId={currentView?.type === "draft" ? currentView.draftId : undefined}
                     currentScriptPath={currentView?.type === "script" ? currentView.script.path : undefined}
                     runningFileIds={runningFiles}
                     agentFileIds={agentFiles}
                     waitingFileIds={waitingFiles}
                     canWrite={canWriteScripts()}
-                    onScratchSelect={onScratchSelect}
-                    onNameScratch={onNameScratch}
-                    onDiscardScratch={onDiscardScratch}
+                    onDraftSelect={onDraftSelect}
+                    onNameDraft={onNameDraft}
+                    onDiscardDraft={onDiscardDraft}
                     onClearUntouched={onClearUntouched}
                     onClearAllDrafts={onClearAllDrafts}
                     sweepDrafts={sweepDrafts}
@@ -2548,7 +2559,7 @@ export function App() {
               <FirstAppBlankslate onNewAppClick={onNewAppClick} canUpdateConfiguration={runtime.canUpdateConfiguration} />
             )}
             {views.length === 0 && configurationLoaded && apps.length > 0 && (
-              <NoFileBlankslate onOpenFinder={() => setFinder("first")} onNewScratch={onNewScratch} recent={recentFiles} />
+              <NoFileBlankslate onOpenFinder={() => setFinder("first")} onNewDraft={onNewDraft} recent={recentFiles} />
             )}
             {views.length > 0 && (
               <div style={{ flex: 1, display: "flex", flexDirection: isHorizontalLayout ? "row" : "column", minHeight: 0 }}>
@@ -2577,19 +2588,19 @@ export function App() {
                           expandApp={compileLogExpandApp}
                         />
                       )}
-                      {(view.type === "scratch" || view.type === "script") && (
+                      {(view.type === "draft" || view.type === "script") && (
                         <div className="relative flex min-h-0 flex-1 flex-col">
                           {/* Somebody else is writing in this one, so the editor
                               follows rather than pretending you can type into a
                               buffer that is being rewritten under you. */}
-                          {view.type === "scratch" && agentViewClient(view.scratchId) && (
+                          {view.type === "draft" && agentViewClient(view.draftId) && (
                             <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border bg-card px-3">
                               <Plug size={13} className="shrink-0 text-muted-foreground" />
-                              <span className="shrink-0 text-sm text-foreground">{agentViewClient(view.scratchId)}</span>
+                              <span className="shrink-0 text-sm text-foreground">{agentViewClient(view.draftId)}</span>
                               <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
-                                agent draft · following {agentViewClient(view.scratchId)}
+                                agent draft · following {agentViewClient(view.draftId)}
                               </span>
-                              <Button variant="outline" size="sm" className="h-6 shrink-0" onClick={() => onTakeOverAgentDraft(view.scratchId)}>
+                              <Button variant="outline" size="sm" className="h-6 shrink-0" onClick={() => onTakeOverAgentDraft(view.draftId)}>
                                 Take over
                               </Button>
                             </div>
@@ -2603,9 +2614,7 @@ export function App() {
                             onMount={(editor) => onEditorReady(view.id, editor)}
                             onGoToDefinition={onGoToDefinition}
                             viewState={view.viewState}
-                            readOnly={
-                              (view.type === "script" && !canWriteScripts()) || (view.type === "scratch" && agentViewClient(view.scratchId) !== undefined)
-                            }
+                            readOnly={(view.type === "script" && !canWriteScripts()) || (view.type === "draft" && agentViewClient(view.draftId) !== undefined)}
                           />
                         </div>
                       )}
@@ -2899,39 +2908,39 @@ export function App() {
           names the work at stake. Its two buttons are both actions, so closing
           it — Esc, the backdrop, the X — clears nothing: the safe path is the
           fast one, not the one you fall into. */}
-      {clearDrafts && (
+      {clearAllPrompt && (
         <Dialog
-          title={`Clear ${clearDrafts.all.length} ${clearDrafts.all.length === 1 ? "draft" : "drafts"}?`}
-          onClose={() => setClearDrafts(null)}
+          title={`Clear ${clearAllPrompt.all.length} ${clearAllPrompt.all.length === 1 ? "draft" : "drafts"}?`}
+          onClose={() => setClearAllPrompt(null)}
           footerButtons={[
             {
-              content: `Keep edited (${clearDrafts.all.length - clearDrafts.edited.length})`,
+              content: `Keep edited (${clearAllPrompt.all.length - clearAllPrompt.edited.length})`,
               onClick: () => {
-                const untouched = clearDrafts.all.filter((scratch) => !clearDrafts.edited.includes(scratch));
-                setClearDrafts(null);
-                clearScratches(untouched, `${untouched.length} untouched ${untouched.length === 1 ? "draft" : "drafts"} cleared`);
+                const untouched = clearAllPrompt.all.filter((draft) => !clearAllPrompt.edited.includes(draft));
+                setClearAllPrompt(null);
+                discardDrafts(untouched, `${untouched.length} untouched ${untouched.length === 1 ? "draft" : "drafts"} cleared`);
               },
             },
             {
-              content: `Clear all ${clearDrafts.all.length}`,
+              content: `Clear all ${clearAllPrompt.all.length}`,
               variant: "destructive",
               onClick: () => {
-                const all = clearDrafts.all;
-                setClearDrafts(null);
-                clearScratches(all, `${all.length} ${all.length === 1 ? "draft" : "drafts"} cleared`);
+                const all = clearAllPrompt.all;
+                setClearAllPrompt(null);
+                discardDrafts(all, `${all.length} ${all.length === 1 ? "draft" : "drafts"} cleared`);
               },
             },
           ]}
         >
           <div className="flex flex-col gap-3">
             <span className="text-sm text-muted-foreground">
-              {untouchedSentence(clearDrafts.all.length - clearDrafts.edited.length)} {clearDrafts.edited.length}{" "}
-              {clearDrafts.edited.length === 1 ? "has edits that aren't" : "have edits that aren't"} saved anywhere:
+              {untouchedSentence(clearAllPrompt.all.length - clearAllPrompt.edited.length)} {clearAllPrompt.edited.length}{" "}
+              {clearAllPrompt.edited.length === 1 ? "has edits that aren't" : "have edits that aren't"} saved anywhere:
             </span>
             <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded-md border border-border bg-card p-2">
-              {clearDrafts.edited.map((scratch) => (
-                <span key={scratch.id} className="truncate text-sm text-foreground">
-                  {scratch.title}
+              {clearAllPrompt.edited.map((draft) => (
+                <span key={draft.id} className="truncate text-sm text-foreground">
+                  {draft.title}
                 </span>
               ))}
             </div>

--- a/ui/src/NoFileBlankslate.tsx
+++ b/ui/src/NoFileBlankslate.tsx
@@ -15,7 +15,7 @@ export interface RecentFile {
 
 interface NoFileBlankslateProps {
   onOpenFinder: () => void;
-  onNewScratch: () => void;
+  onNewDraft: () => void;
   // The last few things you looked at. This is the only moment the cache behind
   // the finder is worth showing as a list.
   recent: RecentFile[];
@@ -32,7 +32,7 @@ interface NoFileBlankslateProps {
  * absent rather than an empty box, which is the right amount for someone who has
  * nothing yet.
  */
-export function NoFileBlankslate({ onOpenFinder, onNewScratch, recent }: NoFileBlankslateProps) {
+export function NoFileBlankslate({ onOpenFinder, onNewDraft, recent }: NoFileBlankslateProps) {
   const modifier = navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+";
 
   return (
@@ -63,7 +63,7 @@ export function NoFileBlankslate({ onOpenFinder, onNewScratch, recent }: NoFileB
           <span className="font-mono">{modifier}P</span> find a call
         </button>
         <div className="h-3 w-px bg-border" />
-        <button type="button" onClick={onNewScratch} className="text-xs text-muted-foreground hover:text-foreground">
+        <button type="button" onClick={onNewDraft} className="text-xs text-muted-foreground hover:text-foreground">
           <span className="font-mono">{modifier}N</span> blank script
         </button>
       </div>

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -21,29 +21,45 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import { IconButton } from "./components/icon-button";
 import { Spinner } from "./components/spinner";
 import { Script } from "./apps";
-import { isAgentScratch, isUntouched, orderScratches, Scratch, untouchedScratches, VISIBLE_DRAFTS } from "./scratches";
-import { titleParts } from "./scratchTitle";
-import { buildScriptTree, filterScripts, FolderNode, folderNameError, TreeNode, visibleRows } from "./scriptTree";
+import { isAgentDraft, isUntouched, orderDrafts, Draft, untouchedDrafts, VISIBLE_DRAFTS } from "./drafts";
+import { titleParts } from "./draftTitle";
+import { buildScriptTree, filterScripts, FolderNode, folderNameError, scriptNameParts, TreeNode, visibleRows } from "./scriptTree";
 import { usePersistedState } from "./usePersistedState";
 import { useMediaQuery } from "./useMediaQuery";
 
 /**
- * The Scripts region: two labelled groups, and four rules holding them together.
+ * Scripts: one section, two labelled groups, and four rules holding them
+ * together.
  *
  * 1. **A draft has no name and no place. A file has both.** That is the entire
  *    difference, and the group label states it. Drafts are as durable as files,
  *    so nothing about them is styled as a warning — the amber dot is gone.
  * 2. **Files never turn into drafts on their own.** Editing a saved file leaves
- *    it a file, in place, with a modified dot. There is one way into Drafts:
- *    run something that has no file yet.
+ *    it a file, in place, auto-saving as you type. There is one way into
+ *    Drafts: run something that has no file yet.
  * 3. **Naming a draft moves it into Files**, which is the one moment the model
  *    is visible.
  * 4. **Discarding is safe by default**: untouched drafts are swept without
  *    asking, edited ones are never removed without a confirm that names them.
  *
- * Only one dot survives: the hollow modified marker on a file with unsaved
- * edits. The run indicators sit in the trailing slot beside it, which is fixed,
- * so nothing under the cursor moves as a run starts.
+ * **The section is what makes those two groups one thing.** Drafts and Files
+ * are halves of a single question — what you run — and a reader who meets them
+ * as two headers floating above the app tree has to work that out. So the
+ * region says its own name once, at the top, in the register the app rows below
+ * use; the groups nest visibly under it, and the filter belongs to it rather
+ * than to either half. It is a title, not a node: both groups already fold, and
+ * a third chevron would only be a shortcut for pressing those two.
+ *
+ * **And it is one list of names, in one font.** Mono on a file row was doing
+ * double duty as the tell for "this one is on disk" — the group label carries
+ * that now, and mono inside a nav list reads as code, which is the wrong
+ * register. Every row here is the UI font; only the extension is dimmed, so a
+ * file still looks like a file without shouting. Mono belongs to content — the
+ * editor, the payload panes, the naming field — not to navigation.
+ *
+ * No dot survives at all: a draft has nothing at risk and a file auto-saves.
+ * The run indicators have the trailing slot to themselves, and it is a fixed
+ * width, so nothing under the cursor moves as a run starts.
  */
 
 // Once the region passes this many rows it earns a filter. Below it the list is
@@ -57,6 +73,10 @@ const DEPTH_INDENT = 14;
 // The chevron column a folder row spends and a file row doesn't.
 const CHEVRON_SLOT = 18;
 
+// The region's own name, in the register the app rows below use: 13px and
+// foreground, so Scripts and an app read as peers across the hairline. It takes
+// no chevron — the two groups under it already fold.
+const SECTION_TITLE = "flex h-[22px] select-none items-center px-2 text-[13px] font-medium text-foreground";
 const GROUP_HEADER = "flex h-[22px] w-full cursor-pointer select-none items-center gap-1.5 px-2 text-xs font-medium text-muted-foreground hover:bg-accent/50";
 const ROW = "group flex h-[22px] cursor-pointer select-none items-center gap-1.5 pr-1 text-[13px] outline-none focus-visible:bg-accent/50";
 const ROW_ACTION = "size-[18px] min-h-0 min-w-0 [&_svg]:size-3";
@@ -64,8 +84,8 @@ const ROW_ACTION = "size-[18px] min-h-0 min-w-0 [&_svg]:size-3";
 export interface ScriptsRegionProps {
   scripts: Script[];
   folders: string[];
-  scratches: Scratch[];
-  currentScratchId?: string;
+  drafts: Draft[];
+  currentDraftId?: string;
   currentScriptPath?: string;
   runningFileIds?: ReadonlySet<string>;
   agentFileIds?: ReadonlySet<string>;
@@ -75,9 +95,9 @@ export interface ScriptsRegionProps {
   // one, so it grows none of the controls for them either.
   canWrite: boolean;
 
-  onScratchSelect: (scratch: Scratch) => void;
-  onNameScratch: (scratch: Scratch) => void;
-  onDiscardScratch: (scratch: Scratch) => void;
+  onDraftSelect: (draft: Draft) => void;
+  onNameDraft: (draft: Draft) => void;
+  onDiscardDraft: (draft: Draft) => void;
   // The two sweeps on the Drafts header, each confirmed against the list it is
   // about to touch. Neither can reach a file.
   onClearUntouched: () => void;
@@ -99,7 +119,7 @@ export interface ScriptsRegionProps {
 }
 
 export function ScriptsRegion(props: ScriptsRegionProps) {
-  const { scripts, folders, scratches, canWrite } = props;
+  const { scripts, folders, drafts, canWrite } = props;
   const [draftsOpen, setDraftsOpen] = usePersistedState("draftsExpanded", true);
   const [filesOpen, setFilesOpen] = usePersistedState("filesExpanded", true);
   const [openFolders, setOpenFolders] = usePersistedState<string[]>("openScriptFolders", []);
@@ -108,11 +128,11 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const touch = useMediaQuery("(hover: none)");
 
-  const ordered = useMemo(() => orderScratches(scratches), [scratches]);
-  const agentDraft = ordered.find(isAgentScratch);
+  const ordered = useMemo(() => orderDrafts(drafts), [drafts]);
+  const agentDraft = ordered.find(isAgentDraft);
   // The agent's row is pinned above your own and outside the count: it isn't
   // yours, and it is not what the number is about.
-  const ownDrafts = useMemo(() => ordered.filter((scratch) => !isAgentScratch(scratch)), [ordered]);
+  const ownDrafts = useMemo(() => ordered.filter((draft) => !isAgentDraft(draft)), [ordered]);
 
   const tree = useMemo(() => buildScriptTree(scripts, folders), [scripts, folders]);
   const rowCount = useMemo(() => scripts.length + folders.length + ownDrafts.length, [scripts, folders, ownDrafts]);
@@ -127,7 +147,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
   // rename is the same row, so the interaction is learned once.
   const [folderEdit, setFolderEdit] = useState<{ parent: string; path?: string; name: string } | null>(null);
   const [scriptMenu, setScriptMenu] = useState<{ script: Script; top: number; left: number } | null>(null);
-  const [draftMenu, setDraftMenu] = useState<{ scratch: Scratch; top: number; left: number } | null>(null);
+  const [draftMenu, setDraftMenu] = useState<{ draft: Draft; top: number; left: number } | null>(null);
   const [folderMenu, setFolderMenu] = useState<{ path: string; top: number; left: number } | null>(null);
   const [filesMenu, setFilesMenu] = useState<{ top: number; left: number } | null>(null);
   const [draftsMenu, setDraftsMenu] = useState<{ top: number; left: number } | null>(null);
@@ -153,13 +173,21 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [props.onCreateFolder]);
 
-  const hasAnything = scripts.length > 0 || scratches.length > 0 || folders.length > 0;
+  const hasAnything = scripts.length > 0 || drafts.length > 0 || folders.length > 0;
   if (!hasAnything) return null;
 
   const active = (key: string) => touch || hovered === key;
 
   return (
-    <nav aria-label="Scripts">
+    <nav aria-labelledby="scripts-section">
+      {/* Said once, at the top: Drafts and Files are two halves of one thing,
+          and this is the thing. The filter below belongs to it rather than to
+          either group, which is why it searches both. It names the nav region
+          too, so the heading is stated once rather than twice. */}
+      <h2 id="scripts-section" className={SECTION_TITLE}>
+        Scripts
+      </h2>
+
       {/* The filter appears once the region is big enough to need one. It
           matches names and folder paths, flattens the result, and says how many
           it found — the one place a count lives outside the group headers,
@@ -176,7 +204,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
               aria-label="Filter scripts"
               className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
             />
-            {filtering && <span className="shrink-0 font-mono text-xs text-muted-foreground">{matches.scripts.length + matches.drafts.length}</span>}
+            {filtering && <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{matches.scripts.length + matches.drafts.length}</span>}
           </div>
         </div>
       )}
@@ -188,7 +216,9 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
           <GroupHeader
             label="Drafts"
             count={ownDrafts.length}
-            open={draftsOpen && !filtering}
+            // A filter opens both groups — the body below renders either way, so
+            // the chevron has to agree with it rather than report the fold.
+            open={draftsOpen || filtering}
             onToggle={() => setDraftsOpen((open) => !open)}
             action={
               ownDrafts.length > 0
@@ -200,33 +230,33 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
             <ul role="tree" aria-label="Drafts" className="select-none">
               {agentDraft && !filtering && (
                 <AgentRow
-                  scratch={agentDraft}
-                  current={props.currentScratchId === agentDraft.id}
+                  draft={agentDraft}
+                  current={props.currentDraftId === agentDraft.id}
                   running={props.runningFileIds?.has(agentDraft.id)}
                   waiting={props.waitingFileIds?.has(agentDraft.id)}
                   active={active(`draft:${agentDraft.id}`)}
                   canWrite={canWrite}
                   onHover={(on) => setHovered(on ? `draft:${agentDraft.id}` : null)}
-                  onSelect={() => props.onScratchSelect(agentDraft)}
-                  onName={() => props.onNameScratch(agentDraft)}
-                  onDiscard={() => props.onDiscardScratch(agentDraft)}
+                  onSelect={() => props.onDraftSelect(agentDraft)}
+                  onName={() => props.onNameDraft(agentDraft)}
+                  onDiscard={() => props.onDiscardDraft(agentDraft)}
                 />
               )}
-              {draftsShown.map((scratch) => (
+              {draftsShown.map((draft) => (
                 <DraftRow
-                  key={scratch.id}
-                  scratch={scratch}
-                  current={props.currentScratchId === scratch.id}
-                  running={props.runningFileIds?.has(scratch.id)}
-                  agent={props.agentFileIds?.has(scratch.id)}
-                  waiting={props.waitingFileIds?.has(scratch.id)}
-                  active={active(`draft:${scratch.id}`)}
+                  key={draft.id}
+                  draft={draft}
+                  current={props.currentDraftId === draft.id}
+                  running={props.runningFileIds?.has(draft.id)}
+                  agent={props.agentFileIds?.has(draft.id)}
+                  waiting={props.waitingFileIds?.has(draft.id)}
+                  active={active(`draft:${draft.id}`)}
                   canWrite={canWrite}
-                  onHover={(on) => setHovered(on ? `draft:${scratch.id}` : null)}
-                  onSelect={() => props.onScratchSelect(scratch)}
-                  onName={() => props.onNameScratch(scratch)}
-                  onDiscard={() => props.onDiscardScratch(scratch)}
-                  onMenu={(event) => setDraftMenu({ scratch, top: event.clientY, left: event.clientX })}
+                  onHover={(on) => setHovered(on ? `draft:${draft.id}` : null)}
+                  onSelect={() => props.onDraftSelect(draft)}
+                  onName={() => props.onNameDraft(draft)}
+                  onDiscard={() => props.onDiscardDraft(draft)}
+                  onMenu={(event) => setDraftMenu({ draft, top: event.clientY, left: event.clientX })}
                 />
               ))}
               {hiddenDrafts > 0 && (
@@ -248,7 +278,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
       <GroupHeader
         label="Files"
         count={scripts.length}
-        open={filesOpen && !filtering}
+        open={filesOpen || filtering}
         onToggle={() => setFilesOpen((open) => !open)}
         action={
           canWrite && (props.onCreateFolder || props.onRevealScripts)
@@ -361,7 +391,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
             them removes nothing you wrote, so it needs no confirm. */}
         <DropdownMenuItem onSelect={props.onClearUntouched}>
           Clear untouched
-          <span className="ml-auto pl-4 text-xs text-muted-foreground">{untouchedScratches(scratches).length}</span>
+          <span className="ml-auto pl-4 text-xs text-muted-foreground">{untouchedDrafts(drafts).length}</span>
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={props.onClearAllDrafts}>
           Clear all
@@ -418,14 +448,14 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
 
       <CursorMenu at={draftMenu} onClose={() => setDraftMenu(null)}>
         {canWrite && (
-          <DropdownMenuItem onSelect={() => draftMenu && props.onNameScratch(draftMenu.scratch)}>
+          <DropdownMenuItem onSelect={() => draftMenu && props.onNameDraft(draftMenu.draft)}>
             <Save size={16} />
             Name…
           </DropdownMenuItem>
         )}
         {/* Nothing is on disk to remove, so this is a discard rather than a
             delete: neutral, and undoable instead of confirmed. */}
-        <DropdownMenuItem onSelect={() => draftMenu && props.onDiscardScratch(draftMenu.scratch)}>
+        <DropdownMenuItem onSelect={() => draftMenu && props.onDiscardDraft(draftMenu.draft)}>
           <X size={16} />
           Discard
         </DropdownMenuItem>
@@ -520,13 +550,13 @@ function GroupHeader({
           }}
         />
       )}
-      <span className="min-w-3 shrink-0 text-right font-mono">{count}</span>
+      <span className="min-w-3 shrink-0 text-right tabular-nums">{count}</span>
     </div>
   );
 }
 
 function DraftRow({
-  scratch,
+  draft,
   current,
   running,
   agent,
@@ -539,7 +569,7 @@ function DraftRow({
   onDiscard,
   onMenu,
 }: {
-  scratch: Scratch;
+  draft: Draft;
   current: boolean;
   running?: boolean;
   agent?: boolean;
@@ -552,8 +582,8 @@ function DraftRow({
   onDiscard: () => void;
   onMenu: (event: React.MouseEvent) => void;
 }) {
-  const { name, qualifier } = titleParts(scratch.title);
-  const browsing = isUntouched(scratch);
+  const { name, qualifier } = titleParts(draft.title);
+  const browsing = isUntouched(draft);
 
   return (
     <li role="treeitem" aria-current={current || undefined}>
@@ -586,14 +616,14 @@ function DraftRow({
           className={cn("flex-1 truncate", browsing && !current && "text-muted-foreground")}
         >
           {name}
-          {qualifier && <span className="ml-1 font-mono text-muted-foreground opacity-70">{qualifier}</span>}
+          {qualifier && <span className="ml-1 text-muted-foreground opacity-70">{qualifier}</span>}
         </span>
         <RowTrailing running={running} agent={agent} waiting={waiting} wide={active}>
           {active && (
             <>
-              {canWrite && <RowAction icon={Save} label={`Name ${scratch.title}`} onClick={onName} />}
-              <RowAction icon={X} label={`Discard ${scratch.title}`} onClick={onDiscard} />
-              <RowAction icon={Ellipsis} label={`Actions for ${scratch.title}`} onClick={onMenu} />
+              {canWrite && <RowAction icon={Save} label={`Name ${draft.title}`} onClick={onName} />}
+              <RowAction icon={X} label={`Discard ${draft.title}`} onClick={onDiscard} />
+              <RowAction icon={Ellipsis} label={`Actions for ${draft.title}`} onClick={onMenu} />
             </>
           )}
         </RowTrailing>
@@ -610,7 +640,7 @@ function DraftRow({
  * another one.
  */
 function AgentRow({
-  scratch,
+  draft,
   current,
   running,
   waiting,
@@ -621,7 +651,7 @@ function AgentRow({
   onName,
   onDiscard,
 }: {
-  scratch: Scratch;
+  draft: Draft;
   current: boolean;
   running?: boolean;
   waiting?: boolean;
@@ -649,21 +679,21 @@ function AgentRow({
         }}
       >
         <Plug size={13} className="shrink-0 text-muted-foreground" />
-        <span className="flex-1 truncate" title={`${scratch.agentClient} is writing here · ${scratch.title}`}>
-          {scratch.agentClient}
+        <span className="flex-1 truncate" title={`${draft.agentClient} is writing here · ${draft.title}`}>
+          {draft.agentClient}
         </span>
         <span className="flex w-6 shrink-0 items-center justify-end gap-0.5">
           {active ? (
             <>
-              {canWrite && <RowAction icon={Save} label={`Name what ${scratch.agentClient} wrote`} onClick={onName} />}
-              <RowAction icon={X} label={`Clear ${scratch.agentClient}'s draft`} onClick={onDiscard} />
+              {canWrite && <RowAction icon={Save} label={`Name what ${draft.agentClient} wrote`} onClick={onName} />}
+              <RowAction icon={X} label={`Clear ${draft.agentClient}'s draft`} onClick={onDiscard} />
             </>
           ) : waiting ? (
             <span aria-hidden title="Waiting for an answer" className="size-[5px] rounded-full bg-amber-500 ring-[3px] ring-amber-500/25" />
           ) : running ? (
             // The only live indicator in the sidebar: it goes out the moment the
             // call finishes and the row stays, name and all.
-            <span aria-hidden title={`${scratch.agentClient} is running this`} className="size-[5px] rounded-full bg-emerald-500" />
+            <span aria-hidden title={`${draft.agentClient} is running this`} className="size-[5px] rounded-full bg-emerald-500" />
           ) : null}
         </span>
       </div>
@@ -848,6 +878,8 @@ function FileRow({
   onSelect: () => void;
   onMenu: (event: React.MouseEvent) => void;
 }) {
+  const { base, extension } = scriptNameParts(script.name);
+
   return (
     <li role="treeitem" aria-current={current || undefined}>
       <div
@@ -869,9 +901,15 @@ function FileRow({
           }
         }}
       >
-        <span className="flex-1 truncate font-mono">
-          {script.name}
-          {suffix && <span className="ml-1.5 font-sans text-xs text-muted-foreground">{suffix}</span>}
+        {/* The same font as a draft, a folder and the app tree below — one
+            list of names. The extension is the same three characters on every
+            row, so it is dimmed rather than shouted or dropped: the row still
+            reads as a file, and the UI font is narrower, so more of a long name
+            survives the truncation. */}
+        <span className="flex-1 truncate">
+          {base}
+          {extension && <span className="text-muted-foreground">{extension}</span>}
+          {suffix && <span className="ml-1.5 text-xs text-muted-foreground">{suffix}</span>}
         </span>
         <RowTrailing running={running} agent={agent} waiting={waiting} wide={false}>
           {active && hasMenu && <RowAction icon={Ellipsis} label={`Actions for ${script.name}`} onClick={onMenu} />}
@@ -961,7 +999,7 @@ function CursorMenu({
 
 // Filtering matches both groups at once and flattens each: a tree of one match
 // per branch is a worse answer than a list.
-function filterAll(scripts: Script[], drafts: Scratch[], query: string): { scripts: Script[]; drafts: Scratch[] } {
+function filterAll(scripts: Script[], drafts: Draft[], query: string): { scripts: Script[]; drafts: Draft[] } {
   const needle = query.trim().toLowerCase();
   if (!needle) return { scripts, drafts };
   return {

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -326,13 +326,13 @@ export function Sidebar({
                                   >
                                     {method.name}
                                     <TreeView.TrailingVisual>
-                                      {/* Adding a call to the scratch you already have open is
+                                      {/* Adding a call to the draft you already have open is
                                           deliberate, so it gets its own target rather than
                                           happening because you clicked in the wrong mood. */}
                                       {(touch || hoveredMethod === mId) && (
                                         <RowAction
                                           icon={PlusIcon}
-                                          label={`Add ${method.name} to the open scratch`}
+                                          label={`Add ${method.name} to the open draft`}
                                           onClick={() => onSelect(method, service, app, "append")}
                                         />
                                       )}

--- a/ui/src/consoles.test.ts
+++ b/ui/src/consoles.test.ts
@@ -491,10 +491,10 @@ describe("run numbering", () => {
 
 describe("renaming, taking and dropping a file", () => {
   it("moves a console to the name the file now has", () => {
-    const created = start("scratch-1");
-    store.renameFile("scratch-1", "/scripts/show.ts");
+    const created = start("draft-1");
+    store.renameFile("draft-1", "/scripts/show.ts");
 
-    expect(store.file("scratch-1").runs).toHaveLength(0);
+    expect(store.file("draft-1").runs).toHaveLength(0);
     expect(store.file("/scripts/show.ts").runs[0].id).toBe(created.id);
     expect(store.file("/scripts/show.ts").runs[0].fileId).toBe("/scripts/show.ts");
   });
@@ -507,15 +507,15 @@ describe("renaming, taking and dropping a file", () => {
   });
 
   it("hands the console back so a discard can be undone", () => {
-    start("scratch-1");
-    const taken = store.takeFile("scratch-1");
+    start("draft-1");
+    const taken = store.takeFile("draft-1");
 
-    expect(store.file("scratch-1").runs).toHaveLength(0);
+    expect(store.file("draft-1").runs).toHaveLength(0);
     expect(taken?.runs).toHaveLength(1);
 
-    store.putFile("scratch-1", taken!);
+    store.putFile("draft-1", taken!);
 
-    expect(store.file("scratch-1").runs).toHaveLength(1);
+    expect(store.file("draft-1").runs).toHaveLength(1);
   });
 
   it("drops a file outright", () => {

--- a/ui/src/consoles.ts
+++ b/ui/src/consoles.ts
@@ -355,7 +355,7 @@ export class FileConsole {
     this.touchedAt = now;
   }
 
-  // A scratch saved to disk, or a script renamed: same console, new name.
+  // A draft saved to disk, or a script renamed: same console, new name.
   rename(fileId: string): void {
     this.runs = this.runs.map((run) => ({ ...run, fileId }));
     for (const run of this.runs) {
@@ -579,7 +579,7 @@ export class Consoles {
     this.#flagsChanged();
   }
 
-  // Taking a console out, and putting it back — discarding a scratch is
+  // Taking a console out, and putting it back — discarding a draft is
   // undoable, so its runs have to be able to come back with it.
   takeFile(fileId: string): FileConsole | undefined {
     const file = this.#files.get(fileId);

--- a/ui/src/draftTitle.test.ts
+++ b/ui/src/draftTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { deriveScratchTitle, proposeFileName, proposeFileNames, readCalls, titleParts } from "./scratchTitle";
+import { deriveDraftTitle, proposeFileName, proposeFileNames, readCalls, titleParts } from "./draftTitle";
 
 const generated = (body: string, names = "TheKajaTheatre") => `import { ${names} } from "theatre/service";\n\n${body}\n`;
 
@@ -19,74 +19,74 @@ describe("readCalls", () => {
   });
 });
 
-describe("deriveScratchTitle", () => {
+describe("deriveDraftTitle", () => {
   it("is the method when the call is about nothing in particular", () => {
-    expect(deriveScratchTitle(generated(`TheKajaTheatre.ListShows({});`))).toBe("ListShows");
+    expect(deriveDraftTitle(generated(`TheKajaTheatre.ListShows({});`))).toBe("ListShows");
   });
 
   // The generated request only holds zero values, so a title only gains a
   // subject once the user has actually filled something in.
   it("ignores the zero values a generated request starts with", () => {
-    expect(deriveScratchTitle(generated(`TheKajaTheatre.GetShow({ id: "", limit: 0 });`))).toBe("GetShow");
+    expect(deriveDraftTitle(generated(`TheKajaTheatre.GetShow({ id: "", limit: 0 });`))).toBe("GetShow");
   });
 
   it("adds the identifying value once one is typed", () => {
-    expect(deriveScratchTitle(generated(`TheKajaTheatre.GetShow({ id: "vera-lune" });`))).toBe("GetShow · vera-lune");
+    expect(deriveDraftTitle(generated(`TheKajaTheatre.GetShow({ id: "vera-lune" });`))).toBe("GetShow · vera-lune");
   });
 
   it("prefers an id over a name, and finds one nested", () => {
-    expect(deriveScratchTitle(generated(`TheKajaTheatre.GetShow({ name: "Neon", show: { id: 42 } });`))).toBe("GetShow · 42");
+    expect(deriveDraftTitle(generated(`TheKajaTheatre.GetShow({ name: "Neon", show: { id: 42 } });`))).toBe("GetShow · 42");
   });
 
   it("truncates a long subject", () => {
     const code = generated(`TheKajaTheatre.GetShow({ id: "an-extremely-long-identifier-value" });`);
-    expect(deriveScratchTitle(code)).toBe("GetShow · an-extremely-long-ident…");
+    expect(deriveDraftTitle(code)).toBe("GetShow · an-extremely-long-ident…");
   });
 
   // Two explorations of the same call usually differ in their arguments, which
   // is what tells the two rows apart.
   it("describes a small request by the values that were filled in", () => {
-    expect(deriveScratchTitle(generated(`Add.Sum({ a: 5, b: 3 });`, "Add"))).toBe("Sum · 5, 3");
-    expect(deriveScratchTitle(generated(`Add.Sum({ a: 5, b: 0 });`, "Add"))).toBe("Sum · 5");
-    expect(deriveScratchTitle(generated(`Add.Sum({ a: 0, b: 0 });`, "Add"))).toBe("Sum");
+    expect(deriveDraftTitle(generated(`Add.Sum({ a: 5, b: 3 });`, "Add"))).toBe("Sum · 5, 3");
+    expect(deriveDraftTitle(generated(`Add.Sum({ a: 5, b: 0 });`, "Add"))).toBe("Sum · 5");
+    expect(deriveDraftTitle(generated(`Add.Sum({ a: 0, b: 0 });`, "Add"))).toBe("Sum");
   });
 
   it("stays quiet about a request too big to read at a glance", () => {
     const code = generated(`TheKajaTheatre.ListShows({ genre: "jazz", limit: 10, offset: 0, page: 1 });`);
-    expect(deriveScratchTitle(code)).toBe("ListShows");
+    expect(deriveDraftTitle(code)).toBe("ListShows");
   });
 
   it("stays quiet when a small request holds something that isn't a scalar", () => {
-    expect(deriveScratchTitle(generated(`Add.Sum({ a: 5, rest: [1, 2] });`, "Add"))).toBe("Sum");
+    expect(deriveDraftTitle(generated(`Add.Sum({ a: 5, rest: [1, 2] });`, "Add"))).toBe("Sum");
   });
 
   it("reads two methods as a sequence", () => {
     const code = generated(`TheKajaTheatre.ListShows({});\nTheKajaTheatre.GetShow({});`);
-    expect(deriveScratchTitle(code)).toBe("ListShows → GetShow");
+    expect(deriveDraftTitle(code)).toBe("ListShows → GetShow");
   });
 
   it("counts the rest past two", () => {
     const code = generated(`TheKajaTheatre.CreateShow({});\nTheKajaTheatre.ListShows({});\nTheKajaTheatre.GetShow({});`);
-    expect(deriveScratchTitle(code)).toBe("CreateShow +2");
+    expect(deriveDraftTitle(code)).toBe("CreateShow +2");
   });
 
   it("treats the same method called repeatedly as one method", () => {
     const code = generated(`TheKajaTheatre.GetShow({ id: "a" });\nTheKajaTheatre.GetShow({ id: "b" });`);
-    expect(deriveScratchTitle(code)).toBe("GetShow · a");
+    expect(deriveDraftTitle(code)).toBe("GetShow · a");
   });
 
   it('ignores a 64-bit zero, which is generated as the string "0"', () => {
     const code = generated(`Add.Sum({ a: "0", b: "0" });`, "Add");
-    expect(deriveScratchTitle(code)).toBe("Sum");
+    expect(deriveDraftTitle(code)).toBe("Sum");
   });
 
   it("still reads a filled 64-bit value", () => {
     const code = generated(`Add.Sum({ a: "5", b: "3" });`, "Add");
-    expect(deriveScratchTitle(code)).toBe("Sum · 5, 3");
+    expect(deriveDraftTitle(code)).toBe("Sum · 5, 3");
   });
 
   it("has nothing to say about code that calls nothing", () => {
-    expect(deriveScratchTitle(`const x = 1;`)).toBeUndefined();
+    expect(deriveDraftTitle(`const x = 1;`)).toBeUndefined();
   });
 });
 
@@ -109,9 +109,9 @@ describe("proposeFileName", () => {
     expect(proposeFileName("ListShows → GetShow")).toBe("listShows");
   });
 
-  it("has something to call a scratch that names nothing", () => {
-    expect(proposeFileName("")).toBe("scratch");
-    expect(proposeFileName("· · ·")).toBe("scratch");
+  it("has something to call a draft that names nothing", () => {
+    expect(proposeFileName("")).toBe("draft");
+    expect(proposeFileName("· · ·")).toBe("draft");
   });
 
   it("steps past what is already on disk, extension or not", () => {
@@ -136,16 +136,16 @@ describe("scripts that draw", () => {
   // is the script drawing rather than a call it made.
   it("is not named after the canvas verbs", () => {
     const code = `import { kaja } from "kaja";\nkaja.text("hello");\nkaja.table(["id"]);\nkaja.code("SELECT 1", "sql");`;
-    expect(deriveScratchTitle(code)).toBeUndefined();
+    expect(deriveDraftTitle(code)).toBeUndefined();
   });
 
   it("still names the call a drawing script makes", () => {
     const code = `import { kaja } from "kaja";\nimport { Shows } from "theatre/shows";\nkaja.text("listing");\nawait Shows.ListShows({});`;
-    expect(deriveScratchTitle(code)).toBe("ListShows");
+    expect(deriveDraftTitle(code)).toBe("ListShows");
   });
 
   it("follows the runtime through an alias", () => {
     const code = `import { kaja as k } from "kaja";\nk.text("hello");`;
-    expect(deriveScratchTitle(code)).toBeUndefined();
+    expect(deriveDraftTitle(code)).toBeUndefined();
   });
 });

--- a/ui/src/draftTitle.ts
+++ b/ui/src/draftTitle.ts
@@ -7,21 +7,21 @@ import ts from "typescript";
 const SMALL_REQUEST_FIELDS = 3;
 const MAX_SUBJECT = 24;
 
-// A call a scratch makes, in source order.
-export interface ScratchCall {
+// A call a draft makes, in source order.
+export interface DraftCall {
   service: string;
   method: string;
   // The first literal bound to an identifying field, if the call fills one in.
   subject?: string;
 }
 
-// The calls a scratch makes. Receivers are matched against what the file
+// The calls a draft makes. Receivers are matched against what the file
 // imports, so `console.log` and friends are never mistaken for a service call.
-export function readCalls(code: string): ScratchCall[] {
-  const file = ts.createSourceFile("scratch.ts", code, ts.ScriptTarget.Latest, /*setParentNodes*/ false, ts.ScriptKind.TS);
+export function readCalls(code: string): DraftCall[] {
+  const file = ts.createSourceFile("draft.ts", code, ts.ScriptTarget.Latest, /*setParentNodes*/ false, ts.ScriptKind.TS);
   const imported = importedNames(file);
   const runtime = runtimeNames(file);
-  const calls: ScratchCall[] = [];
+  const calls: DraftCall[] = [];
 
   const visit = (node: ts.Node) => {
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.expression)) {
@@ -137,8 +137,8 @@ function truncate(value: string): string {
 }
 
 /**
- * What a scratch is called, read from the code it holds. Undefined when it
- * calls nothing yet — the caller falls back to a plain "Scratch".
+ * What a draft is called, read from the code it holds. Undefined when it
+ * calls nothing yet — the caller falls back to a plain "Draft".
  *
  * This is why Kaja can name these better than a chat app names conversations:
  * the content is typed code against a known schema, so the title is a
@@ -166,7 +166,7 @@ export function proposeFileName(title: string, taken: Iterable<string> = []): st
     title
       .replace(/[^A-Za-z0-9]+/g, " ")
       .trim()
-      .split(" ")[0] || "scratch";
+      .split(" ")[0] || "draft";
   const base = word.charAt(0).toLowerCase() + word.slice(1);
   const used = new Set([...taken].map((name) => name.replace(/\.ts$/, "").toLowerCase()));
   if (!used.has(base.toLowerCase())) return base;
@@ -188,12 +188,12 @@ export function proposeFileNames(titles: string[], taken: Iterable<string> = [])
   });
 }
 
-export function deriveScratchTitle(code: string): string | undefined {
+export function deriveDraftTitle(code: string): string | undefined {
   const calls = readCalls(code);
   if (calls.length === 0) return undefined;
 
   // Calling one method three times is still about that one method.
-  const distinct: ScratchCall[] = [];
+  const distinct: DraftCall[] = [];
   for (const call of calls) {
     if (!distinct.some((other) => other.service === call.service && other.method === call.method)) distinct.push(call);
   }

--- a/ui/src/drafts.test.ts
+++ b/ui/src/drafts.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import {
   appendCall,
-  createScratch,
-  editedScratches,
+  createDraft,
+  editedDrafts,
   findUntouched,
   isUntouched,
   markRun,
-  orderScratches,
-  pruneScratches,
+  orderDrafts,
+  pruneDrafts,
   reopen,
-  Scratch,
+  Draft,
   takeOver,
-  untouchedScratches,
+  untouchedDrafts,
   withCode,
-} from "./scratches";
+} from "./drafts";
 
 const NOW = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
@@ -22,28 +22,28 @@ const listShows = `import { TheKajaTheatre } from "theatre/service";\n\nTheKajaT
 const getShow = `import { TheKajaTheatre } from "theatre/service";\n\nTheKajaTheatre.GetShow({ id: "" });\n`;
 const getSeatMap = `import { Seating } from "seating/service";\n\nSeating.GetSeatMap({});\n`;
 
-describe("createScratch", () => {
+describe("createDraft", () => {
   it("names itself from the code it was born with", () => {
-    expect(createScratch(listShows, undefined, NOW).title).toBe("ListShows");
+    expect(createDraft(listShows, undefined, NOW).title).toBe("ListShows");
   });
 
   it("falls back when the code calls nothing", () => {
-    expect(createScratch("// empty", undefined, NOW).title).toBe("Scratch");
+    expect(createDraft("// empty", undefined, NOW).title).toBe("Draft");
   });
 });
 
 describe("isUntouched", () => {
   it("is true only while the code is still what was generated and nothing has run", () => {
-    const scratch = createScratch(listShows, undefined, NOW);
-    expect(isUntouched(scratch)).toBe(true);
-    expect(isUntouched({ ...scratch, code: listShows + "// mine" })).toBe(false);
-    expect(isUntouched({ ...scratch, ran: true })).toBe(false);
+    const draft = createDraft(listShows, undefined, NOW);
+    expect(isUntouched(draft)).toBe(true);
+    expect(isUntouched({ ...draft, code: listShows + "// mine" })).toBe(false);
+    expect(isUntouched({ ...draft, ran: true })).toBe(false);
   });
 });
 
 describe("findUntouched", () => {
-  const buffer = (code: string, originAppName?: string, extra: Partial<Scratch> = {}) => ({
-    ...createScratch(code, originAppName, NOW),
+  const buffer = (code: string, originAppName?: string, extra: Partial<Draft> = {}) => ({
+    ...createDraft(code, originAppName, NOW),
     ...extra,
   });
 
@@ -57,7 +57,7 @@ describe("findUntouched", () => {
     expect(findUntouched([newest, oldest], listShows, "theatre")?.id).toBe(newest.id);
   });
 
-  it("never reaches a scratch that was worked in", () => {
+  it("never reaches a draft that was worked in", () => {
     expect(findUntouched([buffer(listShows, "theatre", { ran: true })], listShows, "theatre")).toBeUndefined();
     expect(findUntouched([buffer(listShows, "theatre", { code: listShows + "// mine" })], listShows, "theatre")).toBeUndefined();
   });
@@ -69,18 +69,18 @@ describe("findUntouched", () => {
 
 describe("reopen", () => {
   it("says the buffer is the one being browsed and settles nothing else", () => {
-    const scratch = createScratch(listShows, undefined, NOW);
-    const held = reopen(scratch, NOW + 1);
+    const draft = createDraft(listShows, undefined, NOW);
+    const held = reopen(draft, NOW + 1);
 
     expect(held.updatedAt).toBe(NOW + 1);
     expect(isUntouched(held)).toBe(true);
-    expect(held.title).toBe(scratch.title);
+    expect(held.title).toBe(draft.title);
   });
 });
 
 describe("takeOver", () => {
   it("re-points a browsing buffer at another method and renames it", () => {
-    const taken = takeOver(createScratch(listShows, undefined, NOW), getShow, undefined, NOW + 1);
+    const taken = takeOver(createDraft(listShows, undefined, NOW), getShow, undefined, NOW + 1);
     expect(taken.title).toBe("GetShow");
     expect(isUntouched(taken)).toBe(true);
   });
@@ -88,9 +88,9 @@ describe("takeOver", () => {
 
 describe("markRun", () => {
   it("re-reads the title from the code as it stands at the run", () => {
-    const scratch = createScratch(getShow, undefined, NOW);
+    const draft = createDraft(getShow, undefined, NOW);
     const filled = getShow.replace('id: ""', 'id: "vera-lune"');
-    const ran = markRun(scratch, filled, NOW + 1);
+    const ran = markRun(draft, filled, NOW + 1);
 
     expect(ran.title).toBe("GetShow · vera-lune");
     expect(ran.ran).toBe(true);
@@ -99,54 +99,54 @@ describe("markRun", () => {
 
 describe("withCode", () => {
   it("settles the title on an append, the way a run does", () => {
-    const appended = withCode(createScratch(listShows, undefined, NOW), appendCall(listShows, getShow), NOW + 1);
+    const appended = withCode(createDraft(listShows, undefined, NOW), appendCall(listShows, getShow), NOW + 1);
     expect(appended.title).toBe("ListShows → GetShow");
   });
 });
 
-describe("pruneScratches", () => {
-  const stale = (id: string, extra: Partial<Scratch> = {}): Scratch => ({
-    ...createScratch(listShows, undefined, NOW - 30 * DAY),
+describe("pruneDrafts", () => {
+  const stale = (id: string, extra: Partial<Draft> = {}): Draft => ({
+    ...createDraft(listShows, undefined, NOW - 30 * DAY),
     id,
     updatedAt: NOW - 30 * DAY,
     ...extra,
   });
 
   it("drops old browsing buffers and keeps everything that was worked in", () => {
-    const kept = pruneScratches(
-      [stale("browsed"), stale("ran", { ran: true }), stale("edited", { code: listShows + "// mine" }), createScratch(listShows, undefined, NOW)],
+    const kept = pruneDrafts(
+      [stale("browsed"), stale("ran", { ran: true }), stale("edited", { code: listShows + "// mine" }), createDraft(listShows, undefined, NOW)],
       NOW,
       new Set(),
     );
 
-    expect(kept.map((scratch) => scratch.id)).toEqual(["ran", "edited", kept[2].id]);
+    expect(kept.map((draft) => draft.id)).toEqual(["ran", "edited", kept[2].id]);
   });
 
   it("never drops one that is open", () => {
-    expect(pruneScratches([stale("browsed")], NOW, new Set(["browsed"]))).toHaveLength(1);
+    expect(pruneDrafts([stale("browsed")], NOW, new Set(["browsed"]))).toHaveLength(1);
   });
 
   // The agent's row persists with no client connected — that is how you read
   // what the last one did — so only a deliberate clear removes it.
   it("never sweeps the agent's draft", () => {
-    expect(pruneScratches([stale("agent", { agentClient: "Claude" })], NOW, new Set())).toHaveLength(1);
+    expect(pruneDrafts([stale("agent", { agentClient: "Claude" })], NOW, new Set())).toHaveLength(1);
   });
 
   it("sweeps nothing while the sweep is off", () => {
-    expect(pruneScratches([stale("browsed")], NOW, new Set(), false)).toHaveLength(1);
+    expect(pruneDrafts([stale("browsed")], NOW, new Set(), false)).toHaveLength(1);
   });
 });
 
 describe("the Drafts group", () => {
-  const draft = (id: string, updatedAt: number, extra: Partial<Scratch> = {}): Scratch => ({
-    ...createScratch(listShows, undefined, updatedAt),
+  const draft = (id: string, updatedAt: number, extra: Partial<Draft> = {}): Draft => ({
+    ...createDraft(listShows, undefined, updatedAt),
     id,
     updatedAt,
     ...extra,
   });
 
   it("pins the agent's row first, then work, then the browsing buffers", () => {
-    const ordered = orderScratches([
+    const ordered = orderDrafts([
       draft("browsed-old", NOW - 2 * DAY),
       draft("edited", NOW - 3 * DAY, { code: listShows + "// mine" }),
       draft("browsed-new", NOW),
@@ -154,15 +154,15 @@ describe("the Drafts group", () => {
       draft("ran", NOW - DAY, { ran: true }),
     ]);
 
-    expect(ordered.map((scratch) => scratch.id)).toEqual(["agent", "ran", "edited", "browsed-new", "browsed-old"]);
+    expect(ordered.map((draft) => draft.id)).toEqual(["agent", "ran", "edited", "browsed-new", "browsed-old"]);
   });
 
   // Clearing untouched drafts must not reach the agent's row or your work.
   it("counts untouched and edited without the agent's row", () => {
     const list = [draft("browsed", NOW), draft("edited", NOW, { code: listShows + "// mine" }), draft("agent", NOW, { agentClient: "Claude" })];
 
-    expect(untouchedScratches(list).map((scratch) => scratch.id)).toEqual(["browsed"]);
-    expect(editedScratches(list).map((scratch) => scratch.id)).toEqual(["edited"]);
+    expect(untouchedDrafts(list).map((draft) => draft.id)).toEqual(["browsed"]);
+    expect(editedDrafts(list).map((draft) => draft.id)).toEqual(["edited"]);
   });
 
   // Clicking a method takes over a browsing buffer of your own, never the one an

--- a/ui/src/drafts.ts
+++ b/ui/src/drafts.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { deriveScratchTitle } from "./scratchTitle";
+import { deriveDraftTitle } from "./draftTitle";
 
 // A draft that was opened, never edited and never run is a browsing buffer, not
 // work. The sweep drops one this old — weekly by default, because the steady
@@ -19,10 +19,11 @@ export const VISIBLE_DRAFTS = 8;
  * reopen exactly as a file does. Naming one is what gives it both and moves it
  * into Files.
  *
- * "Scratch" is the name in the code, where it says precisely which storage tier
- * this is; the UI says Draft.
+ * One word, in the code and in the UI alike. "Scratch" was the name here while
+ * the storage tier was the thing worth naming; the tier is an implementation
+ * detail and the draft is the object, so the object's word won.
  */
-export interface Scratch {
+export interface Draft {
   id: string;
   // Always read from the code — there is no rename, because naming a draft and
   // filing it are the same act.
@@ -49,15 +50,15 @@ export interface Scratch {
 
 let sequence = 0;
 
-export function newScratchId(): string {
+export function newDraftId(): string {
   sequence++;
-  return `scratch-${Date.now().toString(36)}-${sequence}`;
+  return `draft-${Date.now().toString(36)}-${sequence}`;
 }
 
-export function createScratch(code: string, originAppName: string | undefined, now: number): Scratch {
+export function createDraft(code: string, originAppName: string | undefined, now: number): Draft {
   return {
-    id: newScratchId(),
-    title: deriveScratchTitle(code) ?? "Scratch",
+    id: newDraftId(),
+    title: deriveDraftTitle(code) ?? "Draft",
     code,
     generatedCode: code,
     ran: false,
@@ -68,29 +69,29 @@ export function createScratch(code: string, originAppName: string | undefined, n
 }
 
 // Untouched means: still exactly what was generated, and never run. Clicking
-// another method takes such a scratch over rather than leaving a trail.
-export function isUntouched(scratch: Scratch): boolean {
-  return !scratch.ran && scratch.code === scratch.generatedCode;
+// another method takes such a draft over rather than leaving a trail.
+export function isUntouched(draft: Draft): boolean {
+  return !draft.ran && draft.code === draft.generatedCode;
 }
 
-// Two untouched scratches of the same call are one browsing buffer written
+// Two untouched drafts of the same call are one browsing buffer written
 // twice: same code, same title, same dimmed row. So a call reopens the buffer
 // that already holds it rather than adding another beside it.
-export function findUntouched(scratches: Scratch[], code: string, originAppName: string | undefined): Scratch | undefined {
-  return scratches.find((scratch) => !isAgentScratch(scratch) && isUntouched(scratch) && scratch.code === code && scratch.originAppName === originAppName);
+export function findUntouched(drafts: Draft[], code: string, originAppName: string | undefined): Draft | undefined {
+  return drafts.find((draft) => !isAgentDraft(draft) && isUntouched(draft) && draft.code === code && draft.originAppName === originAppName);
 }
 
 // Reopening is not work, so it settles nothing — it only says this buffer is
 // the one being browsed, which is what keeps it at the top of the list and out
 // of the way of the pruner.
-export function reopen(scratch: Scratch, now: number): Scratch {
-  return { ...scratch, updatedAt: now };
+export function reopen(draft: Draft, now: number): Draft {
+  return { ...draft, updatedAt: now };
 }
 
-export function takeOver(scratch: Scratch, code: string, originAppName: string | undefined, now: number): Scratch {
+export function takeOver(draft: Draft, code: string, originAppName: string | undefined, now: number): Draft {
   return {
-    ...scratch,
-    title: deriveScratchTitle(code) ?? "Scratch",
+    ...draft,
+    title: deriveDraftTitle(code) ?? "Draft",
     code,
     generatedCode: code,
     originAppName,
@@ -100,17 +101,17 @@ export function takeOver(scratch: Scratch, code: string, originAppName: string |
 
 // Adding a call is as deliberate as running one, so it settles the title the
 // same way. Typing does not — that would rename the row under the cursor.
-export function withCode(scratch: Scratch, code: string, now: number): Scratch {
-  return { ...scratch, code, title: deriveScratchTitle(code) ?? scratch.title, updatedAt: now };
+export function withCode(draft: Draft, code: string, now: number): Draft {
+  return { ...draft, code, title: deriveDraftTitle(code) ?? draft.title, updatedAt: now };
 }
 
-// A run is the punctuation that settles a scratch, so it is when the title is
+// A run is the punctuation that settles a draft, so it is when the title is
 // re-read. Doing it on every keystroke would rename the row while you type.
-export function markRun(scratch: Scratch, code: string, now: number): Scratch {
+export function markRun(draft: Draft, code: string, now: number): Draft {
   return {
-    ...scratch,
+    ...draft,
     code,
-    title: deriveScratchTitle(code) ?? scratch.title,
+    title: deriveDraftTitle(code) ?? draft.title,
     ran: true,
     updatedAt: now,
   };
@@ -119,8 +120,8 @@ export function markRun(scratch: Scratch, code: string, now: number): Scratch {
 // The agent's draft is one row, pinned above your own. It is excluded from the
 // count and from the sweep: it persists with no client connected, because that
 // is how you read what the last one did, and clearing it is one deliberate act.
-export function isAgentScratch(scratch: Scratch): boolean {
-  return scratch.agentClient !== undefined;
+export function isAgentDraft(draft: Draft): boolean {
+  return draft.agentClient !== undefined;
 }
 
 /**
@@ -128,32 +129,32 @@ export function isAgentScratch(scratch: Scratch): boolean {
  * — work never hides behind generated calls — then the browsing buffers, each
  * half most recently opened first.
  */
-export function orderScratches(scratches: Scratch[]): Scratch[] {
-  const rank = (scratch: Scratch) => (isAgentScratch(scratch) ? 0 : isUntouched(scratch) ? 2 : 1);
-  return [...scratches].sort((a, b) => rank(a) - rank(b) || b.updatedAt - a.updatedAt);
+export function orderDrafts(drafts: Draft[]): Draft[] {
+  const rank = (draft: Draft) => (isAgentDraft(draft) ? 0 : isUntouched(draft) ? 2 : 1);
+  return [...drafts].sort((a, b) => rank(a) - rank(b) || b.updatedAt - a.updatedAt);
 }
 
 // Clearing untouched drafts removes nothing you wrote: clicking the method again
 // regenerates the same code, which is why it needs no confirm.
-export function untouchedScratches(scratches: Scratch[]): Scratch[] {
-  return scratches.filter((scratch) => !isAgentScratch(scratch) && isUntouched(scratch));
+export function untouchedDrafts(drafts: Draft[]): Draft[] {
+  return drafts.filter((draft) => !isAgentDraft(draft) && isUntouched(draft));
 }
 
-export function editedScratches(scratches: Scratch[]): Scratch[] {
-  return scratches.filter((scratch) => !isAgentScratch(scratch) && !isUntouched(scratch));
+export function editedDrafts(drafts: Draft[]): Draft[] {
+  return drafts.filter((draft) => !isAgentDraft(draft) && !isUntouched(draft));
 }
 
 // Unlimited only works if the browsing buffers clear themselves out. Anything
 // run or edited is kept forever, and so is the agent's row, which nothing but a
 // deliberate clear removes.
-export function pruneScratches(scratches: Scratch[], now: number, openIds: Set<string>, sweep = true): Scratch[] {
-  if (!sweep) return scratches;
+export function pruneDrafts(drafts: Draft[], now: number, openIds: Set<string>, sweep = true): Draft[] {
+  if (!sweep) return drafts;
   const cutoff = now - SWEEP_DAYS * 24 * 60 * 60 * 1000;
-  return scratches.filter((scratch) => openIds.has(scratch.id) || isAgentScratch(scratch) || !isUntouched(scratch) || scratch.updatedAt >= cutoff);
+  return drafts.filter((draft) => openIds.has(draft.id) || isAgentDraft(draft) || !isUntouched(draft) || draft.updatedAt >= cutoff);
 }
 
 /**
- * Add a generated call to a scratch that already holds one, merging the import
+ * Add a generated call to a draft that already holds one, merging the import
  * lines instead of stacking a second copy. Edits the existing text rather than
  * reprinting it, so whatever the author wrote keeps its formatting.
  */

--- a/ui/src/loopKey.ts
+++ b/ui/src/loopKey.ts
@@ -1,6 +1,6 @@
 /**
  * Fields whose value identifies the thing a call is about. One definition, read
- * twice: `scratchTitle` reads it off the source to name a script, and the run
+ * twice: `draftTitle` reads it off the source to name a script, and the run
  * log reads it off the request to tell two hundred calls to the same method
  * apart. Ordered — an explicit id beats a name.
  */

--- a/ui/src/mcpCatalog.ts
+++ b/ui/src/mcpCatalog.ts
@@ -48,7 +48,7 @@ export interface McpMethod {
   http?: string;
   streaming?: "server" | "client" | "bidirectional";
   // The generated call, which is the same code clicking the method in the tree
-  // writes into a scratch. Not a second example generator: one method, one
+  // writes into a draft. Not a second example generator: one method, one
   // starting point, wherever you came at it from.
   example: string;
 }

--- a/ui/src/runStore.test.ts
+++ b/ui/src/runStore.test.ts
@@ -6,7 +6,7 @@ import { deserializeFile, pruneArchive, RunArchive, serializeFile, StoredFile } 
 const NOW = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
 
-const run: Run = { id: "r1", title: "ListShows", fileId: "scratch-1", startedAt: NOW, durationMs: 212 };
+const run: Run = { id: "r1", title: "ListShows", fileId: "draft-1", startedAt: NOW, durationMs: 212 };
 
 function call(output: unknown, runId = run.id, id = "item-1"): ConsoleItem {
   const methodCall = {

--- a/ui/src/runStore.ts
+++ b/ui/src/runStore.ts
@@ -248,7 +248,7 @@ export function loadRuns(fileId: string, now = Date.now()): LoadedRuns | undefin
   return stored ? deserializeFile(stored) : undefined;
 }
 
-// A scratch saved to disk, or a script renamed: same console, new name.
+// A draft saved to disk, or a script renamed: same console, new name.
 export function renameStoredFile(oldId: string, newId: string): void {
   const archive = readArchive();
   const stored = archive[oldId];

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -20,7 +20,7 @@ export interface Run {
   // header says `Run 3`, so it has to survive the oldest runs being trimmed —
   // a position in the list would renumber underneath you.
   number?: number;
-  // The file it came from — a scratch id or a script path. The console belongs
+  // The file it came from — a draft id or a script path. The console belongs
   // to the file, so this is what decides which console a run lands in. ("Source"
   // is taken: it means an app's generated proto TypeScript.)
   fileId?: string;

--- a/ui/src/scriptRunner.ts
+++ b/ui/src/scriptRunner.ts
@@ -159,7 +159,7 @@ export interface CapturedRun {
 export async function runScriptCaptured(code: string, kaja: Kaja, apps: App[]): Promise<CapturedRun> {
   const lines: string[] = [];
   // The same console the editor's Run installs, teed into the report. An agent's
-  // snippet runs in the agent's scratch, so its lines belong in that scratch's
+  // snippet runs in the agent's draft, so its lines belong in that draft's
   // console as well as in the answer: a run nobody is watching is still a run
   // somebody can go and look at.
   const captureConsole = scriptConsole((level, message) => {

--- a/ui/src/scriptTree.test.ts
+++ b/ui/src/scriptTree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Script } from "./apps";
-import { buildScriptTree, fileRowCount, filterScripts, folderNameError, folderPaths, TreeNode, visibleRows } from "./scriptTree";
+import { buildScriptTree, fileRowCount, filterScripts, folderNameError, folderPaths, scriptNameParts, TreeNode, visibleRows } from "./scriptTree";
 
 function script(folder: string, name: string): Script {
   return { path: `/w/scripts/${folder ? folder + "/" : ""}${name}`, name, folder };
@@ -55,6 +55,16 @@ describe("fileRowCount", () => {
   it("counts folders and files, which is what decides whether the filter earns its row", () => {
     expect(fileRowCount([script("reports/weekly", "usage.ts")], [])).toBe(3);
     expect(fileRowCount([], ["a", "b"])).toBe(2);
+  });
+});
+
+describe("scriptNameParts", () => {
+  it("splits the extension off, and leaves a name that has none alone", () => {
+    expect(scriptNameParts("churn.ts")).toEqual({ base: "churn", extension: ".ts" });
+    expect(scriptNameParts("markdown-log-entry.ts")).toEqual({ base: "markdown-log-entry", extension: ".ts" });
+    expect(scriptNameParts("notes.d.ts")).toEqual({ base: "notes.d", extension: ".ts" });
+    expect(scriptNameParts("README")).toEqual({ base: "README", extension: "" });
+    expect(scriptNameParts(".gitignore")).toEqual({ base: ".gitignore", extension: "" });
   });
 });
 

--- a/ui/src/scriptTree.ts
+++ b/ui/src/scriptTree.ts
@@ -118,6 +118,19 @@ export function fileRowCount(scripts: Script[], folders: string[]): number {
   return paths.size + scripts.length;
 }
 
+/**
+ * A file's name split from its type. The sidebar is one list of names in one
+ * font — mono was doing the work of saying "this one is on disk" and the group
+ * label says that now — so the extension is drawn dim rather than dropped: it is
+ * the same three characters on every row, and a file still looks like a file
+ * without shouting. A name with no extension (or one that is nothing but an
+ * extension) is all name.
+ */
+export function scriptNameParts(name: string): { base: string; extension: string } {
+  const at = name.lastIndexOf(".");
+  return at <= 0 ? { base: name, extension: "" } : { base: name.slice(0, at), extension: name.slice(at) };
+}
+
 export function folderName(path: string): string {
   const at = path.lastIndexOf("/");
   return at === -1 ? path : path.slice(at + 1);

--- a/ui/src/views.test.ts
+++ b/ui/src/views.test.ts
@@ -8,8 +8,8 @@ function view(id: string, seq: number): View {
   return { type: "compiler", id, seq };
 }
 
-function scratchView(id: string, scratchId: string): View {
-  return { type: "scratch", id, seq: 1, scratchId, model: {} as any };
+function draftView(id: string, draftId: string): View {
+  return { type: "draft", id, seq: 1, draftId, model: {} as any };
 }
 
 describe("visit", () => {
@@ -64,9 +64,9 @@ describe("the mounted cache", () => {
 });
 
 describe("viewIdentity", () => {
-  it("takes a scratch's name from the store, so the two can't drift apart", () => {
-    const scratch = { id: "s1", title: "GetShow · vera-lune", originAppName: "theatre" } as any;
-    const identity = viewIdentity(scratchView("scratch-1", "s1"), [scratch]);
+  it("takes a draft's name from the store, so the two can't drift apart", () => {
+    const draft = { id: "s1", title: "GetShow · vera-lune", originAppName: "theatre" } as any;
+    const identity = viewIdentity(draftView("draft-1", "s1"), [draft]);
 
     expect(identity.name).toBe("GetShow · vera-lune");
     expect(identity.path).toBe("Drafts");
@@ -75,25 +75,25 @@ describe("viewIdentity", () => {
 });
 
 describe("serializeViews", () => {
-  it("stores which scratch a view shows, never its code", () => {
-    const views: View[] = [scratchView("scratch-1", "s1")];
+  it("stores which draft a view shows, never its code", () => {
+    const views: View[] = [draftView("draft-1", "s1")];
     const result = serializeViews(views, () => undefined);
 
-    expect(result.views).toEqual([{ type: "scratch", scratchId: "s1", viewState: undefined }]);
+    expect(result.views).toEqual([{ type: "draft", draftId: "s1", viewState: undefined }]);
   });
 
   // The log reports on this session's apps, so it is not somewhere kaja can
   // start: it is left out on the way down, and skipped on the way back up when
   // an older build wrote one.
   it("leaves the compile log out, and doesn't restore a stored one", () => {
-    const views: View[] = [view("compiler-1", 1), scratchView("scratch-1", "s1")];
-    expect(serializeViews(views, () => undefined).views).toEqual([{ type: "scratch", scratchId: "s1", viewState: undefined }]);
+    const views: View[] = [view("compiler-1", 1), draftView("draft-1", "s1")];
+    expect(serializeViews(views, () => undefined).views).toEqual([{ type: "draft", draftId: "s1", viewState: undefined }]);
 
     expect(restoreViews({ views: [{ type: "compiler" } as any] }, [])).toEqual([]);
   });
 
   it("uses live editor view state over stored view state", () => {
     const live = { cursorState: [{ position: { lineNumber: 5 } }] } as any;
-    expect((serializeViews([scratchView("scratch-1", "s1")], () => live).views[0] as any).viewState).toBe(live);
+    expect((serializeViews([draftView("draft-1", "s1")], () => live).views[0] as any).viewState).toBe(live);
   });
 });

--- a/ui/src/views.ts
+++ b/ui/src/views.ts
@@ -2,7 +2,7 @@ import { Braces, FileCode, PenLine, ScrollText, Settings, type LucideIcon } from
 import * as monaco from "monaco-editor";
 import { appType, appTypeLabel, getAppType } from "./appTypes";
 import { Script } from "./apps";
-import { isUntouched, Scratch } from "./scratches";
+import { isUntouched, Draft } from "./drafts";
 import { ConfigurationApp } from "./server/api";
 
 // How many views the pane keeps mounted. There is no "open files" set: this is
@@ -25,12 +25,12 @@ export interface CompilerView extends ViewBase {
   type: "compiler";
 }
 
-// A window onto a scratch. The scratch itself lives in the scratch store and
+// A window onto a draft. The draft itself lives in the draft store and
 // outlives the view — navigating away puts the buffer down, it doesn't throw
 // the work out.
-export interface ScratchView extends ViewBase {
-  type: "scratch";
-  scratchId: string;
+export interface DraftView extends ViewBase {
+  type: "draft";
+  draftId: string;
   model: monaco.editor.ITextModel;
   viewState?: monaco.editor.ICodeEditorViewState;
 }
@@ -69,7 +69,7 @@ export interface VariablesView extends ViewBase {
   editMode: "table" | "json";
 }
 
-export type View = CompilerView | ScratchView | DefinitionView | AppFormView | ScriptView | VariablesView;
+export type View = CompilerView | DraftView | DefinitionView | AppFormView | ScriptView | VariablesView;
 
 let sequence = 0;
 
@@ -78,7 +78,7 @@ function nextView(type: string): ViewBase {
   return { id: `${type}-${sequence}`, seq: sequence };
 }
 
-// A scratch keeps the same model URI across sessions, so its identity in the
+// A draft keeps the same model URI across sessions, so its identity in the
 // editor is the same one the store uses.
 function editorModel(uri: string, code: string): monaco.editor.ITextModel {
   const parsed = monaco.Uri.parse("ts:/" + uri + ".ts");
@@ -118,7 +118,7 @@ function show(views: View[], view: View): View[] {
 
 // Taking a view out of the cache: the document it showed is untouched, this
 // only stops rendering it (the app it belonged to went away, a preview was
-// switched off, the scratch was deleted).
+// switched off, the draft was deleted).
 export function dropView(views: View[], id: string): View[] {
   return views.filter((view) => view.id !== id);
 }
@@ -129,11 +129,11 @@ function update<T extends View>(views: View[], id: string, type: T["type"], chan
 
 // --- Opening ---
 
-export function showScratch(views: View[], scratch: Scratch): View[] {
-  const existing = views.find((view) => view.type === "scratch" && view.scratchId === scratch.id);
+export function showDraft(views: View[], draft: Draft): View[] {
+  const existing = views.find((view) => view.type === "draft" && view.draftId === draft.id);
   if (existing) return visit(views, existing.id);
 
-  return show(views, { ...nextView("scratch"), type: "scratch", scratchId: scratch.id, model: editorModel(scratch.id, scratch.code) });
+  return show(views, { ...nextView("draft"), type: "draft", draftId: draft.id, model: editorModel(draft.id, draft.code) });
 }
 
 export function showScript(views: View[], script: Script, content: string): View[] {
@@ -196,19 +196,19 @@ export interface ViewIdentity {
   provisional?: boolean;
 }
 
-export function viewIdentity(view: View, scratches: Scratch[] = []): ViewIdentity {
+export function viewIdentity(view: View, drafts: Draft[] = []): ViewIdentity {
   switch (view.type) {
-    case "scratch": {
-      // The scratch store owns the name — it is read from the code, so the view
+    case "draft": {
+      // The draft store owns the name — it is read from the code, so the view
       // can't have its own copy without the two drifting apart. Same vocabulary
       // as a saved script: only the icon says it isn't on disk.
-      const scratch = scratches.find((candidate) => candidate.id === view.scratchId);
+      const draft = drafts.find((candidate) => candidate.id === view.draftId);
       return {
-        name: scratch?.title ?? "Scratch",
+        name: draft?.title ?? "Draft",
         path: "Drafts",
-        origin: scratch?.originAppName ?? "",
+        origin: draft?.originAppName ?? "",
         icon: PenLine,
-        provisional: scratch !== undefined && isUntouched(scratch),
+        provisional: draft !== undefined && isUntouched(draft),
       };
     }
     case "script":
@@ -251,9 +251,9 @@ function appFormIcon(view: AppFormView): LucideIcon {
 
 // --- Persistence ---
 
-interface PersistedScratchView {
-  type: "scratch";
-  scratchId: string;
+interface PersistedDraftView {
+  type: "draft";
+  draftId: string;
   viewState?: object;
 }
 
@@ -266,7 +266,25 @@ interface PersistedScriptView {
   viewState?: object;
 }
 
-type PersistedView = PersistedScratchView | PersistedScriptView;
+/**
+ * What a build from before the word changed wrote for a draft. Read, never
+ * written: the rename is in the code and in the UI, and a workspace that had
+ * drafts open is not the place to make the point.
+ */
+interface LegacyScratchView {
+  type: "scratch";
+  scratchId: string;
+  viewState?: object;
+}
+
+type PersistedView = PersistedDraftView | PersistedScriptView | LegacyScratchView;
+
+// The draft a persisted view is a window onto, under either spelling.
+export function persistedDraftId(view: PersistedView): string | undefined {
+  if (view.type === "draft") return view.draftId;
+  if (view.type === "scratch") return view.scratchId;
+  return undefined;
+}
 
 // The visit order is the order of the list, so nothing else has to be stored:
 // what was on screen is what restores first.
@@ -284,8 +302,8 @@ export function serializeViews(views: View[], getViewState: (id: string) => mona
   const serialized: PersistedView[] = [];
 
   for (const view of views) {
-    if (view.type === "scratch") {
-      serialized.push({ type: "scratch", scratchId: view.scratchId, viewState: (getViewState(view.id) ?? view.viewState) as object | undefined });
+    if (view.type === "draft") {
+      serialized.push({ type: "draft", draftId: view.draftId, viewState: (getViewState(view.id) ?? view.viewState) as object | undefined });
     } else if (view.type === "script") {
       serialized.push({
         type: "script",
@@ -301,7 +319,7 @@ export function serializeViews(views: View[], getViewState: (id: string) => mona
   return { views: serialized };
 }
 
-export function restoreViews(state: PersistedViewState | undefined, scratches: Scratch[]): View[] {
+export function restoreViews(state: PersistedViewState | undefined, drafts: Draft[]): View[] {
   const views: View[] = [];
 
   for (const persisted of state?.views ?? []) {
@@ -318,17 +336,18 @@ export function restoreViews(state: PersistedViewState | undefined, scratches: S
     }
 
     // State written by a build that persisted the compile log still names it.
-    if (persisted.type !== "scratch") continue;
+    const draftId = persistedDraftId(persisted);
+    if (draftId === undefined) continue;
 
-    // A scratch pruned while its view was cached simply doesn't come back.
-    const scratch = scratches.find((candidate) => candidate.id === persisted.scratchId);
-    if (!scratch) continue;
+    // A draft pruned while its view was cached simply doesn't come back.
+    const draft = drafts.find((candidate) => candidate.id === draftId);
+    if (!draft) continue;
 
     views.push({
-      ...nextView("scratch"),
-      type: "scratch",
-      scratchId: scratch.id,
-      model: editorModel(scratch.id, scratch.code),
+      ...nextView("draft"),
+      type: "draft",
+      draftId: draft.id,
+      model: editorModel(draft.id, draft.code),
       viewState: persisted.viewState as monaco.editor.ICodeEditorViewState | undefined,
     });
   }


### PR DESCRIPTION
Drafts and Files now sit under one **Scripts** title with the filter above them, and every row is the UI font with only the `.ts` dimmed. "Scratch" is gone from the code — the object is a draft everywhere, and the old persisted keys are still read once so a workspace keeps its drafts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEojGFR8LhhaxeKZGDs883)_