### PR TITLE
Presented a deeplink's run full screen, and put Run in that bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,7 +439,12 @@ static mono text, which pushed a pasted URL out through the side of the dialog.
   run and should stay that way. There is **no "don't ask again"**: a remembered
   answer is a policy, on the same rule that keeps `kaja.approve`'s standing
   approval inside its own run, and this door is the one place where the thing on
-  the other side may not be a person.
+  the other side may not be a person. **What it runs is presented**: nobody
+  pressed Run for it and nothing else on screen is what they came for, so the
+  moment the run draws, the canvas takes the whole window — see **A run nobody
+  pressed Run for is presented rather than left in a panel**. Which is also why
+  that screen carries Run: a script launched from a hotkey is one somebody runs
+  more than once.
 - **`run` — the Run button asking first.** The same block with no URL line. It
   closes the gap that made a script written for a deeplink only half runnable in
   the app: a manual Run could not supply `kaja.input` at all. Fields start
@@ -910,8 +915,10 @@ selection, the tab and the view as they were left.
   quietly produced a poor one; if it comes back it should be per block — a table's
   own affordance producing TSV — not one button claiming to serialise a document.
   The Calls view keeps its Copy, because a payload is one thing and copying it
-  means something. Stop is not in this header either: it is `RunButton` in the
-  CommandRow, which already swaps to a spinner, "Stop" and an elapsed counter.
+  means something. The console header carries no Run either: it is `RunButton` in
+  the CommandRow, which already swaps to a spinner, "Stop" and an elapsed counter
+  — and the one place that button is drawn a second time is the full-screen bar,
+  which is the only screen that covers the CommandRow.
 - **Full-screen is a size, not a mode** (`Console.FullScreen`). The canvas takes
   the whole window — sidebar, editor, splitters, console header, run strip and
   status bar all covered — and the only chrome left is a 40px bar that keeps the
@@ -924,11 +931,39 @@ selection, the tab and the view as they were left.
     wants it** — a focused ask field cancels its question first and a held call
     refuses itself first, both by `preventDefault` on the document, which is why
     the canvas checks `defaultPrevented` before claiming it. The second Esc leaves.
+  - **The bar carries Run, because this screen is one you sit in.** Running a
+    script again used to mean leaving full screen and coming back — two gestures
+    around the one thing the screen is for, and the one control it covered that
+    anybody wanted. It is the CommandRow's own `RunButton` element, passed down
+    as `runControl` rather than reimplemented, so the two can never disagree
+    about whether the file can run or why it can't: the same Stop with the same
+    counter mid-run, and the same caret, which is how a script launched from a
+    deeplink is run again with the values it was launched with. The bar's own
+    running chip gives way to it — the button already spins and counts — while
+    "waiting for you" and the settled duration stay, since the button says
+    nothing about either.
+  - **Taking the screen settles the view as well as the size**
+    (`enterFullScreen`, the one door all four ways in go through). Full screen is
+    the canvas with the whole window, so it writes `canvas` as the file's choice.
+    Without that the next run has drawn nothing yet, `defaultView` falls back to
+    the calls, and the screen you just pressed Run on closes under you — which is
+    exactly what `⌘⏎` did here before the button existed.
   - **It belongs to the run you were reading**, so it is component state and
     nothing else: not persisted, dropped when the file changes and when the view
     goes back to Calls. The Calls view has no full-screen at all — a flat list of
     calls gains nothing from the room and the splitter already sizes it. The canvas's
     scroll offset is carried across in a ref, so leaving lands where you left.
+  - **A run nobody pressed Run for is presented rather than left in a panel.** A
+    deeplink arrives from outside Kaja — a hotkey, a launcher, a Shortcut — so
+    what it draws takes the window: `onConfirmScriptLink` names the run it just
+    started (`presentRunId`) and the console shows it. The decision is
+    `presentRun` in `runs.ts` and is unit-tested, because it is three states and
+    not one: the canvas is the only thing there is to present, so a run that has
+    drawn nothing yet **waits** for its first block rather than opening on an
+    empty screen, one that has drawn **presents**, and one that ended without
+    drawing is **dropped** — an ordinary run, in the console it already landed
+    in. It is one-shot: the console hands the request back once it has been
+    honoured, and once it is clear it never will be.
 
 ## The canvas is what a run drew
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -378,6 +378,11 @@ export function App() {
   const [linkPrompt, setLinkPrompt] = useState<{ script: Script; input: { [key: string]: string } } | null>(null);
   // The deeplink a script is being copied from, and the parameters it takes.
   const [linkSheet, setLinkSheet] = useState<{ script: Script; parameters: string[] } | null>(null);
+  // The run a deeplink started, waiting to be shown. Nobody pressed Run for it —
+  // it arrived from a launcher, a hotkey or a Shortcut — so what it draws takes
+  // the window rather than sitting in a panel behind the editor. The console
+  // hands it back once it has been shown, and once it is clear it never will be.
+  const [presentRunId, setPresentRunId] = useState<string>();
   // Run, asking for `kaja.input` first. The same sheet the deeplink doors use,
   // minus the URL — which is what makes a script written for a deeplink whole
   // to run in the app.
@@ -1439,6 +1444,7 @@ export function App() {
         // mid-run, or a Run pressed beside it, cannot take them or leave its
         // own behind.
         const { run, kaja } = beginRun(file.script.name, file.script.path, undefined, { input });
+        setPresentRunId(run.id);
         runScript(file.content, kaja, apps, reportScriptError(run))
           .then(() => kaja.settleTables())
           .finally(() => markSettled(run.id));
@@ -2549,7 +2555,10 @@ export function App() {
   const runsHere = currentFileId === undefined ? [] : activeRuns.filter((live) => live.run.fileId === currentFileId);
   const running = runsHere.length > 0;
   const runningSince = running ? Math.min(...runsHere.map((live) => live.run.startedAt)) : undefined;
-  const action = currentIsEditor ? (
+  // One button, in two places: the command row, and the bar of a canvas that has
+  // taken the window. Reimplementing it there would be a second thing to keep in
+  // step with what the file can do.
+  const runButton = currentIsEditor ? (
     <RunButton
       onRun={() => onRunCurrentTab()}
       onStop={onStopActiveRun}
@@ -2561,17 +2570,20 @@ export function App() {
       onRunWithParameters={inputKeys.length > 0 ? onRunWithParameters : undefined}
       onCopyDeeplink={onCopyCurrentLink}
     />
-  ) : jsonView ? (
-    <IconButton
-      icon={Code}
-      aria-label={jsonView.showing ? jsonView.back : "Edit as JSON (⌘J)"}
-      variant="ghost"
-      size="sm"
-      className={cn("size-[26px]", jsonView.showing && "bg-accent text-foreground")}
-      disabled={jsonView.showing && !viewJsonValid}
-      onClick={toggleJsonView}
-    />
   ) : undefined;
+  const action =
+    runButton ??
+    (jsonView ? (
+      <IconButton
+        icon={Code}
+        aria-label={jsonView.showing ? jsonView.back : "Edit as JSON (⌘J)"}
+        variant="ghost"
+        size="sm"
+        className={cn("size-[26px]", jsonView.showing && "bg-accent text-foreground")}
+        disabled={jsonView.showing && !viewJsonValid}
+        onClick={toggleJsonView}
+      />
+    ) : undefined);
 
   // Bodies render in creation order, so bringing a file to the front never moves
   // a live editor in the DOM.
@@ -2798,6 +2810,9 @@ export function App() {
                         onTablePull={onTablePull}
                         onTableCells={onTableCells}
                         onClear={currentFileId ? () => onClearConsole(currentFileId) : undefined}
+                        presentRunId={presentRunId}
+                        onPresented={() => setPresentRunId(undefined)}
+                        runControl={runButton}
                       />
                     </div>
                   </>

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -12,7 +12,19 @@ import { Spinner } from "./components/spinner";
 import { consoles } from "./consoles";
 import { JsonViewerHandle } from "./JsonViewer";
 import { RunLog } from "./RunLog";
-import { callRows, ConsoleItem, ConsoleTab, ConsoleView, defaultView, followSelection, LogFloor, printedCounts, RunGroup, RunSelection } from "./runs";
+import {
+  callRows,
+  ConsoleItem,
+  ConsoleTab,
+  ConsoleView,
+  defaultView,
+  followSelection,
+  LogFloor,
+  presentRun,
+  printedCounts,
+  RunGroup,
+  RunSelection,
+} from "./runs";
 import { runShortcutLabel } from "./RunButton";
 import { CellRef, TableView } from "./tableView";
 
@@ -46,6 +58,15 @@ interface ConsoleProps {
   onTablePull: (blockId: string, search: string, want: number) => void;
   onTableCells: (blockId: string, cells: CellRef[]) => void;
   onClear?: () => void;
+  // A run that was launched rather than pressed, and is therefore worth showing
+  // rather than leaving in a panel: the canvas takes the window as soon as it
+  // draws. One-shot — `onPresented` is called once it has been shown, and once
+  // it is clear it never will be.
+  presentRunId?: string;
+  onPresented?: () => void;
+  // Run/Stop for the file this console belongs to, so a run can be started again
+  // from full screen rather than only from the command row the canvas covers.
+  runControl?: React.ReactNode;
 }
 
 /**
@@ -69,6 +90,9 @@ export function Console({
   onTablePull,
   onTableCells,
   onClear,
+  presentRunId,
+  onPresented,
+  runControl,
 }: ConsoleProps) {
   useSyncExternalStore(
     useCallback((notify: () => void) => (fileId === undefined ? () => {} : consoles.subscribeFile(fileId, notify)), [fileId]),
@@ -125,6 +149,17 @@ export function Console({
   const onSelect = useCallback((next: RunSelection | null) => consoles.setSelection(fileId, next, Date.now()), [fileId]);
   const onTabChange = useCallback((tab: ConsoleTab) => consoles.setTab(fileId, tab, Date.now()), [fileId]);
   const onViewChange = useCallback((view: ConsoleView) => consoles.setView(fileId, view, Date.now()), [fileId]);
+
+  /**
+   * Full screen is the canvas with the whole window, so taking it settles the
+   * view as well as the size. Without that the next run — pressed from the bar
+   * this screen now carries — has drawn nothing yet, the view falls back to the
+   * calls, and the screen you pressed Run on closes under you.
+   */
+  const enterFullScreen = useCallback(() => {
+    onViewChange("canvas");
+    setFullScreen(true);
+  }, [onViewChange]);
 
   // The file and run the console has followed, which is what tells a run
   // arriving apart from a call arriving inside the one already on screen — and
@@ -219,12 +254,37 @@ export function Console({
     if (activeView !== "canvas") setFullScreen(false);
   }, [activeView]);
 
+  /**
+   * A run that arrived from a deeplink is one nobody pressed Run for, so it is
+   * shown rather than left in a panel behind whatever was last on screen: the
+   * moment it draws, the canvas takes the window. It waits for that first block
+   * rather than opening on an empty screen, and a run that ends without drawing
+   * is simply an ordinary run — the request is dropped and the console it landed
+   * in is where it stays.
+   *
+   * Declared after the two that clear full screen, so a fresh file's reset
+   * cannot land on top of the presentation it was opened for.
+   */
+  useEffect(() => {
+    if (presentRunId === undefined) return;
+    const group = groups.find((candidate) => candidate.run.id === presentRunId);
+    const presentation = presentRun(group);
+    if (presentation === "wait") return;
+    if (presentation === "present" && group) {
+      if (selection?.runId !== group.run.id) onSelect({ runId: group.run.id, itemId: group.calls[group.calls.length - 1]?.id });
+      enterFullScreen();
+    }
+    onPresented?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [presentRunId, file.version]);
+
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === "f") {
         if (activeView !== "canvas" || !selectedGroup) return;
         event.preventDefault();
-        setFullScreen((on) => !on);
+        if (fullScreen) setFullScreen(false);
+        else enterFullScreen();
         return;
       }
       // Esc is the canvas's only when nothing else wanted it: a focused ask
@@ -236,7 +296,7 @@ export function Console({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activeView, selectedGroup, fullScreen]);
+  }, [activeView, selectedGroup, fullScreen, enterFullScreen]);
 
   // Picking a row is a decision to read it, so the log stops moving under it.
   const selectRow = useCallback(
@@ -269,7 +329,7 @@ export function Console({
       onCancelAsk={onCancelAsk}
       onDecide={onDecide}
       onSelectCall={selectFromCanvas}
-      onFullScreen={() => setFullScreen(true)}
+      onFullScreen={enterFullScreen}
       scrollRef={canvasScroll}
       tableViews={tableViews}
       onTableView={onTableView}
@@ -280,7 +340,13 @@ export function Console({
 
   if (fullScreen && selectedGroup && activeView === "canvas") {
     return (
-      <Console.FullScreen group={selectedGroup} reserveTrafficLights={reserveTrafficLights} now={now} onLeave={() => setFullScreen(false)}>
+      <Console.FullScreen
+        group={selectedGroup}
+        reserveTrafficLights={reserveTrafficLights}
+        now={now}
+        runControl={runControl}
+        onLeave={() => setFullScreen(false)}
+      >
         {canvas}
       </Console.FullScreen>
     );
@@ -341,7 +407,7 @@ export function Console({
                 size="sm"
                 className={utilityButtonClass}
                 data-testid="console-fullscreen"
-                onClick={() => setFullScreen(true)}
+                onClick={enterFullScreen}
               />
             ) : (
               <>
@@ -474,6 +540,10 @@ interface FullScreenProps {
   group: RunGroup;
   reserveTrafficLights?: boolean;
   now: number;
+  // Run/Stop for the file behind the canvas. It is the command row's own button,
+  // rendered here as well rather than reimplemented, so the two can never
+  // disagree about whether the file can run or why it can't.
+  runControl?: React.ReactNode;
   onLeave: () => void;
   children: React.ReactNode;
 }
@@ -483,9 +553,10 @@ interface FullScreenProps {
  * run strip and status bar all covered. It is a view state rather than a second
  * window — the run keeps running and the log keeps recording behind it — so the
  * only chrome left is a 40px bar that keeps the window's traffic lights and says
- * three things: which script, which run, and the way out.
+ * three things: which script, which run, and the way out — plus the one verb the
+ * canvas is worth having in front of it, Run.
  */
-Console.FullScreen = function ({ group, reserveTrafficLights, now, onLeave, children }: FullScreenProps) {
+Console.FullScreen = function ({ group, reserveTrafficLights, now, runControl, onLeave, children }: FullScreenProps) {
   const waiting = group.awaiting !== undefined;
   const time = formatClockTime(group.run.startedAt);
 
@@ -507,16 +578,27 @@ Console.FullScreen = function ({ group, reserveTrafficLights, now, onLeave, chil
             <span className="font-mono text-xs text-amber-600 dark:text-amber-400">waiting for you</span>
           </div>
         ) : group.running ? (
-          <div className="flex h-[20px] shrink-0 items-center gap-1.5 rounded-md bg-muted px-2">
-            <Spinner className="size-3" />
-            <span className="font-mono text-xs tabular-nums text-muted-foreground">{formatElapsed(now - group.run.startedAt)}</span>
-          </div>
+          // The Run button in this bar is Stop mid-run, with the same spinner
+          // and the same counter, so the chip is only drawn when it isn't there.
+          runControl ? null : (
+            <div className="flex h-[20px] shrink-0 items-center gap-1.5 rounded-md bg-muted px-2">
+              <Spinner className="size-3" />
+              <span className="font-mono text-xs tabular-nums text-muted-foreground">{formatElapsed(now - group.run.startedAt)}</span>
+            </div>
+          )
         ) : (
           <span className={cn("shrink-0 font-mono text-xs", group.status === "error" ? "text-destructive" : "text-muted-foreground")}>
             {group.status === "error" ? "failed" : formatDuration(group.run.durationMs)}
           </span>
         )}
         <div className="ml-auto flex shrink-0 items-center gap-3">
+          {/* Running a script again used to mean leaving full screen and coming
+              back, which is two gestures around the one thing this screen is
+              for. It is the command row's own button, so the caret's
+              Run-with-parameters is here too — which is how a script launched
+              from a deeplink is run again with the values it was launched with. */}
+          {runControl}
+          {runControl && <div className="h-4 w-px bg-border" />}
           <span className="font-mono text-xs text-muted-foreground">Esc</span>
           <IconButton
             icon={Minimize}

--- a/ui/src/runs.test.ts
+++ b/ui/src/runs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { MethodCall } from "./kaja";
 import { Block } from "./blocks";
-import { callRows, callStatus, ConsoleItem, ItemStats, itemStatus, printedCounts, printedLevel, RunGroup, slowestOf, worstStatus } from "./runs";
+import { callRows, callStatus, ConsoleItem, ItemStats, itemStatus, presentRun, printedCounts, printedLevel, RunGroup, slowestOf, worstStatus } from "./runs";
 import { LogLevel } from "./server/api";
 
 const NOW = 1_700_000_000_000;
@@ -266,5 +266,28 @@ describe("printedCounts", () => {
   it("counts the lines and the errors among them", () => {
     const only = group(printed("p1", NOW, LogLevel.LEVEL_INFO), printed("p2", NOW, LogLevel.LEVEL_ERROR), printed("p3", NOW, LogLevel.LEVEL_ERROR));
     expect(printedCounts(only)).toEqual({ lines: 3, errors: 2 });
+  });
+});
+
+describe("presentRun", () => {
+  const running = (changes: Partial<RunGroup> = {}) => ({ drew: false, running: true, ...changes }) as RunGroup;
+
+  // The canvas is the only thing there is to present, so a run that has drawn
+  // nothing yet waits for its first block rather than opening on empty space.
+  it("waits for the run to arrive, and then for it to draw", () => {
+    expect(presentRun(undefined)).toBe("wait");
+    expect(presentRun(running())).toBe("wait");
+  });
+
+  it("presents the run the moment it draws", () => {
+    expect(presentRun(running({ drew: true }))).toBe("present");
+    // Still worth presenting once it is over: the output is why it was launched.
+    expect(presentRun(running({ drew: true, running: false }))).toBe("present");
+  });
+
+  // A script that only made calls reads as an ordinary run, in the console it
+  // already landed in.
+  it("drops a run that ended without drawing", () => {
+    expect(presentRun(running({ running: false }))).toBe("drop");
   });
 });

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -418,6 +418,24 @@ export function defaultView(group: RunGroup | undefined): ConsoleView {
   return group?.drew ? "canvas" : "calls";
 }
 
+/**
+ * What a run that was launched rather than pressed is worth showing.
+ *
+ * A deeplink comes from outside Kaja — a hotkey, a launcher, a Shortcut — so the
+ * window is brought forward for what the run draws and for nothing else, which
+ * is what full screen is. But the canvas is the only thing there is to present:
+ * a run that has drawn nothing yet is `"wait"` rather than an empty screen, and
+ * one that ended without drawing is `"drop"` — it reads as an ordinary run, in
+ * the console it already landed in.
+ */
+export type Presentation = "present" | "wait" | "drop";
+
+export function presentRun(group: RunGroup | undefined): Presentation {
+  if (!group) return "wait";
+  if (group.drew) return "present";
+  return group.running ? "wait" : "drop";
+}
+
 // The measure a set of calls is drawn against, kept for reading a list that is
 // already complete. A live run counts it as it goes (`ItemStats`).
 export function slowestOf(items: ConsoleItem[]): number | undefined {


### PR DESCRIPTION
A `kaja://run/…` run now takes the whole window as soon as it draws — nobody pressed Run for it, so what it drew is what they came for. The full-screen bar carries the CommandRow's own Run/Stop button, so re-running no longer means leaving full screen and coming back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh5MrmT3kbxsGxNEMnhsd5)_