### PR TITLE
Made the Copy link menu item sentence case

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ region in as a node, because the two lists share nothing but the panel.
   **file** row keeps only the kebab: taking a file off disk is not the loop this
   is for, and it still asks first.
 - **Delete and discard are different words for different consequences.** A file
-  row's menu is `Copy Link…` / `Rename…` / `Move to…` / **`Delete file`**,
+  row's menu is `Copy link…` / `Rename…` / `Move to…` / **`Delete file`**,
   destructive and confirmed, because it takes a file off disk — the only action
   in the sidebar
   that does, and the only one in `text-destructive`. A draft row's is `Name…` /

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -406,7 +406,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
         {props.onCopyScriptLink && (
           <DropdownMenuItem onSelect={() => scriptMenu && props.onCopyScriptLink?.(scriptMenu.script)}>
             <Link2 size={16} />
-            Copy Link…
+            Copy link…
           </DropdownMenuItem>
         )}
         {props.onRenameScript && (

--- a/ui/src/scriptLink.ts
+++ b/ui/src/scriptLink.ts
@@ -42,7 +42,7 @@ export function isLinkedScript(scriptName: string, named: string): boolean {
   return !wanted.includes("/") && baseName(linkName(scriptName)) === wanted;
 }
 
-/** The link that runs a script. What the sidebar's Copy Link puts on the clipboard. */
+/** The link that runs a script. What the sidebar's Copy link puts on the clipboard. */
 export function scriptLink(fileName: string, input?: { [key: string]: string }): string {
   return scriptLinkParts(fileName, input)
     .map((part) => part.text)


### PR DESCRIPTION
The script row's menu read `Copy Link…` while the sheet it opens says "Copy link" — every other item in that menu is sentence case, so the label now is too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzzjckU5wdm1FAvaFCzjMr)_