### PR TITLE
Restructured the README around the website's hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 <p align="center">
-  <a href="https://kaja.tools"><img src="docs/logo.svg" alt="Kaja" /></a>
+  <a href="https://kaja.tools"><img src="docs/logo.svg" alt="Kaja" width="240" /></a>
+</p>
+
+<p align="center">
+  <sub><b>macOS · Docker</b></sub>
 </p>
 
 <h3 align="center">A canvas for your APIs</h3>
 
 <p align="center">
-  An agent calling your APIs leaves you a transcript to trust. Kaja gives it a canvas instead.
+  An API client like Postman or Bruno, except your agent writes the payloads.
   <br/>
-  Connect your <a href="https://grpc.io">gRPC</a>, <a href="https://www.openapis.org">OpenAPI</a> and <a href="https://modelcontextprotocol.io">MCP</a> apps, and what your agent does is drawn, logged call by call, and paused for your approval whenever you want one.
+  Kaja draws the flow, and you can inspect every call.
 </p>
 
 <p align="center">
@@ -21,6 +25,7 @@
 </p>
 
 <p align="center">
+  <a href="https://kaja.tools/docs"><strong>Documentation</strong></a> ·
   <a href="https://demo.kaja.tools"><strong>Live Demo</strong></a> ·
   <a href="https://kaja.tools"><strong>Website</strong></a>
 </p>
@@ -32,114 +37,31 @@
 </p>
 
 <p align="center">
+  <img src="docs/how-it-works.svg" alt="gRPC, OpenAPI and MCP apps on one side, an agent writing scripts and you approving writes on the other, all meeting in Kaja" width="840" />
+</p>
+
+<p align="center">
   <a href="https://demo.kaja.tools">
-    <img src="docs/screenshot-1.png" alt="Kaja running a script against a gRPC app" width="720" />
+    <img src="docs/screenshot-1.png" alt="Kaja running a script against a gRPC app" width="820" />
   </a>
 </p>
 
-## Features
+## Documentation
 
-- **Your agent drives it.** Kaja runs an [MCP](https://modelcontextprotocol.io) server, so your agent reads what your apps expose, writes TypeScript against them, and runs it. Nothing it does is invisible: every run lands in the sidebar next to your own.
-- **A canvas, not a transcript.** A script draws what it produced. Tables fill row by row as a loop runs, page and search themselves, and sit alongside text and code.
-- **Every call is on the record.** Request, response, headers and duration for each call in a run, whoever pressed Run.
-- **Approval when you want it.** A script can hold a call until you approve it, so a write goes out when you say so and not before.
-- **gRPC, OpenAPI and MCP.** Read the surface from your `.proto` files, from [gRPC server reflection](https://grpc.io/docs/guides/reflection/), from an OpenAPI document, or from another MCP server. [Twirp](https://github.com/twitchtv/twirp) is supported too.
-- **Still yours to drive.** Click a method and Kaja writes you the call, with full autocomplete for apps, methods and message fields.
-- **macOS & Docker.** Available on the [Mac App Store](https://apps.apple.com/us/app/kaja-for-grpc-and-twirp/id6761604205?mt=12) or as a [Docker container](https://hub.docker.com/r/kajatools/kaja) for any environment.
+Installing Kaja, connecting apps, keeping credentials in variables, writing scripts
+and pointing an agent at it are all documented on the website.
 
-## Run with Docker
+<h3 align="center">
+  <a href="https://kaja.tools/docs">Read the docs at kaja.tools/docs →</a>
+</h3>
 
-```
-docker run --pull always --name kaja -d -p 41520:41520 \
-    -v /my_app/proto:/workspace/proto \
-    -v /my_app/kaja.json:/workspace/kaja.json \
-    -v /my_app/scripts:/workspace/scripts \
-    --add-host=host.docker.internal:host-gateway kajatools/kaja:latest
-```
-
-Then open [http://localhost:41520](http://localhost:41520).
-
-The `scripts` mount is optional: `.ts` files in `/workspace/scripts` appear under
-**Scripts** in the sidebar, ready to open and run. The container serves its
-workspace read-only, so they can't be edited from the browser — check them into
-the repository they belong to and mount them in.
-
-## Configuration
-
-On **macOS**, apps are configured through the UI. The configuration is stored at `~/Library/Application Support/kaja/kaja.json`.
-
-With **Docker**, create a `kaja.json` file and mount it into the container. Every entry in `apps` is one app: a `name` plus one block whose key is the app's type, holding that type's parameters:
-
-```json
-{
-  "apps": [
-    {
-      "name": "users",
-      "twirp": {
-        "url": "http://host.docker.internal:41522",
-        "proto_dir": "users/proto"
-      }
-    },
-    {
-      "name": "teams",
-      "grpc": {
-        "url": "host.docker.internal:41523",
-        "reflection": true,
-        "headers": { "Authorization": "Bearer xxx" }
-      }
-    }
-  ]
-}
-```
-
-The server serves a workspace it does not own, so the UI shows this configuration read-only: it is managed by whoever mounts the file — checked into Git, deployed with the container — and not edited by the engineers running it.
-
-### App options
-
-Each app has a `name` and exactly one typed block:
-
-| Type | Parameters |
-|---|---|
-| `grpc` | `url`, `proto_dir` (path to `.proto` files), `reflection` (use [gRPC server reflection](https://grpc.io/docs/guides/reflection/) instead of local proto files), `headers` |
-| `twirp` | `url`, `proto_dir`, `headers` |
-
-`headers` are sent with each request (e.g. `{"Authorization": "Bearer xxx"}`); for gRPC they are sent as metadata.
-
-#### Migrating from the old format
-
-Earlier versions used a top-level `projects` list with a `protocol` field. Kaja migrates these automatically on load — but to update a file by hand, move each project into `apps` and replace its `protocol`/`url`/`protoDir`/`useReflection` fields with a block named after the type.
-
-Before:
-
-```json
-{
-  "projects": [
-    { "name": "users", "protocol": "RPC_PROTOCOL_TWIRP", "url": "http://host.docker.internal:41522", "protoDir": "users/proto" }
-  ]
-}
-```
-
-After:
-
-```json
-{
-  "apps": [
-    { "name": "users", "twirp": { "url": "http://host.docker.internal:41522", "proto_dir": "users/proto" } }
-  ]
-}
-```
-
-### Docker arguments
-
-| Argument | Description |
-|---|---|
-| `--pull always` | Always pull the latest image. Kaja is updated frequently. |
-| `--name kaja` | Name the container for easy management. |
-| `-d` | Run in [detached mode](https://docs.docker.com/engine/reference/run/#detached--d). |
-| `-p 41520:41520` | Map the container port. Kaja listens on 41520 by default. |
-| `-v .../proto:/workspace/proto` | Mount your [proto_path](https://protobuf.dev/reference/cpp/api-docs/google.protobuf.compiler.command_line_interface/) into the container. |
-| `-v .../kaja.json:/workspace/kaja.json` | Mount your [configuration file](#configuration). |
-| `--add-host=host.docker.internal:host-gateway` | Access host services from the container. |
+|  |  |
+| --- | --- |
+| **[Installation](https://kaja.tools/docs#installation)** | The Mac App Store build, or one `docker run` with your protos and `kaja.json` mounted |
+| **[Apps](https://kaja.tools/docs#apps)** | Connect gRPC, OpenAPI, Twirp and MCP apps, and what each type's block takes |
+| **[Variables](https://kaja.tools/docs#variables)** | Named values your scripts and your app configuration both read, with secrets kept out of the file |
+| **[Scripts](https://kaja.tools/docs#scripts)** | TypeScript with a typed import for every app you connected, drawing on the canvas |
+| **[Agents](https://kaja.tools/docs#agents)** | Point your agent at Kaja's MCP server, and watch every run it makes |
 
 ## Development
 
@@ -150,28 +72,12 @@ The development scripts require [Go](https://go.dev/doc/install) and [Bun](https
 - Run the desktop app: `scripts/desktop`
 - Test UI: `(cd ui && bun test)`
 - TSC UI: `(cd ui && bun run tsc)`
-- Test server: `(cd server && go test ./... -tags development -v)` — the tag `scripts/server` builds with. Without it the packages embed a production UI bundle, which only `go run cmd/build-ui/main.go` writes.
-- Update demo protos: `scripts/demo-protos` — refreshes the `quirks` and `grpcb.in` protos in `workspace/`. The demo *services* live in [kaja-tools/website](https://github.com/kaja-tools/website); `theatre`, `seating` and `concierge` need no protos here, since they are OpenAPI, gRPC reflection and MCP respectively.
-
-### The demo, and the preview apps
-
-Both public deployments serve this repository's own `workspace/` — the demo apps `scripts/server` starts on — baked into the image by the Dockerfile's `demo` stage. **One image, two places it runs**, so a change is clicked through on exactly what it will become:
-
-- **[demo.kaja.tools](https://demo.kaja.tools)** (`deploy/demo/fly.toml`) — deployed by the **main** workflow on every push to `main`, and so from the commit that changed it. One machine stays up, so the first visitor of the day doesn't wait for a cold start.
-- **`https://kaja-pr-<number>.fly.dev`** (`deploy/preview/fly.toml`) — one app per pull request, so a change can be clicked through before it is merged. The **preview** workflow rebuilds it on every push and destroys the app when the pull request closes; the URL is a comment on the pull request throughout. A preview runs no machine until someone opens its URL.
-
-The workspace's configuration is read-only, like any server build, so neither ever asks Fly for a disk, and `workspace/scripts/` ships with them — the demo opens with scripts to press Run on.
-
-Fork pull requests are skipped: they have no access to the token. Setting this up in a fresh repository takes a `FLY_API_TOKEN` secret that may create and destroy apps (`fly tokens create org <org>` — an app-scoped deploy token can't create the per-pull-request apps), and optionally a `FLY_ORG` variable if the org isn't `personal`. The demo's own app and certificate are created once, by hand:
-
-```bash
-fly apps create kaja-demo
-fly certs add demo.kaja.tools --app kaja-demo
-```
+- Test server: `(cd server && go test ./... -tags development -v)`. The `development` tag is the one `scripts/server` builds with. Without it the packages embed a production UI bundle, which only `go run cmd/build-ui/main.go` writes.
+- Update demo protos: `scripts/demo-protos` refreshes the `quirks` and `grpcb.in` protos in `workspace/`. The demo services themselves live in [kaja-tools/website](https://github.com/kaja-tools/website).
 
 ### Releases
 
-Releases are cut from GitHub — no local build needed. Every push to `main` uploads a new build to TestFlight. To ship a version, run the **release** workflow (Actions → Run workflow):
+Releases are cut from GitHub, so no local build is needed. Every push to `main` uploads a new build to TestFlight. To ship a version, run the **release** workflow (Actions → Run workflow):
 
-- `open` (with `patch`/`minor`/`major`) — bumps the version on a branch and opens a PR. **Merge it yourself**: `main` is protected, so the bump has to arrive as a PR and pass the `test` check. TestFlight builds carry the new version from then on.
-- `ship` — tags the commit and publishes a GitHub Release for it, with notes covering the whole cycle. Run it when you promote one of those TestFlight builds to the App Store.
+- `open` (with `patch`/`minor`/`major`) bumps the version on a branch and opens a PR. **Merge it yourself**: `main` is protected, so the bump has to arrive as a PR and pass the `test` check. TestFlight builds carry the new version from then on.
+- `ship` tags the commit and publishes a GitHub Release for it, with notes covering the whole cycle. Run it when you promote one of those TestFlight builds to the App Store.

--- a/docs/how-it-works.svg
+++ b/docs/how-it-works.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 300" width="1000" height="300" role="img" aria-label="Three surfaces Kaja reads on the left, an agent and your approval on the right, all meeting in Kaja.">
+  <style>
+    .card { fill: #fafafa; stroke: #e5e5e5; }
+    .gate { fill: #f59e0b; fill-opacity: 0.08; stroke: #f59e0b; stroke-opacity: 0.4; }
+    .wire { fill: none; stroke: #d4d4d4; stroke-width: 1.5; }
+    .name { fill: #171717; font: 600 15px system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .gate-name { fill: #b45309; font: 600 15px system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .brand { fill: #171717; font: 700 21px system-ui, -apple-system, "Segoe UI", sans-serif; letter-spacing: -0.5px; }
+    .said { fill: #737373; font: 400 13px system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .kind { fill: #737373; font: 400 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+    @media (prefers-color-scheme: dark) {
+      .card { fill: #171717; stroke: #2e2e2e; }
+      .wire { stroke: #3a3a3a; }
+      .name, .brand { fill: #fafafa; }
+      .gate-name { fill: #fbbf24; }
+      .said, .kind { fill: #a3a3a3; }
+    }
+  </style>
+
+  <defs>
+    <linearGradient id="kajaMark" x1="4" y1="24" x2="44" y2="24" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#B0503F" />
+      <stop offset="1" stop-color="#8A35D8" />
+    </linearGradient>
+  </defs>
+
+  <path class="wire" d="M212 44 C 300 44, 350 150, 420 150" />
+  <path class="wire" d="M212 150 H 420" />
+  <path class="wire" d="M212 256 C 300 256, 350 150, 420 150" />
+  <path class="wire" d="M580 150 C 660 150, 710 72, 788 72" />
+  <path class="wire" d="M580 150 C 660 150, 710 228, 788 228" />
+
+  <g>
+    <rect class="card" x="16" y="18" width="196" height="52" rx="10" />
+    <circle cx="34" cy="44" r="3.5" fill="#8A35D8" />
+    <text class="name" x="48" y="49">gRPC</text>
+    <text class="kind" x="196" y="49" text-anchor="end">.proto</text>
+  </g>
+
+  <g>
+    <rect class="card" x="16" y="124" width="196" height="52" rx="10" />
+    <circle cx="34" cy="150" r="3.5" fill="#B0503F" />
+    <text class="name" x="48" y="155">OpenAPI</text>
+    <text class="kind" x="196" y="155" text-anchor="end">schema</text>
+  </g>
+
+  <g>
+    <rect class="card" x="16" y="230" width="196" height="52" rx="10" />
+    <circle cx="34" cy="256" r="3.5" fill="#4A9EDA" />
+    <text class="name" x="48" y="261">MCP</text>
+    <text class="kind" x="196" y="261" text-anchor="end">tools</text>
+  </g>
+
+  <g>
+    <rect class="card" x="420" y="118" width="160" height="64" rx="12" />
+    <g transform="translate(470 150) scale(0.55) translate(-24 -24)">
+      <path d="M4 29 H13 L19 13 L28 35 L33 24 H44" stroke="url(#kajaMark)" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    </g>
+    <text class="brand" x="492" y="157">Kaja</text>
+  </g>
+
+  <g>
+    <rect class="card" x="788" y="41" width="196" height="62" rx="10" />
+    <text class="name" x="806" y="66">An agent</text>
+    <text class="said" x="806" y="87">writes and runs the script</text>
+  </g>
+
+  <g>
+    <rect class="gate" x="788" y="197" width="196" height="62" rx="10" />
+    <text class="gate-name" x="806" y="222">You approve</text>
+    <text class="said" x="806" y="243">if the script asks you to</text>
+  </g>
+</svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,9 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="316" height="88" viewBox="0 0 316 88" fill="none" role="img" aria-label="Kaja">
   <defs><linearGradient id="kajaLock" x1="4" y1="24" x2="44" y2="24" gradientUnits="userSpaceOnUse"><stop stop-color="#B0503F"></stop><stop offset="1" stop-color="#8A35D8"></stop></linearGradient></defs>
-  
+
+  <style>
+    .wordmark { fill: #171717; }
+
+    @media (prefers-color-scheme: dark) {
+      .wordmark { fill: #FAFAFA; }
+    }
+  </style>
+
   <g transform="translate(4 -22) scale(2.75)">
     <path d="M4 29 H13 L19 13 L28 35 L33 24 H44" stroke="url(#kajaLock)" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"></path>
   </g>
-  
-  <text x="152" y="63" font-family="Figtree, &#39;Plus Jakarta Sans&#39;, &#39;Segoe UI&#39;, system-ui, sans-serif" font-size="52" font-weight="700" letter-spacing="-1.2" fill="#FAFAFA">Kaja</text>
+
+  <text class="wordmark" x="152" y="63" font-family="Figtree, &#39;Plus Jakarta Sans&#39;, &#39;Segoe UI&#39;, system-ui, sans-serif" font-size="52" font-weight="700" letter-spacing="-1.2">Kaja</text>
 </svg>


### PR DESCRIPTION
Opened the README with the site's title, tagline and how-it-works diagram, and replaced the features, Docker, configuration and format-migration sections with a prominent link to kaja.tools/docs. Kept Development and Releases, minus the em dashes, and dropped the demo/preview deployment section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4MMjRzNjVrjcAywGmLZeX)_