### PR TITLE
Gave the sidebar a band for the global tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - When I prompt you to make changes that are radically different from what's documented here, please update this file accordingly.
 - Don't commit changes to `kaja.json`
 - The server serves its workspace read-only; `scripts/server --editable` is what lets the UI write to `kaja.json`. The desktop app owns its workspace and is always editable. This is decided at startup only — a configuration file never says whether it may be edited.
-  - **A read-only configuration doesn't offer the verbs that write it.** Editing an app can be refused halfway — the form is still worth opening to read what an app is configured as, so it keeps its banner and its fields are disabled. Creating one can't: there is nothing to read in a blank form whose only button can never be pressed. So `canUpdateConfiguration` false takes the **+** off the sidebar's Apps band and an app's **Delete** away entirely rather than disabling them, and the no-apps blankslate becomes a screen that says where apps come from instead of a button that leads nowhere. **Settings** stays, on the same rule the app form does.
+  - **A read-only configuration doesn't offer the verbs that write it.** Editing an app can be refused halfway — the form is still worth opening to read what an app is configured as, so it keeps its banner and its fields are disabled. Creating one can't: there is nothing to read in a blank form whose only button can never be pressed. So `canUpdateConfiguration` false takes the **+** off the sidebar's Apps header and an app's **Delete** away entirely rather than disabling them, and the no-apps blankslate becomes a screen that says where apps come from instead of a button that leads nowhere. **Settings** stays, on the same rule the app form does.
 - `Configuration` is the file and nothing else; `Runtime` is the running kaja — `can_update_configuration`, `git_ref`, `build_number`, `variable_store_available`. Everything in `Runtime` is settled when the process starts, is never read from or written to `kaja.json`, and is never accepted as input; it rides alongside the configuration on `GetConfigurationResponse`, so saving can't round-trip it. `variable_status` is a third thing again — the result of resolving one against the other. Retired fields are reserved on `Configuration` *and* stripped in `migrateConfiguration`: reserving only stops the schema reusing them, while protojson still fails the whole file on the unknown key.
 - Use past tense in pull request titles and commit messages (e.g., "Fix bug" → "Fixed bug").
 - Use capitalized "Kaja" for user-facing labels (titles, headings, UI text). Keep lowercase "kaja" for code, terminal commands, and file paths.
@@ -116,37 +116,47 @@ once — a rename is not a reason to lose somebody's work.
 ### One section, two groups
 
 `ScriptsRegion.tsx` is the two groups; `Sidebar.tsx` is the panel — the API's
-catalog, and the band over each section — and it takes the region in as a node,
-because the two lists share nothing but the panel.
+catalog, the band over both sections and the header over each — and it takes the
+region in as a node, because the two lists share nothing but the panel.
 
-- **The section says its own name once, in a band the other section also
-  wears.** Drafts and Files are two halves of one question — what you run — and
-  two headers floating above the app tree left that to be worked out. So the
-  panel opens with **Scripts** and the app tree opens with **Apps**, and it is
-  the *same* 40px band both times (`SectionBand` in `Sidebar.tsx`): a name at
-  `text-[13px] font-medium text-foreground`, and on the right the verbs of that
-  section and no other. The band lives in the sidebar rather than in the region
-  because it is one component drawn twice — two labelled regions read as peers,
-  where one label above everything reads as a title for the panel — and because
-  only the panel knows where the macOS traffic lights are. It still names the
+- **A control's scope decides where it lives, and that settles what the band
+  is.** **+** is local, so there is one on Scripts and one on Apps; the search
+  and `{ }` are about the window rather than about either list, so they are in
+  the band above both. What the band is *not* is a header for the first section
+  — which is exactly how it read while it was titled **Scripts** and carried
+  that section's verbs, since everything below it, the app tree included,
+  appeared to be inside it. It is the panel's own 40px row (`GlobalBand`),
+  holding the global tools and nothing else.
+- **The left of the band belongs to the platform, which is what makes the two
+  builds one app.** macOS puts the traffic lights there, so the band takes their
+  inset and stays draggable except where a control is; everywhere else — the
+  browser, and a desktop window whose buttons are on the right — the **Kaja mark
+  and wordmark** take that corner (`KajaTrace`, the real mark rather than a
+  logotype of its own). The tools sit flush right either way, so the cluster
+  never moves between builds and desktop and browser differ by exactly one
+  element.
+- **Both sections are the same in-list header**, 22px like the rows under them
+  (`SectionHeader`): a name at `text-[13px] font-medium text-foreground`, and on
+  the right the one verb that belongs to that list — **+** on Scripts starts a
+  draft (⌘N), **+** on Apps makes an app. That is what makes them peers; a 40px
+  bar over one and a row over the other reads as a title for the panel and a
+  heading inside it. A hairline seats Apps against the section above it, which is
+  enough now that the band says nothing about either. The header still names the
   region's `nav` through `aria-labelledby`, so the heading is stated once.
   Nothing indents: the name sits at 8px, left of the group chevrons, and no row
   under it moves.
-- **The band is where each section's verbs finally have a home.** **+** on
-  Scripts starts a draft (⌘N), `{ }` opens the workspace's variables that
-  scripts read; **+** on Apps makes an app. All three used to sit in one bar at
-  the top of the panel, which is exactly why that bar read as governing
-  everything: it held the actions of both halves and said which of them it meant
-  about none of them.
-- **The name is the fold, not the whole band.** Clicking it collapses the
+- **The two + are permanent; everything else in a header is revealed by the
+  cursor.** Making a draft and adding an app are the verbs somebody comes to
+  this panel for, and they were permanent while the band was theirs. The group
+  actions below them (`Trash2` on Drafts, the Files kebab) keep the hover rule.
+- **The name is the fold, not the whole row.** Clicking it collapses the
   section — the escape valve when the other one gets long — and the chevron is
   revealed by the cursor while the section is open, then stays put once it is
   shut, which is when it is the only way back; it holds its space either way, so
-  the name never moves. The band itself is not the target because on macOS the
-  top one is the window's title bar, and a window dragged by its sidebar must
-  not fold a section on the way.
+  the name never moves. The name rather than the row, so a header can carry a
+  button without the two competing.
 - **Each section scrolls inside itself**, so a hundred methods can't push the
-  Scripts band off the top of the panel. Scripts is content-sized and shrinks
+  Scripts header off the top of the panel. Scripts is content-sized and shrinks
   (`flex-[0_1_auto]`) — a short list of files leaves the room to the apps rather
   than claiming half the panel — and Apps takes what is left; with Apps folded
   away there is nothing to leave room for, so Scripts takes the rest.
@@ -223,16 +233,40 @@ because the two lists share nothing but the panel.
   were never run and never edited past their generated form after `SWEEP_DAYS`
   (7), never touches one that is on screen, never touches the agent's row, and is
   off entirely when `sweepDrafts` is off. Anything run or edited is kept forever.
-- **A filter appears when the region earns one** — past ~15 rows
-  (`FILTER_THRESHOLD`). It belongs to the **section** rather than to either
-  group, which is why it sits directly under the Scripts title and searches
-  both: it matches names and folder paths, **flattens** them (a tree of one
-  match per branch is a worse answer than a list), and shows the folder as a dim
-  suffix on each hit. Below the threshold the list is the answer, and a search
-  box is a control you have to go looking past.
 - **Empty states.** Zero drafts hides the Drafts group entirely rather than
-  showing an empty label — there is nothing there and nothing to say about it.
-  Zero files keeps its header and says one line: where files come from.
+  showing an empty label — there is nothing there and nothing to say about it,
+  and a search that matched no draft is the same nothing. Zero files keeps its
+  header and says one line: where files come from, or that nothing matched.
+
+### The search over both lists
+
+**The search belongs to the panel, not to either section**, which is why it is
+in the band and why it reaches the Scripts region through a context
+(`sidebarFilter.ts`) rather than as a prop — the region is handed to the sidebar
+as a node, and this is the one thing that spans both lists.
+
+- **At rest it is the icon; in use it is the field.** Clicking it turns the icon
+  into a real input filling whatever the platform's corner leaves — snug beside
+  the traffic lights, comfortable in a browser — and the wordmark gives way to it,
+  since the mark alone still says whose window this is. `Esc`, the ✕, or leaving
+  it empty puts it back. It is never persisted: a filter left on from last week
+  is a list that is silently incomplete. There is no row-count threshold any
+  more; a global tool is either there or it isn't.
+- **It matches, then flattens, in both halves.** Scripts match on name and folder
+  path and show the folder as a dim suffix (`filterScripts`); the catalog matches
+  a method by its own name, by `Service.Method`, by its service's name, or by its
+  app's — matching a container means everything in it — and draws the hits as
+  flat rows under their app with the service as a dim suffix (`appFilter.ts`,
+  unit-tested). A tree of one match per branch is a worse answer than a list, in
+  a catalog of forty methods most of all: that tree is what this was built for.
+- **One number, in the field.** The sidebar counts its own catalog and the region
+  reports what it matched (`reportHits`), so a search over two lists states one
+  total. The group counts beside **Drafts** and **Files** report hits rather than
+  totals while it is on, so what is on screen and what the number says can't
+  disagree.
+- **A query outranks the folds.** Both sections open while one is on, because the
+  body renders either way and a fold that hid the answer would be reporting a
+  state nobody asked about.
 
 ### Folders
 
@@ -390,13 +424,13 @@ what buys the horizontal room:
   chevron slot they would never fill, so methods start where the eye already is
   rather than 20px right of it.
 - **Rows are full-bleed** — no radius, no inset — so the panel edge is the row
-  edge and hover reads as a band. The hairline that used to separate your
-  scripts from the API's catalog is gone: the **Apps** band says "a new thing
-  starts here" in a way a 1px rule never could, and it keeps one rule of its own
-  along its top to seat it against the section above.
-- The section bands **stay 40px** regardless, because the top one lines up with
-  the command row across the seam and the second one has to match it to read as
-  its peer.
+  edge and hover reads as a band. The one hairline in the panel separates your
+  scripts from the API's catalog, above the **Apps** header, which is all that is
+  needed to say "a new thing starts here" now that both sections wear the same
+  22px header.
+- The panel's **band stays 40px**, because it lines up with the command row
+  across the seam — one row across the whole window, holding the traffic lights
+  or the mark at one end and the file's own controls at the other.
 
 ## What the tree opens with
 
@@ -447,7 +481,7 @@ service*), and it never ran again: whatever you got on day one you kept forever.
   one gesture that could write `shut` over everything at once and mute the whole
   model from a button in the header. **⌥click a row** takes its subtree instead —
   the same verb, scoped to where the cursor already is, at no cost in chrome.
-  Folding the **Apps** band is not that verb back: it hides the section whole,
+  Folding the **Apps** section is not that verb back: it hides the section whole,
   which is a question about the panel's two halves rather than about the tree,
   and it writes nothing into the fold map.
 - The old `expandedApps`/`expandedServices` keys are **not migrated**. Their ids
@@ -1126,22 +1160,28 @@ illustration, and it degrades correctly: on a first run the recent list is
 whatever you last selected — and the window's right side opens with one 40px
 **command row** (`CommandRow.tsx`) that replaced the old top bar and tab strip:
 sidebar toggle · finder · the file's own pair · spacer · action ·
-hairline · search · layout. There are
+hairline · layout. There are
 no recent chips — with one pane and a finder, they were the last echo of a tab
-strip. Nothing else may be added to it; new controls go on the band of the
-sidebar section they are about, or in the console header. The draft's own pair —
-`Name` and a discard — is the one exception, and it earned it by belonging to
-the file the trigger just named rather than to the window; it is absent on a
-file, which is already on disk, and so most of the time. The sidebar's
-**Scripts** band is 40px too, so the two line up across the seam, and the macOS
+strip. Nothing else may be added to it; new controls go on the sidebar's band or
+on the header of the section they are about, or in the console header. The
+draft's own pair — `Name` and a discard — is the one exception, and it earned it
+by belonging to the file the trigger just named rather than to the window; it is
+absent on a file, which is already on disk, and so most of the time. The
+sidebar's band is 40px too, so the two line up across the seam, and the macOS
 traffic lights stay in it (the row takes over the inset only when the sidebar is
 collapsed).
 
+- **There is no search icon in the row.** It opened the same finder its own
+  trigger opens, which is why it was the first thing dropped as the row narrowed
+  — and once the sidebar's band grew a search of its own, over the scripts and
+  the app tree, two magnifying glasses in one 40px line meant two different
+  searches. The one with a trigger beside it is the one that could go; `⌘P` is
+  unaffected.
 - **The lights move to the band, not the band to the lights**
   (`desktop/traffic_lights_darwin.m`). AppKit centres the three window buttons
   on the 28pt title bar, six points above the centre of the 40px band, so the
   window's top-left corner read as two staggered baselines — the lights on one,
-  and **+**, `{ }`, the panel toggle and the draft's own Name on the other. There
+  and the search, `{ }`, the panel toggle and the draft's own Name on the other. There
   is no position to set: `mac.TitleBar` is six booleans, and Wails has had the
   request open since v2. So the title bar container is made as tall as the band
   and the buttons are centred in it, which is what Electron's

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2549,7 +2549,6 @@ export function App() {
               }
               fileActions={fileActions}
               action={action}
-              onSearch={() => setFinder("first")}
               layout={editorLayout}
               onToggleLayout={onToggleEditorLayout}
             />

--- a/ui/src/CommandRow.tsx
+++ b/ui/src/CommandRow.tsx
@@ -1,4 +1,4 @@
-import { Columns2, PanelLeftClose, PanelLeftOpen, Rows2, Search } from "lucide-react";
+import { Columns2, PanelLeftClose, PanelLeftOpen, Rows2 } from "lucide-react";
 import { cn } from "./cn";
 import { IconButton } from "./components/icon-button";
 import { SimpleTooltip } from "./components/tooltip";
@@ -19,22 +19,26 @@ interface CommandRowProps {
   // form. A file is never both, so they share the slot and the row keeps its
   // shape.
   action?: React.ReactNode;
-  onSearch: () => void;
   layout: "vertical" | "horizontal";
   onToggleLayout: () => void;
 }
 
 // One 40px row instead of a top bar and a tab strip: sidebar toggle · finder ·
-// the file's own save/discard · spacer · action · hairline · search · layout.
-// Nothing else may be added to it — new controls go in the sidebar header or the
-// console header.
+// the file's own save/discard · spacer · action · hairline · layout. Nothing
+// else may be added to it — new controls go on the band of the sidebar section
+// they are about, or in the console header.
+//
+// There is no search icon here. It said nothing the finder trigger beside it
+// doesn't already say, and once the sidebar's band grew a search of its own —
+// over the scripts and the app tree, which is a different thing entirely — two
+// magnifying glasses in one 40px line meant two different searches. The one that
+// had a trigger beside it is the one that could go.
 //
 // As the row narrows, things leave in order of what they are worth, the way the
-// console header's do: the keyboard hint on Run first (there is no keyboard on
-// the screen this narrows for), then the search icon, whose verb the trigger
-// beside it already carries. The finder truncates through all of it, because
-// with the sidebar collapsed it is the only thing saying where you are.
-export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finder, fileActions, action, onSearch, layout, onToggleLayout }: CommandRowProps) {
+// console header's do: the keyboard hint on Run first, there being no keyboard
+// on the screen this narrows for. The finder truncates through all of it,
+// because with the sidebar collapsed it is the only thing saying where you are.
+export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finder, fileActions, action, layout, onToggleLayout }: CommandRowProps) {
   const modifier = navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl+";
 
   return (
@@ -63,19 +67,6 @@ export function CommandRow({ leftInset, sidebarCollapsed, onToggleSidebar, finde
       <div className="flex shrink-0 items-center gap-2" style={{ "--wails-draggable": "no-drag" } as React.CSSProperties}>
         {action}
         {action && <Hairline />}
-        {/* The trigger beside it opens the same finder, so on a row this narrow
-            the icon is the one thing here that says nothing new. */}
-        <SimpleTooltip text={`Find a file (${modifier}K)`} side="bottom">
-          <IconButton
-            icon={Search}
-            aria-label="Find a file"
-            onClick={onSearch}
-            size="sm"
-            variant="ghost"
-            className="size-[26px] @max-[380px]:hidden"
-            tooltip={false}
-          />
-        </SimpleTooltip>
         <SimpleTooltip text={layout === "vertical" ? "Side-by-side layout" : "Top-bottom layout"} side="bottom">
           <IconButton
             icon={layout === "vertical" ? Columns2 : Rows2}

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -11,7 +11,6 @@ import {
   Pencil,
   Plug,
   Save,
-  Search,
   Trash2,
   X,
   type LucideIcon,
@@ -25,6 +24,7 @@ import { isAgentDraft, isUntouched, orderDrafts, Draft, untouchedDrafts, VISIBLE
 import { titleParts } from "./draftTitle";
 import { buildScriptTree, filterScripts, FolderNode, folderNameError, scriptNameParts, TreeNode, visibleRows } from "./scriptTree";
 import { usePersistedState } from "./usePersistedState";
+import { useSidebarFilter } from "./sidebarFilter";
 import { useMediaQuery } from "./useMediaQuery";
 
 /**
@@ -45,11 +45,16 @@ import { useMediaQuery } from "./useMediaQuery";
  * **The section is what makes those two groups one thing.** Drafts and Files
  * are halves of a single question — what you run — and a reader who meets them
  * as two headers floating above the app tree has to work that out. So the
- * section says its own name once, in the band above these rows, which is the
- * sidebar's to draw: the band and the one over Apps are the same band, and it
- * takes the traffic lights and the section's own verbs with it. What is left
- * here is the two groups and the filter, which belongs to the section rather
- * than to either half — which is why it searches both.
+ * section says its own name once, in the header above these rows, which is the
+ * sidebar's to draw: that header and the one over Apps are the same row, and it
+ * takes the section's own **+** with it. What is left here is the two groups.
+ *
+ * **The search is the panel's, not the section's**, so it is read from the
+ * sidebar's context rather than drawn here: it spans the scripts and the app
+ * tree alike, which is why it sits in the band over both. What this region owes
+ * it is the count of what it matched — the two group counts state that while a
+ * query is on, since a result set is the one thing whose size can't be read off
+ * the rows.
  *
  * **And it is one list of names, in one font.** Mono on a file row was doing
  * double duty as the tell for "this one is on disk" — the group label carries
@@ -62,10 +67,6 @@ import { useMediaQuery } from "./useMediaQuery";
  * The run indicators have the trailing slot to themselves, and it is a fixed
  * width, so nothing under the cursor moves as a run starts.
  */
-
-// Once the region passes this many rows it earns a filter. Below it the list is
-// the answer and a search box is a control you have to go looking past.
-const FILTER_THRESHOLD = 15;
 
 // The base indent of a row inside a group, so the group's label and its rows
 // share a left edge, and one level of folder depth.
@@ -121,7 +122,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
   const [filesOpen, setFilesOpen] = usePersistedState("filesExpanded", true);
   const [openFolders, setOpenFolders] = usePersistedState<string[]>("openScriptFolders", []);
   const [showAllDrafts, setShowAllDrafts] = useState(false);
-  const [query, setQuery] = useState("");
+  const { query, reportHits } = useSidebarFilter();
   const [hovered, setHovered] = useState<string | null>(null);
   const touch = useMediaQuery("(hover: none)");
 
@@ -132,9 +133,13 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
   const ownDrafts = useMemo(() => ordered.filter((draft) => !isAgentDraft(draft)), [ordered]);
 
   const tree = useMemo(() => buildScriptTree(scripts, folders), [scripts, folders]);
-  const rowCount = useMemo(() => scripts.length + folders.length + ownDrafts.length, [scripts, folders, ownDrafts]);
   const filtering = query.trim().length > 0;
   const matches = useMemo(() => filterAll(scripts, ownDrafts, query), [scripts, ownDrafts, query]);
+
+  // What the panel's field states, for the half of the search that lives here.
+  useEffect(() => {
+    reportHits("scripts", filtering ? matches.scripts.length + matches.drafts.length : 0);
+  }, [filtering, matches, reportHits]);
 
   const rows = useMemo(() => visibleRows(tree, new Set(openFolders)), [tree, openFolders]);
   const draftsShown = filtering ? matches.drafts : showAllDrafts ? ownDrafts : ownDrafts.slice(0, VISIBLE_DRAFTS);
@@ -176,34 +181,15 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
     // Named by the band above it, which is the sidebar's: the heading is stated
     // once rather than twice.
     <nav aria-labelledby="scripts-section">
-      {/* The filter appears once the region is big enough to need one. It
-          matches names and folder paths, flattens the result, and says how many
-          it found — the one place a count lives outside the group headers,
-          because there is no other way to see the size of a result. */}
-      {rowCount > FILTER_THRESHOLD && (
-        <div className="px-2 pb-1 pt-0.5">
-          <div className="flex h-[26px] items-center gap-1.5 rounded-md border border-input bg-background px-2">
-            <Search size={13} className="shrink-0 text-muted-foreground" />
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={(event) => event.key === "Escape" && setQuery("")}
-              placeholder="Filter scripts"
-              aria-label="Filter scripts"
-              className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
-            />
-            {filtering && <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{matches.scripts.length + matches.drafts.length}</span>}
-          </div>
-        </div>
-      )}
-
       {/* Zero drafts hides the group rather than showing an empty label: there
-          is nothing there and nothing to say about it. */}
-      {(agentDraft !== undefined || ownDrafts.length > 0) && (
+          is nothing there and nothing to say about it. A search that matched no
+          draft is the same nothing, so it hides the group too — the field
+          already said how many it found in all. */}
+      {(filtering ? matches.drafts.length > 0 : agentDraft !== undefined || ownDrafts.length > 0) && (
         <>
           <GroupHeader
             label="Drafts"
-            count={ownDrafts.length}
+            count={filtering ? matches.drafts.length : ownDrafts.length}
             // A filter opens both groups — the body below renders either way, so
             // the chevron has to agree with it rather than report the fold.
             open={draftsOpen || filtering}
@@ -265,7 +251,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
 
       <GroupHeader
         label="Files"
-        count={scripts.length}
+        count={filtering ? matches.scripts.length : scripts.length}
         open={filesOpen || filtering}
         onToggle={() => setFilesOpen((open) => !open)}
         action={

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { cn } from "./cn";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "./components/dropdown-menu";
 import { IconButton } from "./components/icon-button";
+import { SimpleTooltip } from "./components/tooltip";
 import { TreeView } from "./components/tree-view";
 import {
   Braces,
@@ -12,9 +13,11 @@ import {
   Plus,
   Plus as PlusIcon,
   RotateCw,
+  Search,
   Settings,
   Trash2,
   TriangleAlert,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { usePersistedState } from "./usePersistedState";
@@ -22,6 +25,9 @@ import { appType } from "./appTypes";
 import { AppTypeIcon } from "./AppTypeIcon";
 import { Method, App, Service, methodId } from "./apps";
 import { appWarnings, firstErrorMessage } from "./compileSummary";
+import { AppHits, countHits, filterApps } from "./appFilter";
+import { KajaTrace } from "./KajaTrace";
+import { SidebarFilterProvider } from "./sidebarFilter";
 import { useMediaQuery } from "./useMediaQuery";
 import {
   appNodeId,
@@ -43,25 +49,25 @@ import {
 } from "./treeExpansion";
 
 /**
- * The panel is two labelled sections, Scripts and Apps, and the label is the
- * whole of what makes them two.
+ * The panel is one band and two labelled sections under it.
  *
- * Scripts used to be the only heading in the panel, so everything below it —
- * the apps and their services — read as being inside it, and the 40px band at
- * the top read as governing the whole panel because it held the actions of both
- * halves: **+** made an app, `{ }` opened the workspace's variables, and neither
- * said which list it was about. The asymmetry was the problem, not the amount of
- * content.
+ * **A control's scope decides where it lives**, and that is the whole of this
+ * layout. **+** is local, so there is one on Scripts and one on Apps; search and
+ * `{ }` are about the window rather than about either list, so they live in the
+ * band above both. Sorting them that way is what finally settles what the band
+ * is: not a header for the first section, which is how it read while it was
+ * titled "Scripts" and carried that section's verbs, but the panel's own
+ * 40px row, holding the global tools and nothing else.
  *
- * So Apps gets the same band Scripts has. A 40px bar with a name says "a new
- * thing starts here" in a way a hairline never will, and it gives each section
- * somewhere to put the verbs that belong to it and to nothing else: **+** on
- * Apps makes an app, **+** on Scripts makes a draft. Nothing else moves — the
- * groups, the rows and their indents are exactly where they were.
+ * **The left of the band belongs to the platform**, which is what makes the two
+ * builds one app: the traffic lights on macOS, the Kaja mark and wordmark
+ * everywhere else. The tools sit flush right, so the cluster never moves between
+ * builds — desktop and browser differ by exactly one element.
  *
- * Both bands fold, which is the escape valve when one section gets long, and
- * each section scrolls inside itself, so a hundred methods can't push the
- * Scripts band off the top of the panel.
+ * **Both sections are in-list headers**, 22px like the rows under them, each
+ * with its own **+**. Both fold, which is the escape valve when one gets long,
+ * and each scrolls inside itself, so a hundred methods can't push the Scripts
+ * header off the top of the panel.
  *
  * Tabs were the other candidate and were cut: the core loop is clicking a method
  * in Apps and landing in a draft under Scripts, and tabs hide one half of that
@@ -101,10 +107,11 @@ function RowAction({ icon, label, onClick }: { icon: LucideIcon; label: string; 
 interface SidebarProps {
   apps: App[];
   // The Scripts region — Drafts and Files — built by App and handed in whole.
-  // The sidebar's own subject is the API's catalog under the Apps band; the two
-  // are different lists and share nothing but the panel. The band above each is
-  // the sidebar's, because a section's name and a section's verbs belong
-  // together and only the panel knows where the traffic lights are.
+  // The sidebar's own subject is the API's catalog under the Apps header; the
+  // two are different lists and share nothing but the panel. The header over
+  // each is the sidebar's, because a section's name and a section's verbs belong
+  // together; the search above them both is the panel's, and reaches the region
+  // through a context for the same reason.
   scriptsRegion?: React.ReactNode;
   // A read-only configuration doesn't disable the verbs that change apps, it
   // doesn't offer them: New and Delete both go, so there is no way to reach a
@@ -127,8 +134,10 @@ interface SidebarProps {
   onVariablesClick?: () => void;
   // One-shot signal to auto-expand a just-added app (and its first service).
   autoExpandApp?: { name: string };
-  // macOS desktop: inset the header row to clear the window traffic lights and make
-  // the empty parts draggable, so the controls share the title bar band (saves a row).
+  // macOS desktop: inset the band to clear the window traffic lights and make
+  // its empty parts draggable, so the tools share the title bar band (saves a
+  // row). It is also what decides whether the band's left corner is the
+  // platform's or ours: where the lights are not, the mark is.
   reserveTrafficLights?: boolean;
   onEditApp: (appName: string) => void;
   onDeleteApp: (appName: string) => void;
@@ -153,6 +162,12 @@ export function Sidebar({
   // so it is remembered like every other fold in the panel.
   const [scriptsOpen, setScriptsOpen] = usePersistedState("scriptsSectionExpanded", true);
   const [appsOpen, setAppsOpen] = usePersistedState("appsSectionExpanded", true);
+  // The search is a tool, not a fixture: at rest it is the icon in the band, and
+  // it becomes a field in the room the platform's corner leaves. Not persisted —
+  // a filter left on from last week is a list that is silently incomplete.
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<Record<string, number>>({});
   // Right-click context menu for an app, anchored at the cursor.
   const [appMenu, setAppMenu] = useState<{ appName: string; top: number; left: number } | null>(null);
   const appMenuAnchorRef = useRef<HTMLDivElement>(null);
@@ -172,6 +187,19 @@ export function Sidebar({
   const pendingScrollRef = useRef<string | null>(null);
 
   const treeApps: TreeApp[] = apps.map((app) => ({ name: app.configuration.name, services: app.services }));
+
+  const filtering = query.trim().length > 0;
+  const appHits = useMemo(() => (filtering ? filterApps(apps, query) : []), [apps, query, filtering]);
+  const reportHits = useCallback((section: string, count: number) => {
+    setHits((previous) => (previous[section] === count ? previous : { ...previous, [section]: count }));
+  }, []);
+  const filter = useMemo(() => ({ query, reportHits }), [query, reportHits]);
+  const totalHits = countHits(appHits) + Object.values(hits).reduce((total, count) => total + count, 0);
+
+  const closeSearch = () => {
+    setSearchOpen(false);
+    setQuery("");
+  };
 
   useEffect(() => {
     saveFolds(folds);
@@ -255,267 +283,393 @@ export function Sidebar({
     if (fold === "open") pendingScrollRef.current = nodeId;
   };
 
+  // A search opens both sections: the body renders either way, so the folds have
+  // to agree with it rather than hide the answer.
+  const scriptsShown = scriptsOpen || filtering;
+  const appsShown = appsOpen || filtering;
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-chrome">
-      {/* The panel's top band, which is the Scripts band: 40px, the same as the
-          command row next to it, so the two line up across the seam, and on
-          macOS the band the traffic lights sit in. What it holds is what Scripts
-          is about — a new draft, and the variables scripts read. */}
-      <SectionBand
-        id="scripts-section"
-        title="Scripts"
-        open={scriptsOpen}
-        onToggle={() => setScriptsOpen((open) => !open)}
-        reserveTrafficLights={reserveTrafficLights}
-        actions={
-          <>
-            {onNewScript && <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New script" onClick={onNewScript} />}
-            {onVariablesClick && <IconButton icon={Braces} size="sm" variant="ghost" aria-label="Variables" onClick={onVariablesClick} />}
-          </>
-        }
-      />
-      {scriptsOpen && (
-        // Content-sized, so a short list of scripts leaves the room to the apps
-        // below rather than claiming half the panel; it shrinks and scrolls
-        // inside itself once there is more of it than there is room. It never
-        // grows: the Apps band belongs directly under the last file, not pinned
-        // to the bottom of the panel where it would read as a footer.
-        <div className="min-h-0 flex-[0_1_auto] overflow-y-auto py-1">{scriptsRegion}</div>
-      )}
+    <SidebarFilterProvider value={filter}>
+      <div className="flex min-h-0 flex-1 flex-col bg-chrome">
+        {/* 40px, the same as the command row next to it, so the two line up across
+          the seam, and on macOS the band the traffic lights sit in. What it
+          holds is what belongs to the window rather than to either list below:
+          the search over both, and the variables they read. */}
+        <GlobalBand
+          reserveTrafficLights={reserveTrafficLights}
+          searchOpen={searchOpen}
+          query={query}
+          hits={filtering ? totalHits : undefined}
+          onQueryChange={setQuery}
+          onOpenSearch={() => setSearchOpen(true)}
+          onCloseSearch={closeSearch}
+          onVariablesClick={onVariablesClick}
+        />
 
-      {/* The same band, and that is the whole fix: Apps is a section rather than
-          whatever is left below Scripts. Its + is the one that makes an app —
-          it used to sit in the panel's header, where it read as belonging to
-          everything. */}
-      <SectionBand
-        id="apps-section"
-        title="Apps"
-        open={appsOpen}
-        onToggle={() => setAppsOpen((open) => !open)}
-        seam
-        actions={canUpdateConfiguration && <IconButton icon={Plus} size="sm" variant="ghost" aria-label="New app" onClick={onNewAppClick} />}
-      />
-      {appsOpen && (
-        <div className="min-h-0 flex-1 overflow-y-auto py-1">
-          {apps.length === 0 && (
-            <div className="px-2 py-1 text-xs text-muted-foreground">
-              {canUpdateConfiguration ? "Add an app to explore its API." : "Apps named in kaja.json appear here."}
-            </div>
-          )}
-          {apps.map((app, appIndex) => {
-            const appName = app.configuration.name;
-            const treeApp = treeApps[appIndex];
-            const appId = appNodeId(appName);
-            const isExpanded = isOpen(folds, appId);
-            // The row's own highlight stays the cursor's; only the verb on it is
-            // unconditional where there is no cursor to reveal it with.
-            const active = hoveredApp === appName || appMenu?.appName === appName;
+        {/* Both sections are the same 22px row now, which is what makes them read
+          as peers: a name, the verb that belongs to that list and no other, and
+          nothing that governs the panel. */}
+        <SectionHeader
+          id="scripts-section"
+          title="Scripts"
+          open={scriptsShown}
+          onToggle={() => setScriptsOpen((open) => !open)}
+          actions={onNewScript && <RowAction icon={Plus} label="New script" onClick={onNewScript} />}
+        />
+        {scriptsShown && (
+          // Content-sized, so a short list of scripts leaves the room to the apps
+          // below rather than claiming half the panel; it shrinks and scrolls
+          // inside itself once there is more of it than there is room. It never
+          // grows: the Apps header belongs directly under the last file, not
+          // pinned to the bottom of the panel where it would read as a footer.
+          <div className="min-h-0 flex-[0_1_auto] overflow-y-auto pb-1">{scriptsRegion}</div>
+        )}
 
-            return (
-              <nav
-                key={appName}
-                ref={(el) => {
-                  if (el) elementRefs.current.set(appId, el);
-                  else elementRefs.current.delete(appId);
-                }}
-                aria-label="Services and methods"
-              >
-                {/* The app keeps its icon: it is the one place in the tree where
+        {/* A hairline is enough to say a new thing starts here, now that the two
+          headers are the same row and the band above says nothing about either.
+          Its + is the one that makes an app. */}
+        <SectionHeader
+          id="apps-section"
+          title="Apps"
+          open={appsShown}
+          onToggle={() => setAppsOpen((open) => !open)}
+          seam
+          actions={canUpdateConfiguration && <RowAction icon={Plus} label="New app" onClick={onNewAppClick} />}
+        />
+        {appsShown && (
+          <div className="min-h-0 flex-1 overflow-y-auto pb-1">
+            {apps.length === 0 && !filtering && (
+              <div className="px-2 py-1 text-xs text-muted-foreground">
+                {canUpdateConfiguration ? "Add an app to explore its API." : "Apps named in kaja.json appear here."}
+              </div>
+            )}
+            {filtering && <AppMatches hits={appHits} query={query} touch={touch} hovered={hoveredMethod} onHover={setHoveredMethod} onSelect={onSelect} />}
+            {!filtering &&
+              apps.map((app, appIndex) => {
+                const appName = app.configuration.name;
+                const treeApp = treeApps[appIndex];
+                const appId = appNodeId(appName);
+                const isExpanded = isOpen(folds, appId);
+                // The row's own highlight stays the cursor's; only the verb on it is
+                // unconditional where there is no cursor to reveal it with.
+                const active = hoveredApp === appName || appMenu?.appName === appName;
+
+                return (
+                  <nav
+                    key={appName}
+                    ref={(el) => {
+                      if (el) elementRefs.current.set(appId, el);
+                      else elementRefs.current.delete(appId);
+                    }}
+                    aria-label="Services and methods"
+                  >
+                    {/* The app keeps its icon: it is the one place in the tree where
                   the glyph says something the indent can't — gRPC or OpenAPI or
                   Folder. Everything below repeats itself, so it goes. */}
-                <div
-                  className={cn(SECTION_ROW, active ? "bg-accent" : "hover:bg-accent/50")}
-                  onMouseEnter={() => setHoveredApp(appName)}
-                  onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
-                  onClick={(e: React.MouseEvent) => setFold(treeApp, appId, isExpanded ? "shut" : "open", e.altKey)}
-                  onContextMenu={(e: React.MouseEvent) => {
-                    e.preventDefault();
-                    setAppMenu({ appName, top: e.clientY, left: e.clientX });
-                  }}
-                >
-                  <ChevronRight size={12} className={cn("shrink-0 text-muted-foreground transition-transform duration-[120ms]", isExpanded && "rotate-90")} />
-                  <AppTypeIcon type={appType(app.configuration)} size={13} />
-                  <span className="truncate">{appName}</span>
-                  <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
-                  <span className="ml-auto flex w-6 shrink-0 items-center justify-center">
-                    {(touch || active) && (
-                      <RowAction icon={Ellipsis} label={`Actions for ${appName}`} onClick={(e) => setAppMenu({ appName, top: e.clientY, left: e.clientX })} />
-                    )}
-                  </span>
-                </div>
-                {isExpanded && (
-                  <TreeView guide aria-label="Services and methods">
-                    {app.compilation.status === "running" || app.compilation.status === "pending" ? (
-                      <LoadingTreeViewItem />
-                    ) : (
-                      (() => {
-                        const multiplePackages = hasMultiplePackages(app.services);
+                    <div
+                      className={cn(SECTION_ROW, active ? "bg-accent" : "hover:bg-accent/50")}
+                      onMouseEnter={() => setHoveredApp(appName)}
+                      onMouseLeave={() => setHoveredApp((prev) => (prev === appName ? null : prev))}
+                      onClick={(e: React.MouseEvent) => setFold(treeApp, appId, isExpanded ? "shut" : "open", e.altKey)}
+                      onContextMenu={(e: React.MouseEvent) => {
+                        e.preventDefault();
+                        setAppMenu({ appName, top: e.clientY, left: e.clientX });
+                      }}
+                    >
+                      <ChevronRight
+                        size={12}
+                        className={cn("shrink-0 text-muted-foreground transition-transform duration-[120ms]", isExpanded && "rotate-90")}
+                      />
+                      <AppTypeIcon type={appType(app.configuration)} size={13} />
+                      <span className="truncate">{appName}</span>
+                      <AppCompileMarker app={app} onShowCompileLog={onShowCompileLog} />
+                      <span className="ml-auto flex w-6 shrink-0 items-center justify-center">
+                        {(touch || active) && (
+                          <RowAction
+                            icon={Ellipsis}
+                            label={`Actions for ${appName}`}
+                            onClick={(e) => setAppMenu({ appName, top: e.clientY, left: e.clientX })}
+                          />
+                        )}
+                      </span>
+                    </div>
+                    {isExpanded && (
+                      <TreeView guide aria-label="Services and methods">
+                        {app.compilation.status === "running" || app.compilation.status === "pending" ? (
+                          <LoadingTreeViewItem />
+                        ) : (
+                          (() => {
+                            const multiplePackages = hasMultiplePackages(app.services);
 
-                        const renderServiceItem = (service: Service) => {
-                          const svcId = serviceNodeId(appName, service);
-                          return (
-                            <TreeView.Item
-                              id={svcId}
-                              key={svcId}
-                              ref={(el: HTMLElement | null) => {
-                                if (el) elementRefs.current.set(svcId, el);
-                                else elementRefs.current.delete(svcId);
-                              }}
-                              expanded={isOpen(folds, svcId)}
-                              onExpandedChange={(expanded, event) => setFold(treeApp, svcId, expanded ? "open" : "shut", event.altKey)}
-                            >
-                              {service.name}
-                              <TreeView.SubTree leaf>
-                                {service.methods.map((method) => {
-                                  const mId = methodId(service, method);
-                                  return (
-                                    <TreeView.Item
-                                      id={mId}
-                                      key={mId}
-                                      ref={(el: HTMLElement | null) => {
-                                        if (el) {
-                                          elementRefs.current.set(mId, el);
-                                          // TreeView.Item doesn't forward these, so attach them to the node.
-                                          el.onmouseenter = () => setHoveredMethod(mId);
-                                          el.onmouseleave = () => setHoveredMethod((previous) => (previous === mId ? null : previous));
-                                        } else elementRefs.current.delete(mId);
-                                      }}
-                                      onSelect={(event) => onSelect(method, service, app, event?.altKey ? "append" : "go")}
-                                    >
-                                      {method.name}
-                                      <TreeView.TrailingVisual>
-                                        {/* Adding a call to the draft you already have open is
+                            const renderServiceItem = (service: Service) => {
+                              const svcId = serviceNodeId(appName, service);
+                              return (
+                                <TreeView.Item
+                                  id={svcId}
+                                  key={svcId}
+                                  ref={(el: HTMLElement | null) => {
+                                    if (el) elementRefs.current.set(svcId, el);
+                                    else elementRefs.current.delete(svcId);
+                                  }}
+                                  expanded={isOpen(folds, svcId)}
+                                  onExpandedChange={(expanded, event) => setFold(treeApp, svcId, expanded ? "open" : "shut", event.altKey)}
+                                >
+                                  {service.name}
+                                  <TreeView.SubTree leaf>
+                                    {service.methods.map((method) => {
+                                      const mId = methodId(service, method);
+                                      return (
+                                        <TreeView.Item
+                                          id={mId}
+                                          key={mId}
+                                          ref={(el: HTMLElement | null) => {
+                                            if (el) {
+                                              elementRefs.current.set(mId, el);
+                                              // TreeView.Item doesn't forward these, so attach them to the node.
+                                              el.onmouseenter = () => setHoveredMethod(mId);
+                                              el.onmouseleave = () => setHoveredMethod((previous) => (previous === mId ? null : previous));
+                                            } else elementRefs.current.delete(mId);
+                                          }}
+                                          onSelect={(event) => onSelect(method, service, app, event?.altKey ? "append" : "go")}
+                                        >
+                                          {method.name}
+                                          <TreeView.TrailingVisual>
+                                            {/* Adding a call to the draft you already have open is
                                           deliberate, so it gets its own target rather than
                                           happening because you clicked in the wrong mood. */}
-                                        {(touch || hoveredMethod === mId) && (
-                                          <RowAction
-                                            icon={PlusIcon}
-                                            label={`Add ${method.name} to the open draft`}
-                                            onClick={() => onSelect(method, service, app, "append")}
-                                          />
-                                        )}
-                                      </TreeView.TrailingVisual>
-                                    </TreeView.Item>
-                                  );
-                                })}
-                              </TreeView.SubTree>
-                            </TreeView.Item>
-                          );
-                        };
+                                            {(touch || hoveredMethod === mId) && (
+                                              <RowAction
+                                                icon={PlusIcon}
+                                                label={`Add ${method.name} to the open draft`}
+                                                onClick={() => onSelect(method, service, app, "append")}
+                                              />
+                                            )}
+                                          </TreeView.TrailingVisual>
+                                        </TreeView.Item>
+                                      );
+                                    })}
+                                  </TreeView.SubTree>
+                                </TreeView.Item>
+                              );
+                            };
 
-                        if (!multiplePackages) {
-                          return <>{app.services.map(renderServiceItem)}</>;
-                        }
+                            if (!multiplePackages) {
+                              return <>{app.services.map(renderServiceItem)}</>;
+                            }
 
-                        const packageNodes = groupServicesByPackage(app.services).map(([packageName, services]) => {
-                          const packageId = packageNodeId(appName, packageName);
-                          return (
-                            <TreeView.Item
-                              id={packageId}
-                              key={packageId}
-                              ref={(el: HTMLElement | null) => {
-                                if (el) elementRefs.current.set(packageId, el);
-                                else elementRefs.current.delete(packageId);
-                              }}
-                              expanded={isOpen(folds, packageId)}
-                              onExpandedChange={(expanded, event) => setFold(treeApp, packageId, expanded ? "open" : "shut", event.altKey)}
-                            >
-                              {/* No icon: every package row carried the same one,
+                            const packageNodes = groupServicesByPackage(app.services).map(([packageName, services]) => {
+                              const packageId = packageNodeId(appName, packageName);
+                              return (
+                                <TreeView.Item
+                                  id={packageId}
+                                  key={packageId}
+                                  ref={(el: HTMLElement | null) => {
+                                    if (el) elementRefs.current.set(packageId, el);
+                                    else elementRefs.current.delete(packageId);
+                                  }}
+                                  expanded={isOpen(folds, packageId)}
+                                  onExpandedChange={(expanded, event) => setFold(treeApp, packageId, expanded ? "open" : "shut", event.altKey)}
+                                >
+                                  {/* No icon: every package row carried the same one,
                                 which is 20px per row spent saying what the guide
                                 already says. */}
-                              <span className="text-muted-foreground">{packageName}</span>
-                              <TreeView.SubTree>{services.map(renderServiceItem)}</TreeView.SubTree>
-                            </TreeView.Item>
-                          );
-                        });
-                        return <>{packageNodes}</>;
-                      })()
+                                  <span className="text-muted-foreground">{packageName}</span>
+                                  <TreeView.SubTree>{services.map(renderServiceItem)}</TreeView.SubTree>
+                                </TreeView.Item>
+                              );
+                            });
+                            return <>{packageNodes}</>;
+                          })()
+                        )}
+                      </TreeView>
                     )}
-                  </TreeView>
-                )}
-              </nav>
-            );
-          })}
-        </div>
-      )}
-      <div ref={appMenuAnchorRef} style={{ position: "fixed", top: appMenu?.top ?? 0, left: appMenu?.left ?? 0, width: 1, height: 1, pointerEvents: "none" }} />
-      <DropdownMenu open={!!appMenu} onOpenChange={(open) => !open && setAppMenu(null)}>
-        <DropdownMenuContent align="start" anchor={appMenuAnchorRef} className="w-48">
-          <DropdownMenuItem
-            onSelect={() => {
-              const appName = appMenu?.appName;
-              if (appName) onEditApp(appName);
-            }}
-          >
-            <Settings size={16} />
-            Settings
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              const appName = appMenu?.appName;
-              if (appName) onRecompileApp(appName);
-            }}
-          >
-            <RotateCw size={16} />
-            Recompile
-          </DropdownMenuItem>
-          {canUpdateConfiguration && (
+                  </nav>
+                );
+              })}
+          </div>
+        )}
+        <div
+          ref={appMenuAnchorRef}
+          style={{ position: "fixed", top: appMenu?.top ?? 0, left: appMenu?.left ?? 0, width: 1, height: 1, pointerEvents: "none" }}
+        />
+        <DropdownMenu open={!!appMenu} onOpenChange={(open) => !open && setAppMenu(null)}>
+          <DropdownMenuContent align="start" anchor={appMenuAnchorRef} className="w-48">
             <DropdownMenuItem
-              variant="danger"
               onSelect={() => {
                 const appName = appMenu?.appName;
-                if (appName) onDeleteApp(appName);
+                if (appName) onEditApp(appName);
               }}
             >
-              <Trash2 size={16} />
-              Delete
+              <Settings size={16} />
+              Settings
             </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            <DropdownMenuItem
+              onSelect={() => {
+                const appName = appMenu?.appName;
+                if (appName) onRecompileApp(appName);
+              }}
+            >
+              <RotateCw size={16} />
+              Recompile
+            </DropdownMenuItem>
+            {canUpdateConfiguration && (
+              <DropdownMenuItem
+                variant="danger"
+                onSelect={() => {
+                  const appName = appMenu?.appName;
+                  if (appName) onDeleteApp(appName);
+                }}
+              >
+                <Trash2 size={16} />
+                Delete
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </SidebarFilterProvider>
+  );
+}
+
+/**
+ * The panel's band: 40px, the global tools, and whatever the platform puts in
+ * the window's left corner.
+ *
+ * It says nothing about the lists below it, which is the point — while it was
+ * titled "Scripts" and carried that section's **+**, it read as a header for
+ * everything under it, and the two sections could not be peers. What is left in
+ * it is what is genuinely about the window: the search over both lists, and the
+ * workspace's variables that both read.
+ *
+ * The corner is the platform's. On macOS the traffic lights sit in it, so the
+ * band takes their inset and stays draggable except where a control is; anywhere
+ * else the Kaja mark and wordmark take that space, so the browser and the
+ * desktop differ by exactly one element and the tools never move between them.
+ */
+function GlobalBand({
+  reserveTrafficLights,
+  searchOpen,
+  query,
+  hits,
+  onQueryChange,
+  onOpenSearch,
+  onCloseSearch,
+  onVariablesClick,
+}: {
+  reserveTrafficLights?: boolean;
+  searchOpen: boolean;
+  query: string;
+  // How many rows the query matched across both sections, absent when there is
+  // no query: a result set is the one thing in the panel whose size can't be
+  // read off the rows.
+  hits?: number;
+  onQueryChange: (query: string) => void;
+  onOpenSearch: () => void;
+  onCloseSearch: () => void;
+  onVariablesClick?: () => void;
+}) {
+  const noDrag = reserveTrafficLights ? ({ "--wails-draggable": "no-drag" } as React.CSSProperties) : undefined;
+  const field = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (searchOpen) field.current?.focus();
+  }, [searchOpen]);
+
+  return (
+    <div
+      className="flex h-10 shrink-0 items-center gap-1 border-b border-border pr-1.5"
+      style={reserveTrafficLights ? ({ paddingLeft: TRAFFIC_LIGHTS_INSET, "--wails-draggable": "drag" } as React.CSSProperties) : undefined}
+    >
+      {!reserveTrafficLights && (
+        <div className="flex shrink-0 select-none items-center gap-1.5 pl-2.5">
+          <KajaTrace width={18} height={11} />
+          {/* The wordmark gives way to the field, the way the lights don't have
+              to: the mark alone still says whose window this is, and the field
+              is worth more than the four letters beside it while it is open. */}
+          {!searchOpen && <span className="text-[13px] font-semibold text-foreground">Kaja</span>}
+        </div>
+      )}
+      <div className={cn("ml-auto flex min-w-0 items-center gap-1", searchOpen && "flex-1")} style={noDrag}>
+        {searchOpen ? (
+          // The field fills whatever the corner leaves — snug beside the lights,
+          // comfortable in a browser — which is the same control the icon stood
+          // for rather than a second place to search from.
+          <div className="flex h-[26px] min-w-0 flex-1 items-center gap-1.5 rounded-md border border-input bg-background pl-2 pr-1">
+            <Search size={13} className="shrink-0 text-muted-foreground" />
+            <input
+              ref={field}
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  onCloseSearch();
+                }
+              }}
+              // Leaving an empty field is leaving the search: a control that has
+              // nothing to say shouldn't hold the room its icon fits in.
+              onBlur={() => query.trim().length === 0 && onCloseSearch()}
+              placeholder="Search scripts and methods"
+              aria-label="Search scripts and methods"
+              className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            {hits !== undefined && <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{hits}</span>}
+            <IconButton
+              icon={X}
+              size="xs"
+              variant="ghost"
+              tooltip={false}
+              aria-label="Close search"
+              className="size-[18px] min-h-0 min-w-0 shrink-0 [&_svg]:size-3"
+              onClick={onCloseSearch}
+            />
+          </div>
+        ) : (
+          <SimpleTooltip text="Search scripts and methods" side="bottom">
+            <IconButton icon={Search} size="sm" variant="ghost" tooltip={false} aria-label="Search scripts and methods" onClick={onOpenSearch} />
+          </SimpleTooltip>
+        )}
+        {onVariablesClick && (
+          <SimpleTooltip text="Variables" side="bottom">
+            <IconButton icon={Braces} size="sm" variant="ghost" tooltip={false} aria-label="Variables" onClick={onVariablesClick} />
+          </SimpleTooltip>
+        )}
+      </div>
     </div>
   );
 }
 
 /**
- * A section's band: 40px, its name, and the verbs that belong to that section
- * and to nothing else. Both sections wear the same one, which is the point —
- * two labelled regions read as peers, where one label above everything reads as
- * a title for the panel.
+ * A section's header: the same 22px row as everything under it, its name, and
+ * the verb that belongs to that section and to nothing else. Both sections wear
+ * the same one, which is what makes them peers — a 40px bar over one of them and
+ * a row over the other reads as a title for the panel and a heading inside it.
  *
- * The name is the fold, not the whole band: on macOS the top band is the window's
- * title bar, so the rest of it has to stay draggable, and a window dragged by
- * its sidebar must not fold a section on the way. The chevron is revealed by the
- * cursor while the section is open and stays put once it is shut, which is when
- * it is the only way back. It holds its space either way, so the name never
- * moves.
+ * The name is the fold, not the whole row, so a header can carry a button
+ * without the two competing. The chevron is revealed by the cursor while the
+ * section is open and stays put once it is shut, which is when it is the only
+ * way back; it holds its space either way, so the name never moves.
  */
-function SectionBand({
+function SectionHeader({
   id,
   title,
   open,
   onToggle,
   actions,
   seam,
-  reserveTrafficLights,
 }: {
   id: string;
   title: string;
   open: boolean;
   onToggle: () => void;
   actions?: React.ReactNode;
-  // The rule that seats a band against the section above it. The top one has
-  // nothing above it and takes none.
+  // What separates one section from the next. The top one has nothing above it
+  // and takes none.
   seam?: boolean;
-  reserveTrafficLights?: boolean;
 }) {
-  const noDrag = reserveTrafficLights ? ({ "--wails-draggable": "no-drag" } as React.CSSProperties) : undefined;
   return (
-    <div
-      className={cn("flex h-10 shrink-0 items-center gap-1 pr-1.5", seam && "border-t border-border")}
-      style={reserveTrafficLights ? ({ paddingLeft: TRAFFIC_LIGHTS_INSET, "--wails-draggable": "drag" } as React.CSSProperties) : undefined}
-    >
-      <h2 id={id} className="flex min-w-0" style={noDrag}>
+    <div className={cn("flex h-[22px] shrink-0 items-center gap-1 pr-1.5", seam && "mt-1 h-[27px] border-t border-border pt-1")}>
+      <h2 id={id} className="flex min-w-0">
         <button
           type="button"
           onClick={onToggle}
@@ -532,10 +686,83 @@ function SectionBand({
           />
         </button>
       </h2>
-      <div className="ml-auto flex shrink-0 items-center" style={noDrag}>
-        {actions}
-      </div>
+      {/* Not revealed by the cursor, unlike the group actions below it: making a
+          draft and adding an app are the two verbs somebody comes to this panel
+          for, and they were permanent while the band was theirs. */}
+      <div className="ml-auto flex shrink-0 items-center">{actions}</div>
     </div>
+  );
+}
+
+/**
+ * The catalog, filtered: matching methods flattened under their app, each
+ * carrying the service it came from as a dim suffix. Flat rather than folded,
+ * on the same rule the scripts filter follows — a tree with one match per branch
+ * is a worse answer than a list.
+ */
+function AppMatches({
+  hits,
+  query,
+  touch,
+  hovered,
+  onHover,
+  onSelect,
+}: {
+  hits: AppHits[];
+  query: string;
+  touch: boolean;
+  hovered: string | null;
+  onHover: (id: string | null) => void;
+  onSelect: (method: Method, service: Service, app: App, mode?: "go" | "append") => void;
+}) {
+  if (hits.length === 0) {
+    return <div className="px-2 py-1 text-xs text-muted-foreground">No methods match “{query.trim()}”</div>;
+  }
+
+  return (
+    <>
+      {hits.map(({ app, methods }) => {
+        // The suffix has to tell two hits apart, so it says as much as the tree
+        // would: the service, and its package where an app has more than one.
+        const packages = hasMultiplePackages(app.services);
+        return (
+          <nav key={app.configuration.name} aria-label={`${app.configuration.name} matches`}>
+            <div className={cn(SECTION_ROW, "cursor-default")}>
+              <AppTypeIcon type={appType(app.configuration)} size={13} />
+              <span className="truncate">{app.configuration.name}</span>
+            </div>
+            <TreeView leaf aria-label="Matching methods">
+              {methods.map(({ service, method }) => {
+                // The package is part of the id: one app can hold two versions of
+                // a service, and a flat list is where they land next to each other.
+                const id = `${serviceNodeId(app.configuration.name, service)}.${method.name}`;
+                return (
+                  <TreeView.Item
+                    id={id}
+                    key={id}
+                    ref={(el: HTMLElement | null) => {
+                      if (el) {
+                        el.onmouseenter = () => onHover(id);
+                        el.onmouseleave = () => onHover(null);
+                      }
+                    }}
+                    onSelect={(event) => onSelect(method, service, app, event?.altKey ? "append" : "go")}
+                  >
+                    {method.name}
+                    <span className="ml-1.5 text-xs text-muted-foreground">{packages ? `${service.packageName}.${service.name}` : service.name}</span>
+                    <TreeView.TrailingVisual>
+                      {(touch || hovered === id) && (
+                        <RowAction icon={PlusIcon} label={`Add ${method.name} to the open draft`} onClick={() => onSelect(method, service, app, "append")} />
+                      )}
+                    </TreeView.TrailingVisual>
+                  </TreeView.Item>
+                );
+              })}
+            </TreeView>
+          </nav>
+        );
+      })}
+    </>
   );
 }
 

--- a/ui/src/appFilter.test.ts
+++ b/ui/src/appFilter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { App, Method, Service } from "./apps";
+import { countHits, filterApps } from "./appFilter";
+
+function service(name: string, methods: string[]): Service {
+  return {
+    name,
+    packageName: "demo",
+    sourcePath: `${name}.proto`,
+    clientStubModuleId: `${name}.client`,
+    methods: methods.map((method) => ({ name: method }) as Method),
+  };
+}
+
+function app(name: string, services: Service[]): App {
+  return { configuration: { name }, services } as unknown as App;
+}
+
+const apps = [
+  app("theatre", [service("Theatre", ["ListMovies", "ListShows", "CreateShow"])]),
+  app("seating", [service("Seating", ["GetSeatMap", "BookSeats"])]),
+];
+
+describe("filterApps", () => {
+  it("matches a method by its own name", () => {
+    const hits = filterApps(apps, "seatmap");
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.app.configuration.name).toBe("seating");
+    expect(hits[0]!.methods.map((hit) => hit.method.name)).toEqual(["GetSeatMap"]);
+  });
+
+  it("matches on Service.Method, which is how a method is written down", () => {
+    const hits = filterApps(apps, "theatre.list");
+    expect(hits[0]!.methods.map((hit) => hit.method.name)).toEqual(["ListMovies", "ListShows"]);
+  });
+
+  it("takes a whole service when the service is what matched", () => {
+    expect(countHits(filterApps(apps, "seating"))).toBe(2);
+  });
+
+  it("takes a whole app when the app is what matched", () => {
+    const hits = filterApps(apps, "theatre");
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.methods.length).toBe(3);
+  });
+
+  it("is case-insensitive and ignores surrounding space", () => {
+    expect(countHits(filterApps(apps, "  BOOKSEATS "))).toBe(1);
+  });
+
+  it("drops an app nothing in it matched", () => {
+    expect(filterApps(apps, "movies").map((hit) => hit.app.configuration.name)).toEqual(["theatre"]);
+  });
+
+  it("has nothing to say about an empty query — the tree is the answer then", () => {
+    expect(filterApps(apps, "")).toEqual([]);
+    expect(filterApps(apps, "   ")).toEqual([]);
+  });
+
+  it("counts every hit, across apps", () => {
+    expect(countHits(filterApps(apps, "list"))).toBe(2);
+    expect(countHits(filterApps(apps, "s"))).toBe(5);
+  });
+});

--- a/ui/src/appFilter.ts
+++ b/ui/src/appFilter.ts
@@ -1,0 +1,51 @@
+import { App, Method, Service } from "./apps";
+
+/**
+ * The catalog half of the sidebar's search.
+ *
+ * The search is the panel's rather than either section's, so it has to answer
+ * for the app tree as well as for the scripts — and a dense tree of forty
+ * methods is the list it was worth building for. The rule is the one the scripts
+ * filter already follows: match, then **flatten**. A tree with one match per
+ * branch is a worse answer than a list, so a hit is a method row under its app,
+ * carrying the service it came from as a dim suffix.
+ *
+ * A needle matches a method by its own name, by `Service.Method`, by the
+ * service's name, or by the app's — matching a container means everything in it,
+ * because "show me what is in OpenMeter" is a question people ask of a tree.
+ */
+
+export interface MethodHit {
+  service: Service;
+  method: Method;
+}
+
+export interface AppHits {
+  app: App;
+  methods: MethodHit[];
+}
+
+export function filterApps(apps: App[], query: string): AppHits[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+
+  const hits: AppHits[] = [];
+  for (const app of apps) {
+    const wholeApp = app.configuration.name.toLowerCase().includes(needle);
+    const methods: MethodHit[] = [];
+    for (const service of app.services) {
+      const wholeService = wholeApp || service.name.toLowerCase().includes(needle);
+      for (const method of service.methods) {
+        if (wholeService || `${service.name}.${method.name}`.toLowerCase().includes(needle)) {
+          methods.push({ service, method });
+        }
+      }
+    }
+    if (methods.length > 0) hits.push({ app, methods });
+  }
+  return hits;
+}
+
+export function countHits(hits: AppHits[]): number {
+  return hits.reduce((total, hit) => total + hit.methods.length, 0);
+}

--- a/ui/src/scriptTree.test.ts
+++ b/ui/src/scriptTree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Script } from "./apps";
-import { buildScriptTree, fileRowCount, filterScripts, folderNameError, folderPaths, scriptNameParts, TreeNode, visibleRows } from "./scriptTree";
+import { buildScriptTree, filterScripts, folderNameError, folderPaths, scriptNameParts, TreeNode, visibleRows } from "./scriptTree";
 
 function script(folder: string, name: string): Script {
   return { path: `/w/scripts/${folder ? folder + "/" : ""}${name}`, name, folder };
@@ -48,13 +48,6 @@ describe("filterScripts", () => {
     expect(filterScripts(scripts, "churn").map((s) => s.name)).toEqual(["churn.ts", "churn-rate.ts"]);
     expect(filterScripts(scripts, "billing").map((s) => s.name)).toEqual(["churn-rate.ts"]);
     expect(filterScripts(scripts, "  ").length).toBe(3);
-  });
-});
-
-describe("fileRowCount", () => {
-  it("counts folders and files, which is what decides whether the filter earns its row", () => {
-    expect(fileRowCount([script("reports/weekly", "usage.ts")], [])).toBe(3);
-    expect(fileRowCount([], ["a", "b"])).toBe(2);
   });
 });
 

--- a/ui/src/scriptTree.ts
+++ b/ui/src/scriptTree.ts
@@ -110,14 +110,6 @@ export function filterScripts(scripts: Script[], query: string): Script[] {
   });
 }
 
-/** How many rows the Files group would draw fully expanded, which is what decides whether the filter is worth its row. */
-export function fileRowCount(scripts: Script[], folders: string[]): number {
-  const paths = new Set<string>();
-  for (const folder of folders) addFolderPath(paths, folder);
-  for (const script of scripts) addFolderPath(paths, script.folder);
-  return paths.size + scripts.length;
-}
-
 /**
  * A file's name split from its type. The sidebar is one list of names in one
  * font — mono was doing the work of saying "this one is on disk" and the group

--- a/ui/src/sidebarFilter.ts
+++ b/ui/src/sidebarFilter.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from "react";
+
+/**
+ * The sidebar's search, which belongs to the panel rather than to either section
+ * in it.
+ *
+ * That is why it is passed as a context instead of a prop: the Scripts region is
+ * handed to the sidebar as a node, because the two lists share nothing but the
+ * panel — and the search is the one thing that now spans both, so the region
+ * reads it from the panel rather than being told it by whoever assembled them.
+ *
+ * Hits travel back the other way so the field can state one number for a search
+ * over two lists. The sidebar counts its own catalog; anything else reports what
+ * it matched under a key of its own.
+ */
+
+export interface SidebarFilter {
+  query: string;
+  reportHits: (section: string, hits: number) => void;
+}
+
+const SidebarFilterContext = createContext<SidebarFilter>({ query: "", reportHits: () => {} });
+
+export const SidebarFilterProvider = SidebarFilterContext.Provider;
+
+export function useSidebarFilter(): SidebarFilter {
+  return useContext(SidebarFilterContext);
+}


### PR DESCRIPTION
Option 1B: the 40px band now holds only what is global — the search and `{ }`, flush right — with the traffic lights on macOS and the Kaja mark in the browser at its left, so both builds read the same. Scripts and Apps became peer 22px in-list headers with their own `+`, and the search spans both lists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7SvH46ihgLWaBXX2mtghN)_