### PR TITLE
Showed a script's link before copying it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ region in as a node, because the two lists share nothing but the panel.
   **file** row keeps only the kebab: taking a file off disk is not the loop this
   is for, and it still asks first.
 - **Delete and discard are different words for different consequences.** A file
-  row's menu is `Copy Link` / `Rename…` / `Move to…` / **`Delete file`**,
+  row's menu is `Copy Link…` / `Rename…` / `Move to…` / **`Delete file`**,
   destructive and confirmed, because it takes a file off disk — the only action
   in the sidebar
   that does, and the only one in `text-destructive`. A draft row's is `Name…` /
@@ -396,9 +396,38 @@ shell. Kaja integrates with none of them and reaches none of them.
   (`main.go`). It rides on a Wails event in each direction rather than a bound
   method, which is what keeps the generated bindings out of it.
 - **The link comes from the row that runs it**: right-click a script → **Copy
-  Link**, which is where the pin used to be. Nobody types one of these by hand,
-  and the parameters are appended wherever it is pasted, since that is where the
-  values that fill them come from.
+  Link…**, which is where the pin used to be. Nobody types one of these by hand.
+- **And it is shown before it is copied** (`CopyLinkSheet.tsx`), because the
+  clipboard is the wrong shape for this on its own: nobody has seen a `kaja://`
+  URL before, so a silent copy hands over a string that says nothing about what
+  it is or where it can be pasted — and the half of it worth having is the
+  query, which a copy of the bare address can't carry at all. So the sheet's
+  headline **is the URL**, whole, at body size, in one line of mono with the
+  scheme and the keys dimmed: it teaches the scheme, the script's address and
+  the query syntax at once, and nothing on screen has to explain any of them.
+  One line under it says what opens a URL — a Raycast quicklink, an Alfred
+  workflow, a Shortcut, `open` from a shell — and the clipboard is the only
+  exit. **Run now was designed and cut**: with two verbs the sheet is no longer
+  about copying, and running is two feet away in the command row with a console
+  attached to catch the output.
+- **The parameters are the script's own, read at the language level**
+  (`scriptInputs.ts`). `readInputKeys` walks the AST rather than the text, which
+  is the only way to be right about any of it: `kaja` is an ordinary local
+  binding, so what names it is what the file imported (`scriptBindings.ts`,
+  shared with `draftTitle`), and a key is written four ways a pattern over the
+  source would miss or invent — `kaja.input.url`, `kaja.input["order id"]`,
+  `const { url: link } = kaja.input`, and an alias a line above any of them. A
+  key the script computes is left out rather than guessed at, and a
+  `kaja.input.x` in a comment or a string is not a parameter. The keys are
+  **labels, not fields**: they come from the source, and an empty key/value grid
+  would ask for the thing the sheet exists to tell you. A blank value still
+  ships its `?key=` — that trailing equals is where a launcher's own token goes.
+  A script that reads nothing still gets the sheet, minus the block: the URL is
+  the whole point of it.
+- **The link the sheet shows is the link it copies, by construction.**
+  `scriptLinkParts` is what `scriptLink` is built from rather than a second
+  reading of it, so the dimming can't drift from the string, and each pair is
+  encoded by the same `URLSearchParams` that writes the whole query.
 - **Desktop only**, because registering a scheme is a bundle's to do
   (`info.protocols` in `wails.json` → `CFBundleURLTypes`). The web has no such
   door and grows no menu item for one.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -103,7 +103,9 @@ import {
   renameScriptFolder,
   writeScriptFile,
 } from "./scriptFiles";
-import { isLinkedScript, parseScriptLink, scriptLink } from "./scriptLink";
+import { isLinkedScript, parseScriptLink } from "./scriptLink";
+import { readInputKeys } from "./scriptInputs";
+import { CopyLinkSheet } from "./CopyLinkSheet";
 import { MCPScriptResult, MCPServerInfo, MCPSetCatalog, ResolvedVariables, ScriptsFolder, ShowFileInFinder } from "./wailsjs/go/main/App";
 import { main } from "./wailsjs/go/models";
 import { runScript, runScriptCaptured } from "./scriptRunner";
@@ -371,6 +373,8 @@ export function App() {
   const [clearAllPrompt, setClearAllPrompt] = useState<{ all: Draft[]; edited: Draft[] } | null>(null);
   // A `kaja://run/…` link that arrived and is waiting to be let through.
   const [linkPrompt, setLinkPrompt] = useState<{ script: Script; input: { [key: string]: string } } | null>(null);
+  // The link a script is being copied from, and the parameters it takes.
+  const [linkSheet, setLinkSheet] = useState<{ script: Script; parameters: string[] } | null>(null);
   /**
    * The runs in flight. There is more than one because there is nothing to stop
    * there being: ⌘⏎ twice, Run on a second file, a `kaja://` link arriving while
@@ -1369,11 +1373,24 @@ export function App() {
     [applyViews, showFileError],
   );
 
-  // Right-click → the `kaja://run/<script>` link that runs this script, for
-  // whatever the link is going to be pasted into.
-  const onCopyScriptLink = useCallback((script: Script) => {
-    navigator.clipboard?.writeText(scriptLink(scriptName(script))).catch(() => {});
-  }, []);
+  // Right-click → the `kaja://run/<script>` link that runs this script, shown
+  // before it is copied: nobody has seen one of these before, and the half of
+  // it worth having is the query, which a silent copy can't carry. The
+  // parameters are read out of the script's own source, so the sheet asks for
+  // what this script actually takes — from the open buffer when it is open,
+  // since that is the script as it is now rather than as disk caught up to it.
+  const onCopyScriptLink = useCallback(
+    async (script: Script) => {
+      try {
+        const open = viewsRef.current.find((view) => view.type === "script" && view.script.path === script.path);
+        const content = open?.type === "script" ? open.model.getValue() : (await readScriptFile(script))?.content;
+        setLinkSheet({ script, parameters: content ? readInputKeys(content) : [] });
+      } catch (err) {
+        showFileError(`Copy link failed: ${err}`);
+      }
+    },
+    [showFileError],
+  );
 
   // A `kaja://run/…` link opens the script it names and asks. Anything that can
   // open a URL can arrive here — a launcher, a Shortcut, a web page — so the
@@ -2529,7 +2546,7 @@ export function App() {
                     onRenameScript={canWriteScripts() ? onRenameScript : undefined}
                     onMoveScript={canWriteScripts() ? onMoveScript : undefined}
                     onDeleteScript={canWriteScripts() ? (script) => setDeleteScript(script) : undefined}
-                    onCopyScriptLink={isWailsEnvironment() ? onCopyScriptLink : undefined}
+                    onCopyScriptLink={isWailsEnvironment() ? (script) => void onCopyScriptLink(script) : undefined}
                     onCreateFolder={canWriteScripts() ? onCreateFolder : undefined}
                     onRenameFolder={canWriteScripts() ? onRenameFolder : undefined}
                     onDeleteFolder={canWriteScripts() ? (path) => setDeleteFolder(path) : undefined}
@@ -2897,6 +2914,7 @@ export function App() {
           </div>
         </Dialog>
       )}
+      {linkSheet && <CopyLinkSheet script={linkSheet.script} parameters={linkSheet.parameters} onClose={() => setLinkSheet(null)} />}
       {newAppOpen && <NewAppDialog appsPreviewEnabled={previewApps} onClose={() => setNewAppOpen(false)} onSelect={onSelectAppType} />}
       {deleteScript && (
         <ConfirmationDialog

--- a/ui/src/CopyLinkSheet.tsx
+++ b/ui/src/CopyLinkSheet.tsx
@@ -1,0 +1,154 @@
+import { Check, Copy, Link2 } from "lucide-react";
+import { Fragment, useCallback, useMemo, useRef, useState } from "react";
+
+import { Script, scriptName } from "./apps";
+import { cn } from "./cn";
+import { Dialog } from "./components/dialog";
+import { IconButton } from "./components/icon-button";
+import { Input } from "./components/input";
+import { linkName, scriptLinkParts } from "./scriptLink";
+
+export interface CopyLinkSheetProps {
+  script: Script;
+  // The parameters the script reads, in the order it reads them. Read from its
+  // own source, so the fields are the script's actual inputs.
+  parameters: string[];
+  onClose: () => void;
+}
+
+/**
+ * A script's address outside Kaja, shown before it is copied.
+ *
+ * Nobody has seen a `kaja://` URL before, and the half of it worth having is
+ * the query — so a silent copy hands over a string that says nothing and
+ * carries no parameters. The URL is the headline here rather than a caption:
+ * shown whole, at body size, it teaches the scheme, the script's address and
+ * the query syntax at once, and no copy on screen has to explain any of it.
+ *
+ * The clipboard is the only exit. Running is two feet away in the command row,
+ * with a console attached to catch the output.
+ */
+export function CopyLinkSheet({ script, parameters, onClose }: CopyLinkSheetProps) {
+  const [values, setValues] = useState<{ [key: string]: string }>({});
+  const [copied, setCopied] = useState(false);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  const name = scriptName(script);
+  // Every parameter rides along, blank or not: the trailing `=` is where a
+  // launcher's own token goes, so it has to be in what gets copied.
+  const parts = useMemo(() => scriptLinkParts(name, Object.fromEntries(parameters.map((key) => [key, values[key] ?? ""]))), [name, parameters, values]);
+  const link = parts.map((part) => part.text).join("");
+  // An illustration rather than the link again: the URL is already on screen
+  // whole, and this line is about the shell, not about this script's values.
+  const address = parts
+    .filter((part) => part.kind === "scheme" || part.kind === "script")
+    .map((part) => part.text)
+    .join("");
+  const firstKey = parts.find((part) => part.kind === "key");
+  const shellExample = firstKey ? `${address}${firstKey.text}…` : address;
+
+  const copy = useCallback(() => {
+    navigator.clipboard?.writeText(link).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      },
+      () => {},
+    );
+  }, [link]);
+
+  const copyAndClose = useCallback(() => {
+    navigator.clipboard?.writeText(link).catch(() => {});
+    onClose();
+  }, [link, onClose]);
+
+  return (
+    <Dialog
+      title={
+        <span className="flex items-center gap-2">
+          <Link2 size={15} className="shrink-0 text-muted-foreground" />
+          <span>
+            Copy link to <span className="font-mono">{linkName(script.name)}</span>
+          </span>
+        </span>
+      }
+      onClose={onClose}
+      initialFocusRef={parameters.length > 0 ? firstFieldRef : undefined}
+      footerButtons={[
+        { content: "Cancel", variant: "ghost", onClick: onClose },
+        { content: "Copy link", variant: "default", onClick: copyAndClose },
+      ]}
+    >
+      <div className={cn("flex flex-col py-3", parameters.length > 0 ? "gap-4" : "gap-3")}>
+        <div className="relative rounded-md border border-border bg-muted/40 p-3 pr-10">
+          <p className="m-0 break-all font-mono text-sm leading-[1.55] text-foreground">
+            {parts.map((part, index) => (
+              <span key={index} className={part.kind === "scheme" || part.kind === "key" ? "text-muted-foreground" : undefined}>
+                {part.text}
+              </span>
+            ))}
+          </p>
+          <div className="absolute right-1.5 top-1.5">
+            <IconButton icon={copied ? Check : Copy} aria-label={copied ? "Copied" : "Copy link"} variant="ghost" size="sm" onClick={copy} />
+          </div>
+        </div>
+
+        {parameters.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-baseline gap-2">
+              <span className="text-xs font-medium text-muted-foreground">Parameters</span>
+              <span className="text-xs text-muted-foreground opacity-75">read from the script</span>
+            </div>
+            {/* The keys come from the source, so they are labels rather than
+                fields: an empty key/value grid would ask for the thing this
+                sheet exists to tell you. */}
+            <div className="grid grid-cols-4 items-center gap-3">
+              {parameters.map((key, index) => (
+                <Fragment key={key}>
+                  <label className="col-span-1 truncate font-mono text-sm text-foreground" htmlFor={`link-parameter-${index}`} title={key}>
+                    {key}
+                  </label>
+                  <div className="col-span-3">
+                    <Input
+                      id={`link-parameter-${index}`}
+                      ref={index === 0 ? firstFieldRef : undefined}
+                      value={values[key] ?? ""}
+                      placeholder="leave blank to fill in later"
+                      onChange={(event) => setValues((prev) => ({ ...prev, [key]: event.target.value }))}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          copyAndClose();
+                        }
+                      }}
+                    />
+                  </div>
+                </Fragment>
+              ))}
+            </div>
+            <p className="m-0 text-xs leading-[1.55] text-muted-foreground">
+              A value typed here is baked into the link. Left blank, the key still ships — point a launcher's token at it, like Raycast&rsquo;s{" "}
+              <span className="font-mono">{"{clipboard}"}</span>.
+            </p>
+          </div>
+        )}
+
+        {parameters.length > 0 ? (
+          <div className="rounded-md border border-border px-3 py-2">
+            <p className="m-0 text-xs leading-[1.6] text-muted-foreground">
+              Anything on this Mac that opens a URL can run this script: a Raycast quicklink, an Alfred workflow, a Shortcut, or{" "}
+              <span className="font-mono text-foreground">open &ldquo;{shellExample}&rdquo;</span> in a shell.
+            </p>
+          </div>
+        ) : (
+          // A script that takes nothing still gets the sheet: the URL is the
+          // whole point of it, and this is the shortest version of the lesson.
+          <p className="m-0 text-xs leading-[1.6] text-muted-foreground">
+            This script takes no parameters. Anything that opens a URL can run it — a Raycast quicklink, an Alfred workflow, a Shortcut, or{" "}
+            <span className="font-mono text-foreground">open</span> in a shell.
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -400,12 +400,13 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
             you type. And there is no route from here into Drafts either — that
             group is for things that have never had a name. */}
         {/* A script's address outside Kaja — paste it into a launcher, a
-            Shortcut, a shell, and append the parameters where the values that
-            fill them come from. */}
+            Shortcut, a shell. It opens a sheet rather than copying straight to
+            the clipboard: the URL is worth reading before it leaves, and the
+            parameters are worth filling in while it is being built. */}
         {props.onCopyScriptLink && (
           <DropdownMenuItem onSelect={() => scriptMenu && props.onCopyScriptLink?.(scriptMenu.script)}>
             <Link2 size={16} />
-            Copy Link
+            Copy Link…
           </DropdownMenuItem>
         )}
         {props.onRenameScript && (

--- a/ui/src/draftTitle.ts
+++ b/ui/src/draftTitle.ts
@@ -1,4 +1,5 @@
 import { SUBJECT_FIELDS } from "./loopKey";
+import { importedNames, runtimeNames } from "./scriptBindings";
 import ts from "typescript";
 
 // A request small enough to read at a glance is described by its values, which
@@ -44,29 +45,6 @@ export function readCalls(code: string): DraftCall[] {
   ts.forEachChild(file, visit);
 
   return calls;
-}
-
-function importedNames(file: ts.SourceFile): Set<string> {
-  return boundNames(file, () => true);
-}
-
-// Whatever the kaja runtime was bound to in this file, alias included — Monaco's
-// auto-import can write the relative form of the module.
-function runtimeNames(file: ts.SourceFile): Set<string> {
-  return boundNames(file, (path) => path === "kaja" || path === "./kaja");
-}
-
-function boundNames(file: ts.SourceFile, wanted: (modulePath: string) => boolean): Set<string> {
-  const names = new Set<string>();
-  for (const statement of file.statements) {
-    if (!ts.isImportDeclaration(statement)) continue;
-    if (!ts.isStringLiteral(statement.moduleSpecifier) || !wanted(statement.moduleSpecifier.text)) continue;
-    const bindings = statement.importClause?.namedBindings;
-    if (bindings && ts.isNamedImports(bindings)) {
-      for (const element of bindings.elements) names.add(element.name.text);
-    }
-  }
-  return names;
 }
 
 // The generated request only ever holds zero values, so an empty string, a 0 or

--- a/ui/src/scriptBindings.ts
+++ b/ui/src/scriptBindings.ts
@@ -1,0 +1,32 @@
+import ts from "typescript";
+
+/**
+ * What a script's imports bound, which is the only thing that says what a name
+ * in the body means. `kaja` and a service are both ordinary local bindings, so
+ * a receiver is identified by what brought it into the file rather than by how
+ * it is spelled.
+ */
+
+/** Every name the file imported, whatever it imported it from. */
+export function importedNames(file: ts.SourceFile): Set<string> {
+  return boundNames(file, () => true);
+}
+
+// Whatever the kaja runtime was bound to in this file, alias included — Monaco's
+// auto-import can write the relative form of the module.
+export function runtimeNames(file: ts.SourceFile): Set<string> {
+  return boundNames(file, (path) => path === "kaja" || path === "./kaja");
+}
+
+function boundNames(file: ts.SourceFile, wanted: (modulePath: string) => boolean): Set<string> {
+  const names = new Set<string>();
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    if (!ts.isStringLiteral(statement.moduleSpecifier) || !wanted(statement.moduleSpecifier.text)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) names.add(element.name.text);
+    }
+  }
+  return names;
+}

--- a/ui/src/scriptInputs.test.ts
+++ b/ui/src/scriptInputs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { readInputKeys } from "./scriptInputs";
+
+const script = (body: string, imports = `import { kaja } from "kaja";`) => `${imports}\n\n${body}\n`;
+
+describe("readInputKeys", () => {
+  it("reads a property access, in source order", () => {
+    expect(readInputKeys(script(`const url = kaja.input.url;\nconst note = kaja.input.note;`))).toEqual(["url", "note"]);
+  });
+
+  it("names each key once, however often it is read", () => {
+    expect(readInputKeys(script(`if (kaja.input.url) kaja.text(kaja.input.url);`))).toEqual(["url"]);
+  });
+
+  it("reads an optional chain", () => {
+    expect(readInputKeys(script(`const url = kaja.input?.url ?? "";`))).toEqual(["url"]);
+  });
+
+  it("reads a bracketed key, which is the only way to write one that isn't an identifier", () => {
+    expect(readInputKeys(script(`const value = kaja.input["order id"];`))).toEqual(["order id"]);
+  });
+
+  it("reads a destructuring, and a rename by the key rather than the local name", () => {
+    expect(readInputKeys(script(`const { url: link, note } = kaja.input;`))).toEqual(["url", "note"]);
+  });
+
+  it("ignores the rest of a destructuring, which names no key", () => {
+    expect(readInputKeys(script(`const { url, ...rest } = kaja.input;`))).toEqual(["url"]);
+  });
+
+  it("follows a name bound to the input map", () => {
+    expect(readInputKeys(script(`const input = kaja.input;\nconst url = input.url;\nconst { note } = input;`))).toEqual(["url", "note"]);
+  });
+
+  it("follows the alias the import was given", () => {
+    expect(readInputKeys(script(`const url = k.input.url;`, `import { kaja as k } from "kaja";`))).toEqual(["url"]);
+  });
+
+  it("reads a file that hasn't imported the runtime yet", () => {
+    expect(readInputKeys(`const url = kaja.input.url;`)).toEqual(["url"]);
+  });
+
+  // The whole reason this is an AST read rather than a pattern over the source.
+  it("ignores an `input` on anything but the runtime", () => {
+    const code = script(`const url = call.input.url;\nconst other = response.input["note"];`);
+    expect(readInputKeys(code)).toEqual([]);
+  });
+
+  it("ignores a mention in a comment or a string", () => {
+    const code = script(`// kaja.input.stale\nkaja.text("kaja.input.quoted");`);
+    expect(readInputKeys(code)).toEqual([]);
+  });
+
+  it("ignores a key the script computes, since there is no name to list", () => {
+    expect(readInputKeys(script(`const which = "url";\nconst value = kaja.input[which];`))).toEqual([]);
+  });
+
+  it("says nothing about a script that reads the map whole", () => {
+    expect(readInputKeys(script(`for (const [name, value] of Object.entries(kaja.input)) kaja.text(name + value);`))).toEqual([]);
+  });
+
+  it("reads a key deep inside the script", () => {
+    const code = script(`async function main() {\n  const rows = kaja.table(["a"]);\n  rows.row(kaja.input.since);\n}\nawait main();`);
+    expect(readInputKeys(code)).toEqual(["since"]);
+  });
+
+  it("reads what it can out of a file that doesn't parse", () => {
+    expect(readInputKeys(script(`const url = kaja.input.url;\nconst broken = (;`))).toEqual(["url"]);
+  });
+
+  it("has nothing to say about a script that takes nothing", () => {
+    expect(readInputKeys(script(`kaja.text("hello");`))).toEqual([]);
+  });
+});

--- a/ui/src/scriptInputs.ts
+++ b/ui/src/scriptInputs.ts
@@ -1,0 +1,97 @@
+import { runtimeNames } from "./scriptBindings";
+import ts from "typescript";
+
+/**
+ * The parameters a script takes, in the order it reads them.
+ *
+ * `kaja://run/<script>?key=value` leaves the whole query to the script, so the
+ * only thing that knows which keys a script takes is the script — and the only
+ * thing that knows what a name in it means is the compiler. So this reads the
+ * AST rather than the text: `kaja` is an ordinary local binding, and a key is
+ * written four ways that a pattern over the source would either miss or invent.
+ * `kaja.input["a key"]`, `const { url: link } = kaja.input` and an alias one
+ * line up are all reads of a parameter; a property called `input` on something
+ * else entirely is not, and a `kaja.input` in a comment or a string is not.
+ *
+ * A key the script computes (`kaja.input[whichever]`) is left out rather than
+ * guessed at: the sheet lists what the script names, and a value nothing named
+ * can still be typed into the link by hand.
+ */
+export function readInputKeys(code: string): string[] {
+  const file = ts.createSourceFile("script.ts", code, ts.ScriptTarget.Latest, /*setParentNodes*/ false, ts.ScriptKind.TS);
+  // A file mid-edit may not have written the import yet, and the runtime is
+  // spelled `kaja` everywhere it isn't aliased.
+  const runtime = runtimeNames(file);
+  const receivers = runtime.size > 0 ? runtime : new Set(["kaja"]);
+  const aliases = inputAliases(file, receivers);
+
+  const isInput = (node: ts.Expression): boolean => {
+    if (ts.isIdentifier(node)) return aliases.has(node.text);
+    return ts.isPropertyAccessExpression(node) && node.name.text === "input" && ts.isIdentifier(node.expression) && receivers.has(node.expression.text);
+  };
+
+  const keys = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isPropertyAccessExpression(node) && isInput(node.expression)) {
+      keys.add(node.name.text);
+    } else if (ts.isElementAccessExpression(node) && isInput(node.expression)) {
+      const literal = stringLiteral(node.argumentExpression);
+      if (literal !== undefined) keys.add(literal);
+    } else if (ts.isVariableDeclaration(node) && node.initializer && isInput(node.initializer) && ts.isObjectBindingPattern(node.name)) {
+      for (const key of boundKeys(node.name)) keys.add(key);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(file, visit);
+
+  return [...keys];
+}
+
+// Names bound to the input map itself (`const input = kaja.input`), so the
+// reads a line later are reads of a parameter.
+function inputAliases(file: ts.SourceFile, receivers: Set<string>): Set<string> {
+  const aliases = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isPropertyAccessExpression(node.initializer) &&
+      node.initializer.name.text === "input" &&
+      ts.isIdentifier(node.initializer.expression) &&
+      receivers.has(node.initializer.expression.text)
+    ) {
+      aliases.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(file, visit);
+  return aliases;
+}
+
+// The keys a destructuring reads. A rename (`{ url: link }`) is a read of
+// `url`, which is the name the link has to carry.
+function boundKeys(pattern: ts.ObjectBindingPattern): string[] {
+  const keys: string[] = [];
+  for (const element of pattern.elements) {
+    // `...rest` names no key.
+    if (element.dotDotDotToken) continue;
+    if (element.propertyName) {
+      const literal = ts.isComputedPropertyName(element.propertyName)
+        ? stringLiteral(element.propertyName.expression)
+        : ts.isIdentifier(element.propertyName) || ts.isStringLiteral(element.propertyName)
+          ? element.propertyName.text
+          : undefined;
+      if (literal !== undefined) keys.push(literal);
+    } else if (ts.isIdentifier(element.name)) {
+      keys.push(element.name.text);
+    }
+  }
+  return keys;
+}
+
+function stringLiteral(node: ts.Expression | undefined): string | undefined {
+  if (!node) return undefined;
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  return undefined;
+}

--- a/ui/src/scriptLink.test.ts
+++ b/ui/src/scriptLink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isLinkedScript, linkName, parseScriptLink, scriptLink } from "./scriptLink";
+import { isLinkedScript, linkName, parseScriptLink, scriptLink, scriptLinkParts } from "./scriptLink";
 
 function parsed(text: string) {
   const result = parseScriptLink(text);
@@ -79,6 +79,33 @@ describe("scriptLink", () => {
   test("round-trips what it built", () => {
     const input = { url: "https://example.com/x y", "odd key": "a&b=c" };
     expect(parsed(scriptLink("thread.ts", input))).toEqual({ script: "thread", input });
+  });
+
+  // What the sheet is for: a key with nothing behind it is where a launcher's
+  // own token goes, so the link has to carry it.
+  test("keeps a key whose value is blank", () => {
+    expect(scriptLink("thread.ts", { url: "", note: "" })).toBe("kaja://run/thread?url=&note=");
+  });
+});
+
+describe("scriptLinkParts", () => {
+  test("is the link it splits", () => {
+    const input = { url: "https://example.com/a?b=1", note: "" };
+    expect(
+      scriptLinkParts("reports/weekly usage.ts", input)
+        .map((part) => part.text)
+        .join(""),
+    ).toBe(scriptLink("reports/weekly usage.ts", input));
+  });
+
+  test("separates what the scheme says from what the script says", () => {
+    expect(scriptLinkParts("thread.ts", { url: "abc", note: "" })).toEqual([
+      { kind: "scheme", text: "kaja://run/" },
+      { kind: "script", text: "thread" },
+      { kind: "key", text: "?url=" },
+      { kind: "value", text: "abc" },
+      { kind: "key", text: "&note=" },
+    ]);
   });
 });
 

--- a/ui/src/scriptLink.ts
+++ b/ui/src/scriptLink.ts
@@ -44,13 +44,40 @@ export function isLinkedScript(scriptName: string, named: string): boolean {
 
 /** The link that runs a script. What the sidebar's Copy Link puts on the clipboard. */
 export function scriptLink(fileName: string, input?: { [key: string]: string }): string {
+  return scriptLinkParts(fileName, input)
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * The same link, split into what it is made of. The sheet shows the URL whole
+ * and dims everything that is the scheme rather than the script's own — so the
+ * link it displays is the link it copies, by construction rather than by two
+ * functions agreeing.
+ */
+export type LinkPart = { kind: "scheme" | "script" | "key" | "value"; text: string };
+
+export function scriptLinkParts(fileName: string, input?: { [key: string]: string }): LinkPart[] {
   const path = linkName(fileName)
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-  const link = `${LINK_SCHEME}://run/${path}`;
-  const query = new URLSearchParams(input ?? {}).toString();
-  return query ? `${link}?${query}` : link;
+  const parts: LinkPart[] = [
+    { kind: "scheme", text: `${LINK_SCHEME}://run/` },
+    { kind: "script", text: path },
+  ];
+
+  const entries = Object.entries(input ?? {});
+  entries.forEach(([name, value], index) => {
+    // Encoded a pair at a time, by the same URLSearchParams that writes the
+    // whole query, so splitting the link up can't change what it says.
+    const pair = new URLSearchParams([[name, value]]).toString();
+    const equals = pair.indexOf("=");
+    parts.push({ kind: "key", text: `${index === 0 ? "?" : "&"}${pair.slice(0, equals + 1)}` });
+    if (equals + 1 < pair.length) parts.push({ kind: "value", text: pair.slice(equals + 1) });
+  });
+
+  return parts;
 }
 
 function baseName(path: string): string {


### PR DESCRIPTION
Copy Link… now opens a sheet with the `kaja://` URL as its headline and a field per parameter, instead of copying a bare address silently. The parameters are read out of the script's AST (`kaja.input.<key>`, bracketed keys, destructuring, aliases) rather than grepped.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nq7UvmTHNtGde4MeePngk)_