### PR TITLE
Gave Apps a band of its own, so Scripts is a section rather than the panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - When I prompt you to make changes that are radically different from what's documented here, please update this file accordingly.
 - Don't commit changes to `kaja.json`
 - The server serves its workspace read-only; `scripts/server --editable` is what lets the UI write to `kaja.json`. The desktop app owns its workspace and is always editable. This is decided at startup only — a configuration file never says whether it may be edited.
-  - **A read-only configuration doesn't offer the verbs that write it.** Editing an app can be refused halfway — the form is still worth opening to read what an app is configured as, so it keeps its banner and its fields are disabled. Creating one can't: there is nothing to read in a blank form whose only button can never be pressed. So `canUpdateConfiguration` false takes the sidebar's **+** and an app's **Delete** away entirely rather than disabling them, and the no-apps blankslate becomes a screen that says where apps come from instead of a button that leads nowhere. **Settings** stays, on the same rule the app form does.
+  - **A read-only configuration doesn't offer the verbs that write it.** Editing an app can be refused halfway — the form is still worth opening to read what an app is configured as, so it keeps its banner and its fields are disabled. Creating one can't: there is nothing to read in a blank form whose only button can never be pressed. So `canUpdateConfiguration` false takes the **+** off the sidebar's Apps band and an app's **Delete** away entirely rather than disabling them, and the no-apps blankslate becomes a screen that says where apps come from instead of a button that leads nowhere. **Settings** stays, on the same rule the app form does.
 - `Configuration` is the file and nothing else; `Runtime` is the running kaja — `can_update_configuration`, `git_ref`, `build_number`, `variable_store_available`. Everything in `Runtime` is settled when the process starts, is never read from or written to `kaja.json`, and is never accepted as input; it rides alongside the configuration on `GetConfigurationResponse`, so saving can't round-trip it. `variable_status` is a third thing again — the result of resolving one against the other. Retired fields are reserved on `Configuration` *and* stripped in `migrateConfiguration`: reserving only stops the schema reusing them, while protojson still fails the whole file on the unknown key.
 - Use past tense in pull request titles and commit messages (e.g., "Fix bug" → "Fixed bug").
 - Use capitalized "Kaja" for user-facing labels (titles, headings, UI text). Keep lowercase "kaja" for code, terminal commands, and file paths.
@@ -115,20 +115,46 @@ once — a rename is not a reason to lose somebody's work.
 
 ### One section, two groups
 
-`ScriptsRegion.tsx` is the whole region; `Sidebar.tsx` is the API's catalog below
-the hairline and hands the region in as a node, because the two are different
-lists that share nothing but the panel.
+`ScriptsRegion.tsx` is the two groups; `Sidebar.tsx` is the panel — the API's
+catalog, and the band over each section — and it takes the region in as a node,
+because the two lists share nothing but the panel.
 
-- **The section says its own name once, at the top.** Drafts and Files are two
-  halves of one question — what you run — and two headers floating above the app
-  tree left that to be worked out. So the region opens with **Scripts**, a 22px
-  row at `text-[13px] font-medium text-foreground`: the same register the app
-  rows below use, so Scripts and an app read as peers across the hairline. It is
-  a **title, not a node** — no chevron, and it names the `nav` through
-  `aria-labelledby` rather than repeating itself as a label. Both groups already
-  fold, so a third chevron would only be a shortcut for pressing those two, and
-  nothing indents: the title sits at 8px, left of the group chevrons, and no row
-  moves.
+- **The section says its own name once, in a band the other section also
+  wears.** Drafts and Files are two halves of one question — what you run — and
+  two headers floating above the app tree left that to be worked out. So the
+  panel opens with **Scripts** and the app tree opens with **Apps**, and it is
+  the *same* 40px band both times (`SectionBand` in `Sidebar.tsx`): a name at
+  `text-[13px] font-medium text-foreground`, and on the right the verbs of that
+  section and no other. The band lives in the sidebar rather than in the region
+  because it is one component drawn twice — two labelled regions read as peers,
+  where one label above everything reads as a title for the panel — and because
+  only the panel knows where the macOS traffic lights are. It still names the
+  region's `nav` through `aria-labelledby`, so the heading is stated once.
+  Nothing indents: the name sits at 8px, left of the group chevrons, and no row
+  under it moves.
+- **The band is where each section's verbs finally have a home.** **+** on
+  Scripts starts a draft (⌘N), `{ }` opens the workspace's variables that
+  scripts read; **+** on Apps makes an app. All three used to sit in one bar at
+  the top of the panel, which is exactly why that bar read as governing
+  everything: it held the actions of both halves and said which of them it meant
+  about none of them.
+- **The name is the fold, not the whole band.** Clicking it collapses the
+  section — the escape valve when the other one gets long — and the chevron is
+  revealed by the cursor while the section is open, then stays put once it is
+  shut, which is when it is the only way back; it holds its space either way, so
+  the name never moves. The band itself is not the target because on macOS the
+  top one is the window's title bar, and a window dragged by its sidebar must
+  not fold a section on the way.
+- **Each section scrolls inside itself**, so a hundred methods can't push the
+  Scripts band off the top of the panel. Scripts is content-sized and shrinks
+  (`flex-[0_1_auto]`) — a short list of files leaves the room to the apps rather
+  than claiming half the panel — and Apps takes what is left; with Apps folded
+  away there is nothing to leave room for, so Scripts takes the rest.
+- **Tabs were the other candidate and were cut.** The core loop is clicking a
+  method in Apps and landing in a draft under Scripts, and one region at a time
+  hides half of that loop at the moment it matters — every method click becomes a
+  tab switch back. They buy full height for a 150-method tree, and are worth
+  revisiting if a third section ever appears.
 - **One list of names, in one font.** Mono on a file row was doing double duty as
   the tell for "this one is on disk"; the group label carries that now, and mono
   inside a nav list reads as code, which is the wrong register. So every row in
@@ -364,10 +390,13 @@ what buys the horizontal room:
   chevron slot they would never fill, so methods start where the eye already is
   rather than 20px right of it.
 - **Rows are full-bleed** — no radius, no inset — so the panel edge is the row
-  edge and hover reads as a band. The one hairline that remains is the one
-  between your scripts and the API's catalog.
-- The sidebar **header stays 40px** regardless, because it lines up with the
-  command row across the seam.
+  edge and hover reads as a band. The hairline that used to separate your
+  scripts from the API's catalog is gone: the **Apps** band says "a new thing
+  starts here" in a way a 1px rule never could, and it keeps one rule of its own
+  along its top to seat it against the section above.
+- The section bands **stay 40px** regardless, because the top one lines up with
+  the command row across the seam and the second one has to match it to read as
+  its peer.
 
 ## What the tree opens with
 
@@ -417,9 +446,10 @@ service*), and it never ran again: whatever you got on day one you kept forever.
   view of the tree, which stopped being something you do, and Fold All was the
   one gesture that could write `shut` over everything at once and mute the whole
   model from a button in the header. **⌥click a row** takes its subtree instead —
-  the same verb, scoped to where the cursor already is, at no cost in chrome. The
-  sidebar header's right side is now empty: the left side makes things, and that
-  is the whole header.
+  the same verb, scoped to where the cursor already is, at no cost in chrome.
+  Folding the **Apps** band is not that verb back: it hides the section whole,
+  which is a question about the panel's two halves rather than about the tree,
+  and it writes nothing into the fold map.
 - The old `expandedApps`/`expandedServices` keys are **not migrated**. Their ids
   differ, and ignoring them lands an existing workspace on the cold start, which
   is a better tree than their stale contents would rebuild.
@@ -1098,13 +1128,14 @@ whatever you last selected — and the window's right side opens with one 40px
 sidebar toggle · finder · the file's own pair · spacer · action ·
 hairline · search · layout. There are
 no recent chips — with one pane and a finder, they were the last echo of a tab
-strip. Nothing else may be added to it; new controls go in the sidebar header or
-the console header. The draft's own pair — `Name` and a discard — is the one
-exception, and it earned it by belonging to the file the trigger just named
-rather than to the window; it is absent on a file, which is already on disk, and
-so most of the time. The sidebar header is 40px too, so the two line up
-across the seam, and the macOS traffic lights stay in it (the row takes over the
-inset only when the sidebar is collapsed).
+strip. Nothing else may be added to it; new controls go on the band of the
+sidebar section they are about, or in the console header. The draft's own pair —
+`Name` and a discard — is the one exception, and it earned it by belonging to
+the file the trigger just named rather than to the window; it is absent on a
+file, which is already on disk, and so most of the time. The sidebar's
+**Scripts** band is 40px too, so the two line up across the seam, and the macOS
+traffic lights stay in it (the row takes over the inset only when the sidebar is
+collapsed).
 
 - **The lights move to the band, not the band to the lights**
   (`desktop/traffic_lights_darwin.m`). AppKit centres the three window buttons

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2493,6 +2493,7 @@ export function App() {
                 onShowCompileLog={onShowCompileLog}
                 onRecompileApp={onRecompile}
                 onNewAppClick={onNewAppClick}
+                onNewScript={onNewDraft}
                 onVariablesClick={onVariablesClick}
                 autoExpandApp={autoExpandApp}
                 reserveTrafficLights={isDesktopMac}

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -45,10 +45,11 @@ import { useMediaQuery } from "./useMediaQuery";
  * **The section is what makes those two groups one thing.** Drafts and Files
  * are halves of a single question — what you run — and a reader who meets them
  * as two headers floating above the app tree has to work that out. So the
- * region says its own name once, at the top, in the register the app rows below
- * use; the groups nest visibly under it, and the filter belongs to it rather
- * than to either half. It is a title, not a node: both groups already fold, and
- * a third chevron would only be a shortcut for pressing those two.
+ * section says its own name once, in the band above these rows, which is the
+ * sidebar's to draw: the band and the one over Apps are the same band, and it
+ * takes the traffic lights and the section's own verbs with it. What is left
+ * here is the two groups and the filter, which belongs to the section rather
+ * than to either half — which is why it searches both.
  *
  * **And it is one list of names, in one font.** Mono on a file row was doing
  * double duty as the tell for "this one is on disk" — the group label carries
@@ -73,10 +74,6 @@ const DEPTH_INDENT = 14;
 // The chevron column a folder row spends and a file row doesn't.
 const CHEVRON_SLOT = 18;
 
-// The region's own name, in the register the app rows below use: 13px and
-// foreground, so Scripts and an app read as peers across the hairline. It takes
-// no chevron — the two groups under it already fold.
-const SECTION_TITLE = "flex h-[22px] select-none items-center px-2 text-[13px] font-medium text-foreground";
 const GROUP_HEADER = "flex h-[22px] w-full cursor-pointer select-none items-center gap-1.5 px-2 text-xs font-medium text-muted-foreground hover:bg-accent/50";
 const ROW = "group flex h-[22px] cursor-pointer select-none items-center gap-1.5 pr-1 text-[13px] outline-none focus-visible:bg-accent/50";
 const ROW_ACTION = "size-[18px] min-h-0 min-w-0 [&_svg]:size-3";
@@ -173,21 +170,12 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [props.onCreateFolder]);
 
-  const hasAnything = scripts.length > 0 || drafts.length > 0 || folders.length > 0;
-  if (!hasAnything) return null;
-
   const active = (key: string) => touch || hovered === key;
 
   return (
+    // Named by the band above it, which is the sidebar's: the heading is stated
+    // once rather than twice.
     <nav aria-labelledby="scripts-section">
-      {/* Said once, at the top: Drafts and Files are two halves of one thing,
-          and this is the thing. The filter below belongs to it rather than to
-          either group, which is why it searches both. It names the nav region
-          too, so the heading is stated once rather than twice. */}
-      <h2 id="scripts-section" className={SECTION_TITLE}>
-        Scripts
-      </h2>
-
       {/* The filter appears once the region is big enough to need one. It
           matches names and folder paths, flattens the result, and says how many
           it found — the one place a count lives outside the group headers,

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -3,7 +3,21 @@ import { cn } from "./cn";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "./components/dropdown-menu";
 import { IconButton } from "./components/icon-button";
 import { TreeView } from "./components/tree-view";
-import { Braces, ChevronRight, CircleX, Ellipsis, Plus, Plus as PlusIcon, RotateCw, Settings, Trash2, TriangleAlert, type LucideIcon } from "lucide-react";
+import {
+  Braces,
+  ChevronDown,
+  ChevronRight,
+  CircleX,
+  Ellipsis,
+  Plus,
+  Plus as PlusIcon,
+  RotateCw,
+  Settings,
+  Trash2,
+  TriangleAlert,
+  type LucideIcon,
+} from "lucide-react";
+import { usePersistedState } from "./usePersistedState";
 import { appType } from "./appTypes";
 import { AppTypeIcon } from "./AppTypeIcon";
 import { Method, App, Service, methodId } from "./apps";
@@ -27,6 +41,33 @@ import {
   subtreeNodes,
   TreeApp,
 } from "./treeExpansion";
+
+/**
+ * The panel is two labelled sections, Scripts and Apps, and the label is the
+ * whole of what makes them two.
+ *
+ * Scripts used to be the only heading in the panel, so everything below it —
+ * the apps and their services — read as being inside it, and the 40px band at
+ * the top read as governing the whole panel because it held the actions of both
+ * halves: **+** made an app, `{ }` opened the workspace's variables, and neither
+ * said which list it was about. The asymmetry was the problem, not the amount of
+ * content.
+ *
+ * So Apps gets the same band Scripts has. A 40px bar with a name says "a new
+ * thing starts here" in a way a hairline never will, and it gives each section
+ * somewhere to put the verbs that belong to it and to nothing else: **+** on
+ * Apps makes an app, **+** on Scripts makes a draft. Nothing else moves — the
+ * groups, the rows and their indents are exactly where they were.
+ *
+ * Both bands fold, which is the escape valve when one section gets long, and
+ * each section scrolls inside itself, so a hundred methods can't push the
+ * Scripts band off the top of the panel.
+ *
+ * Tabs were the other candidate and were cut: the core loop is clicking a method
+ * in Apps and landing in a draft under Scripts, and tabs hide one half of that
+ * loop at the moment it matters. They are worth it if a third section ever
+ * appears, not before.
+ */
 
 // Width the macOS traffic lights occupy at the window's left edge. The desktop
 // window hides its title bar, so whatever sits in that corner has to clear them.
@@ -60,8 +101,10 @@ function RowAction({ icon, label, onClick }: { icon: LucideIcon; label: string; 
 interface SidebarProps {
   apps: App[];
   // The Scripts region — Drafts and Files — built by App and handed in whole.
-  // The sidebar's own subject is the API's catalog below the hairline; the two
-  // are different lists and share nothing but the panel.
+  // The sidebar's own subject is the API's catalog under the Apps band; the two
+  // are different lists and share nothing but the panel. The band above each is
+  // the sidebar's, because a section's name and a section's verbs belong
+  // together and only the panel knows where the traffic lights are.
   scriptsRegion?: React.ReactNode;
   // A read-only configuration doesn't disable the verbs that change apps, it
   // doesn't offer them: New and Delete both go, so there is no way to reach a
@@ -77,6 +120,9 @@ interface SidebarProps {
   onRecompileApp: (appName: string) => void;
   // Opens the create form to add an app (gRPC, Twirp, or a built-in integration).
   onNewAppClick: () => void;
+  // Starts a blank draft — the same thing ⌘N does, on the band of the section
+  // the new row lands in.
+  onNewScript?: () => void;
   // Opens the variables manager tab.
   onVariablesClick?: () => void;
   // One-shot signal to auto-expand a just-added app (and its first service).
@@ -96,12 +142,17 @@ export function Sidebar({
   onShowCompileLog,
   onRecompileApp,
   onNewAppClick,
+  onNewScript,
   onVariablesClick,
   autoExpandApp,
   reserveTrafficLights = false,
   onEditApp,
   onDeleteApp,
 }: SidebarProps) {
+  // Folding a whole section is the escape valve when the other one gets long,
+  // so it is remembered like every other fold in the panel.
+  const [scriptsOpen, setScriptsOpen] = usePersistedState("scriptsSectionExpanded", true);
+  const [appsOpen, setAppsOpen] = usePersistedState("appsSectionExpanded", true);
   // Right-click context menu for an app, anchored at the cursor.
   const [appMenu, setAppMenu] = useState<{ appName: string; top: number; left: number } | null>(null);
   const appMenuAnchorRef = useRef<HTMLDivElement>(null);
@@ -205,180 +256,188 @@ export function Sidebar({
   };
 
   return (
-    <div className="bg-chrome" style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
-      <div
-        // 40px, the same as the command row next to it, so the two line up
-        // across the seam.
-        style={
-          reserveTrafficLights
-            ? ({
-                display: "flex",
-                alignItems: "center",
-                flexShrink: 0,
-                height: 40,
-                paddingLeft: TRAFFIC_LIGHTS_INSET,
-                paddingRight: 8,
-                "--wails-draggable": "drag",
-              } as React.CSSProperties)
-            : { display: "flex", alignItems: "center", height: 40, padding: "0 12px", flexShrink: 0 }
+    <div className="flex min-h-0 flex-1 flex-col bg-chrome">
+      {/* The panel's top band, which is the Scripts band: 40px, the same as the
+          command row next to it, so the two line up across the seam, and on
+          macOS the band the traffic lights sit in. What it holds is what Scripts
+          is about — a new draft, and the variables scripts read. */}
+      <SectionBand
+        id="scripts-section"
+        title="Scripts"
+        open={scriptsOpen}
+        onToggle={() => setScriptsOpen((open) => !open)}
+        reserveTrafficLights={reserveTrafficLights}
+        actions={
+          <>
+            {onNewScript && <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New script" onClick={onNewScript} />}
+            {onVariablesClick && <IconButton icon={Braces} size="sm" variant="ghost" aria-label="Variables" onClick={onVariablesClick} />}
+          </>
         }
-      >
-        <div
-          style={
-            reserveTrafficLights
-              ? ({ display: "flex", alignItems: "center", "--wails-draggable": "no-drag" } as React.CSSProperties)
-              : { display: "flex", alignItems: "center" }
-          }
-        >
-          {canUpdateConfiguration && <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New app" onClick={onNewAppClick} />}
-          {onVariablesClick && <IconButton icon={Braces} size="sm" variant="ghost" aria-label="Variables" onClick={onVariablesClick} />}
-        </div>
-        {/* Nothing on the right. Fold All and Unfold All lived here and were both
-            about managing a view of the tree, which stopped being something you
-            do: the tree opens on what you call, and ⌥click on a row takes its
-            whole subtree. The left side makes things; that is the whole header. */}
-      </div>
-      <div style={{ flex: 1, overflowY: "auto", padding: "4px 0", minHeight: 0 }}>
-        {/* Your scripts and the API's catalog are two different lists, and two
-            rows can carry the same name across the seam. A rule keeps nobody
-            reading them as one. */}
-        {scriptsRegion}
-        {scriptsRegion && apps.length > 0 && <div className="my-1 h-px bg-border" />}
-        {apps.map((app, appIndex) => {
-          const appName = app.configuration.name;
-          const treeApp = treeApps[appIndex];
-          const appId = appNodeId(appName);
-          const isExpanded = isOpen(folds, appId);
-          // The row's own highlight stays the cursor's; only the verb on it is
-          // unconditional where there is no cursor to reveal it with.
-          const active = hoveredApp === appName || appMenu?.appName === appName;
+      />
+      {scriptsOpen && (
+        // Content-sized, so a short list of scripts leaves the room to the apps
+        // below rather than claiming half the panel; it shrinks and scrolls
+        // inside itself once there is more of it than there is room. It never
+        // grows: the Apps band belongs directly under the last file, not pinned
+        // to the bottom of the panel where it would read as a footer.
+        <div className="min-h-0 flex-[0_1_auto] overflow-y-auto py-1">{scriptsRegion}</div>
+      )}
 
-          return (
-            <nav
-              key={appName}
-              ref={(el) => {
-                if (el) elementRefs.current.set(appId, el);
-                else elementRefs.current.delete(appId);
-              }}
-              aria-label="Services and methods"
-            >
-              {/* The app keeps its icon: it is the one place in the tree where
+      {/* The same band, and that is the whole fix: Apps is a section rather than
+          whatever is left below Scripts. Its + is the one that makes an app —
+          it used to sit in the panel's header, where it read as belonging to
+          everything. */}
+      <SectionBand
+        id="apps-section"
+        title="Apps"
+        open={appsOpen}
+        onToggle={() => setAppsOpen((open) => !open)}
+        seam
+        actions={canUpdateConfiguration && <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New app" onClick={onNewAppClick} />}
+      />
+      {appsOpen && (
+        <div className="min-h-0 flex-1 overflow-y-auto py-1">
+          {apps.length === 0 && (
+            <div className="px-2 py-1 text-xs text-muted-foreground">
+              {canUpdateConfiguration ? "Add an app to explore its API." : "Apps named in kaja.json appear here."}
+            </div>
+          )}
+          {apps.map((app, appIndex) => {
+            const appName = app.configuration.name;
+            const treeApp = treeApps[appIndex];
+            const appId = appNodeId(appName);
+            const isExpanded = isOpen(folds, appId);
+            // The row's own highlight stays the cursor's; only the verb on it is
+            // unconditional where there is no cursor to reveal it with.
+            const active = hoveredApp === appName || appMenu?.appName === appName;
+
+            return (
+              <nav
+                key={appName}
+                ref={(el) => {
+                  if (el) elementRefs.current.set(appId, el);
+                  else elementRefs.current.delete(appId);
+                }}
+                aria-label="Services and methods"
+              >
+                {/* The app keeps its icon: it is the one place in the tree where
                   the glyph says something the indent can't — gRPC or OpenAPI or
                   Folder. Everything below repeats itself, so it goes. */}
-              <div
-                className={cn(SECTION_ROW, active ? "bg-accent" : "hover:bg-accent/50")}
-                onMouseEnter={() => setHoveredApp(appName)}
-                onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
-                onClick={(e: React.MouseEvent) => setFold(treeApp, appId, isExpanded ? "shut" : "open", e.altKey)}
-                onContextMenu={(e: React.MouseEvent) => {
-                  e.preventDefault();
-                  setAppMenu({ appName, top: e.clientY, left: e.clientX });
-                }}
-              >
-                <ChevronRight size={12} className={cn("shrink-0 text-muted-foreground transition-transform duration-[120ms]", isExpanded && "rotate-90")} />
-                <AppTypeIcon type={appType(app.configuration)} size={13} />
-                <span className="truncate">{appName}</span>
-                <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
-                <span className="ml-auto flex w-6 shrink-0 items-center justify-center">
-                  {(touch || active) && (
-                    <RowAction icon={Ellipsis} label={`Actions for ${appName}`} onClick={(e) => setAppMenu({ appName, top: e.clientY, left: e.clientX })} />
-                  )}
-                </span>
-              </div>
-              {isExpanded && (
-                <TreeView guide aria-label="Services and methods">
-                  {app.compilation.status === "running" || app.compilation.status === "pending" ? (
-                    <LoadingTreeViewItem />
-                  ) : (
-                    (() => {
-                      const multiplePackages = hasMultiplePackages(app.services);
+                <div
+                  className={cn(SECTION_ROW, active ? "bg-accent" : "hover:bg-accent/50")}
+                  onMouseEnter={() => setHoveredApp(appName)}
+                  onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
+                  onClick={(e: React.MouseEvent) => setFold(treeApp, appId, isExpanded ? "shut" : "open", e.altKey)}
+                  onContextMenu={(e: React.MouseEvent) => {
+                    e.preventDefault();
+                    setAppMenu({ appName, top: e.clientY, left: e.clientX });
+                  }}
+                >
+                  <ChevronRight size={12} className={cn("shrink-0 text-muted-foreground transition-transform duration-[120ms]", isExpanded && "rotate-90")} />
+                  <AppTypeIcon type={appType(app.configuration)} size={13} />
+                  <span className="truncate">{appName}</span>
+                  <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
+                  <span className="ml-auto flex w-6 shrink-0 items-center justify-center">
+                    {(touch || active) && (
+                      <RowAction icon={Ellipsis} label={`Actions for ${appName}`} onClick={(e) => setAppMenu({ appName, top: e.clientY, left: e.clientX })} />
+                    )}
+                  </span>
+                </div>
+                {isExpanded && (
+                  <TreeView guide aria-label="Services and methods">
+                    {app.compilation.status === "running" || app.compilation.status === "pending" ? (
+                      <LoadingTreeViewItem />
+                    ) : (
+                      (() => {
+                        const multiplePackages = hasMultiplePackages(app.services);
 
-                      const renderServiceItem = (service: Service) => {
-                        const svcId = serviceNodeId(appName, service);
-                        return (
-                          <TreeView.Item
-                            id={svcId}
-                            key={svcId}
-                            ref={(el: HTMLElement | null) => {
-                              if (el) elementRefs.current.set(svcId, el);
-                              else elementRefs.current.delete(svcId);
-                            }}
-                            expanded={isOpen(folds, svcId)}
-                            onExpandedChange={(expanded, event) => setFold(treeApp, svcId, expanded ? "open" : "shut", event.altKey)}
-                          >
-                            {service.name}
-                            <TreeView.SubTree leaf>
-                              {service.methods.map((method) => {
-                                const mId = methodId(service, method);
-                                return (
-                                  <TreeView.Item
-                                    id={mId}
-                                    key={mId}
-                                    ref={(el: HTMLElement | null) => {
-                                      if (el) {
-                                        elementRefs.current.set(mId, el);
-                                        // TreeView.Item doesn't forward these, so attach them to the node.
-                                        el.onmouseenter = () => setHoveredMethod(mId);
-                                        el.onmouseleave = () => setHoveredMethod((previous) => (previous === mId ? null : previous));
-                                      } else elementRefs.current.delete(mId);
-                                    }}
-                                    onSelect={(event) => onSelect(method, service, app, event?.altKey ? "append" : "go")}
-                                  >
-                                    {method.name}
-                                    <TreeView.TrailingVisual>
-                                      {/* Adding a call to the draft you already have open is
+                        const renderServiceItem = (service: Service) => {
+                          const svcId = serviceNodeId(appName, service);
+                          return (
+                            <TreeView.Item
+                              id={svcId}
+                              key={svcId}
+                              ref={(el: HTMLElement | null) => {
+                                if (el) elementRefs.current.set(svcId, el);
+                                else elementRefs.current.delete(svcId);
+                              }}
+                              expanded={isOpen(folds, svcId)}
+                              onExpandedChange={(expanded, event) => setFold(treeApp, svcId, expanded ? "open" : "shut", event.altKey)}
+                            >
+                              {service.name}
+                              <TreeView.SubTree leaf>
+                                {service.methods.map((method) => {
+                                  const mId = methodId(service, method);
+                                  return (
+                                    <TreeView.Item
+                                      id={mId}
+                                      key={mId}
+                                      ref={(el: HTMLElement | null) => {
+                                        if (el) {
+                                          elementRefs.current.set(mId, el);
+                                          // TreeView.Item doesn't forward these, so attach them to the node.
+                                          el.onmouseenter = () => setHoveredMethod(mId);
+                                          el.onmouseleave = () => setHoveredMethod((previous) => (previous === mId ? null : previous));
+                                        } else elementRefs.current.delete(mId);
+                                      }}
+                                      onSelect={(event) => onSelect(method, service, app, event?.altKey ? "append" : "go")}
+                                    >
+                                      {method.name}
+                                      <TreeView.TrailingVisual>
+                                        {/* Adding a call to the draft you already have open is
                                           deliberate, so it gets its own target rather than
                                           happening because you clicked in the wrong mood. */}
-                                      {(touch || hoveredMethod === mId) && (
-                                        <RowAction
-                                          icon={PlusIcon}
-                                          label={`Add ${method.name} to the open draft`}
-                                          onClick={() => onSelect(method, service, app, "append")}
-                                        />
-                                      )}
-                                    </TreeView.TrailingVisual>
-                                  </TreeView.Item>
-                                );
-                              })}
-                            </TreeView.SubTree>
-                          </TreeView.Item>
-                        );
-                      };
+                                        {(touch || hoveredMethod === mId) && (
+                                          <RowAction
+                                            icon={PlusIcon}
+                                            label={`Add ${method.name} to the open draft`}
+                                            onClick={() => onSelect(method, service, app, "append")}
+                                          />
+                                        )}
+                                      </TreeView.TrailingVisual>
+                                    </TreeView.Item>
+                                  );
+                                })}
+                              </TreeView.SubTree>
+                            </TreeView.Item>
+                          );
+                        };
 
-                      if (!multiplePackages) {
-                        return <>{app.services.map(renderServiceItem)}</>;
-                      }
+                        if (!multiplePackages) {
+                          return <>{app.services.map(renderServiceItem)}</>;
+                        }
 
-                      const packageNodes = groupServicesByPackage(app.services).map(([packageName, services]) => {
-                        const packageId = packageNodeId(appName, packageName);
-                        return (
-                          <TreeView.Item
-                            id={packageId}
-                            key={packageId}
-                            ref={(el: HTMLElement | null) => {
-                              if (el) elementRefs.current.set(packageId, el);
-                              else elementRefs.current.delete(packageId);
-                            }}
-                            expanded={isOpen(folds, packageId)}
-                            onExpandedChange={(expanded, event) => setFold(treeApp, packageId, expanded ? "open" : "shut", event.altKey)}
-                          >
-                            {/* No icon: every package row carried the same one,
+                        const packageNodes = groupServicesByPackage(app.services).map(([packageName, services]) => {
+                          const packageId = packageNodeId(appName, packageName);
+                          return (
+                            <TreeView.Item
+                              id={packageId}
+                              key={packageId}
+                              ref={(el: HTMLElement | null) => {
+                                if (el) elementRefs.current.set(packageId, el);
+                                else elementRefs.current.delete(packageId);
+                              }}
+                              expanded={isOpen(folds, packageId)}
+                              onExpandedChange={(expanded, event) => setFold(treeApp, packageId, expanded ? "open" : "shut", event.altKey)}
+                            >
+                              {/* No icon: every package row carried the same one,
                                 which is 20px per row spent saying what the guide
                                 already says. */}
-                            <span className="text-muted-foreground">{packageName}</span>
-                            <TreeView.SubTree>{services.map(renderServiceItem)}</TreeView.SubTree>
-                          </TreeView.Item>
-                        );
-                      });
-                      return <>{packageNodes}</>;
-                    })()
-                  )}
-                </TreeView>
-              )}
-            </nav>
-          );
-        })}
-      </div>
+                              <span className="text-muted-foreground">{packageName}</span>
+                              <TreeView.SubTree>{services.map(renderServiceItem)}</TreeView.SubTree>
+                            </TreeView.Item>
+                          );
+                        });
+                        return <>{packageNodes}</>;
+                      })()
+                    )}
+                  </TreeView>
+                )}
+              </nav>
+            );
+          })}
+        </div>
+      )}
       <div ref={appMenuAnchorRef} style={{ position: "fixed", top: appMenu?.top ?? 0, left: appMenu?.left ?? 0, width: 1, height: 1, pointerEvents: "none" }} />
       <DropdownMenu open={!!appMenu} onOpenChange={(open) => !open && setAppMenu(null)}>
         <DropdownMenuContent align="start" anchor={appMenuAnchorRef} className="w-48">
@@ -414,6 +473,68 @@ export function Sidebar({
           )}
         </DropdownMenuContent>
       </DropdownMenu>
+    </div>
+  );
+}
+
+/**
+ * A section's band: 40px, its name, and the verbs that belong to that section
+ * and to nothing else. Both sections wear the same one, which is the point —
+ * two labelled regions read as peers, where one label above everything reads as
+ * a title for the panel.
+ *
+ * The name is the fold, not the whole band: on macOS the top band is the window's
+ * title bar, so the rest of it has to stay draggable, and a window dragged by
+ * its sidebar must not fold a section on the way. The chevron is revealed by the
+ * cursor while the section is open and stays put once it is shut, which is when
+ * it is the only way back. It holds its space either way, so the name never
+ * moves.
+ */
+function SectionBand({
+  id,
+  title,
+  open,
+  onToggle,
+  actions,
+  seam,
+  reserveTrafficLights,
+}: {
+  id: string;
+  title: string;
+  open: boolean;
+  onToggle: () => void;
+  actions?: React.ReactNode;
+  // The rule that seats a band against the section above it. The top one has
+  // nothing above it and takes none.
+  seam?: boolean;
+  reserveTrafficLights?: boolean;
+}) {
+  const noDrag = reserveTrafficLights ? ({ "--wails-draggable": "no-drag" } as React.CSSProperties) : undefined;
+  return (
+    <div
+      className={cn("flex h-10 shrink-0 items-center gap-1 pr-1.5", seam && "border-t border-border")}
+      style={reserveTrafficLights ? ({ paddingLeft: TRAFFIC_LIGHTS_INSET, "--wails-draggable": "drag" } as React.CSSProperties) : undefined}
+    >
+      <h2 id={id} className="flex min-w-0" style={noDrag}>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          className="group/band flex h-[22px] min-w-0 cursor-pointer select-none items-center gap-1 rounded px-2 text-[13px] font-medium text-foreground outline-none hover:bg-accent/50 focus-visible:bg-accent/50"
+        >
+          <span className="truncate">{title}</span>
+          <ChevronDown
+            size={12}
+            className={cn(
+              "shrink-0 text-muted-foreground transition-[transform,opacity] duration-[120ms]",
+              open ? "opacity-0 group-hover/band:opacity-100 group-focus-visible/band:opacity-100" : "-rotate-90",
+            )}
+          />
+        </button>
+      </h2>
+      <div className="ml-auto flex shrink-0 items-center" style={noDrag}>
+        {actions}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Apps now wears the same 40px band Scripts has, each carrying only its own verbs — `+` draft and `{ }` variables on Scripts, `+` app on Apps — instead of one bar at the top holding both. Both fold from their name and each section scrolls inside itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcKybWxLbj1frbVfcShitF)_