### PR TITLE
Kept the Run caret on every script and filled its menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,8 @@ useful, so the panel's is gone (`sidebarFilter.ts`, `appFilter.ts` and
   buffer nothing would keep — the same shape as an app form whose fields are
   disabled, and the same reason. A draft beside it is unaffected: it lives in
   the browser, so it is as writable there as anywhere, and `⌘N` is the way to
-  take a copy of a script somewhere you can change it.
+  take a copy of a script somewhere you can change it — `Duplicate as draft`, in
+  the Run caret's menu, is that gesture with the file's own code in it.
 
 ### The agent's draft
 
@@ -469,19 +470,49 @@ static mono text, which pushed a pasted URL out through the side of the dialog.
 
 **Plain Run keeps its place, its shape and its `⌘⏎`** — the one-click path is
 untouched, and pressing Run still never opens anything. A 22px caret beside it
-(`RunButton.tsx`) opens the second gesture: `Run ⌘⏎` · `Run with parameters…
-⇧⌘⏎` · `Copy deeplink… ⌘⇧C`, the three doors in one menu so they read as one
-feature.
+(`RunButton.tsx`) opens the script's action menu: the run gestures, then a rule,
+then what this script is once the run is over.
 
-- **The caret is what the file reads, not a permanent fixture.** A script that
-  names no `kaja.input` key has nothing to be asked for, so it gets a bare Run
-  button, exactly as before. Mid-run the button is Stop, which is one thing to
-  press and nothing to choose between.
-- **`Copy deeplink…` is desktop-only and file-only**: a draft has no address,
-  and the web can't register a scheme. `⌘⇧C` falls through to the browser's own
-  Copy wherever the item isn't there.
+- **The caret is the script's action menu, not a parameters affordance, so it is
+  on for every script and the menu is what varies.** Keying it to `kaja.input`
+  was what gave the pill two widths — it stepped 23px wider the moment you moved
+  from a script that declares a key to one that doesn't, a control moving under
+  the cursor for a reason nothing on screen explains — and it also left
+  `Copy deeplink…` sitting in a menu that a file with no parameters had no way
+  to open. Mid-run the button is Stop, which is one thing to press and nothing
+  to choose between, so the caret is gone there and only there.
+- **The second group is never empty, because every script has an answer to
+  "what is this once the run is over".** A **file** offers the address it has —
+  `Copy deeplink… ⌘⇧C` and `Reveal in Finder`, the file itself rather than the
+  folder the Files group already reveals. A **draft** offers the sheet that
+  gives it one: `Name… ⌘S`, and the `Discard` beside it. That is the whole
+  substitution — a draft has no deeplink *because* it has no name, so the item
+  in that slot is the one that fixes it — and it is what lets the caret stay on
+  everywhere without being a stub kept for alignment.
+- **`Copy deeplink…` and `Reveal in Finder` are desktop-only**: the web can't
+  register a scheme and doesn't own the disk. `⌘⇧C` falls through to the
+  browser's own Copy wherever the item isn't there.
+- **A read-only file's answer is `Duplicate as draft`**, which is the one place
+  a file may become a draft. Files never turn into drafts on their own and there
+  is no forking — but a server serving a workspace it does not own has no second
+  file to copy this one into, so on the **web** a draft is the whole of what
+  "take a copy and change it" can mean. `⌘N` was already named as that route
+  and only ever gave you a blank script; this is the same route with the file's
+  own code in it. On the desktop a file is writable, so the item is absent.
+  The copy is taken from the **buffer**, on the rule Run follows, and lands with
+  an empty `generatedCode` so a deliberate copy is work rather than a browsing
+  buffer the next method click would take over.
+- **Omit, don't disable.** `Run with parameters…` is absent on a script that
+  declares no key rather than greyed, since a greyed item makes people hunt for
+  the way to enable it. Absent, the menu just reads as short.
+- **The draft's two verbs are in two places on purpose.** The command row
+  carries `Name` and the discard beside the file's name, which is the pair you
+  reach for mid-edit; the menu restates them at the other end of the row, which
+  is where your hand already is once you have pressed Run. `Name` is in four
+  places now (row hover, row menu, command row, this menu) and that was already
+  the status quo for it.
 - **Prefill is not a menu item.** The last run's values live only as the link
-  inside the sheet, so the menu stays two gestures.
+  inside the sheet, so the run half of the menu stays two gestures.
 
 ### Where the rest of it lives
 
@@ -1380,10 +1411,10 @@ collapsed).
   file is never both a script and a form. Run is absent (not disabled) on
   non-script surfaces. Its disabled state and the trigger's `N errors` state come
   from the same `useSyntaxErrors` (`RunButton.tsx`), so the row never disagrees
-  with itself. Run is a **split button** on a file that reads `kaja.input` — see
-  **The Run button, split** — and a plain one everywhere else; the caret is the
-  only thing that ever grew here, and it belongs to the file rather than to the
-  row.
+  with itself. Run is a **split button** on every script — see **The Run button,
+  split** — and a plain one only while a run is in flight; the caret is the only
+  thing that ever grew here, and it belongs to the file rather than to the row,
+  which is why its menu changes as the file does and its width never does.
 - **Shortcuts** — `⌘P` finder on the previous place · `⌘N` blank script ·
   `⇧⌘N` new folder · `⌘⏎`/F5 run · `⇧⌘⏎` run with parameters · `⌘⇧C` copy
   deeplink · `⌘J` JSON view · `⌘B` sidebar · `⌘S` name a draft (a file is

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2188,6 +2188,45 @@ export function App() {
   const onCopyCurrentLinkRef = useRef(onCopyCurrentLink);
   onCopyCurrentLinkRef.current = onCopyCurrentLink;
 
+  // The file itself rather than the folder it sits in, which is what the Files
+  // group's own Reveal already does. `ShowFileInFinder` selects the file and
+  // falls back to the nearest folder that exists, so a script written but not
+  // yet flushed still lands somewhere useful.
+  const onRevealCurrentScript = useMemo(() => {
+    if (!isWailsEnvironment() || currentView?.type !== "script") return undefined;
+    const script = currentView.script;
+    return () => {
+      ScriptsFolder()
+        .then((folder) => ShowFileInFinder(`${folder}/${scriptName(script)}`))
+        .catch(() => {});
+    };
+  }, [currentView]);
+
+  /**
+   * The copy of a read-only file, in the one place it can be edited. A file
+   * never becomes a draft on its own — that is what keeps Drafts the group for
+   * things that have never had a name — but a server serving a workspace it
+   * does not own has no second file to copy this one into, so a draft is the
+   * whole of what "take a copy of this and change it" can mean there. On the
+   * desktop a file is writable and forking is deliberately not a gesture, so
+   * this is absent.
+   *
+   * The buffer rather than the disk, on the same rule Run follows: the script
+   * as it is now is the one being copied.
+   */
+  const onDuplicateAsDraft = useCallback(() => {
+    const view = viewsRef.current[0];
+    if (view?.type !== "script") return;
+    const code = editorRegistryRef.current.get(view.id)?.getValue() ?? "";
+    const now = Date.now();
+    // A copy is work, not a browsing buffer: an empty `generatedCode` is what
+    // keeps the next method click from taking it over and the sweep from
+    // dropping it.
+    const draft = { ...createDraft(code, undefined, now), generatedCode: "" };
+    applyDrafts((list) => [draft, ...list]);
+    applyViews((views) => showDraft(views, draft));
+  }, [applyDrafts, applyViews]);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       // A sheet on top of the editor answers ⏎ itself, and its Run is the one
@@ -2556,10 +2595,17 @@ export function App() {
       running={running}
       startedAt={runningSince}
       error={syntaxErrors.first}
-      // The caret is there because this file reads `kaja.input`; without that
-      // there is nothing behind it worth opening.
+      // Only when this file reads `kaja.input`; there is nothing to ask for
+      // otherwise, and a greyed item would make people hunt for the way to
+      // enable it. The caret itself is on either way.
       onRunWithParameters={inputKeys.length > 0 ? onRunWithParameters : undefined}
       onCopyDeeplink={onCopyCurrentLink}
+      onRevealInFinder={onRevealCurrentScript}
+      // A draft's two verbs, the same pair the command row carries beside its
+      // name — answering the moment you are already at this end of the row.
+      onNameDraft={currentDraft && canWriteScripts() ? onRequestSave : undefined}
+      onDiscardDraft={currentDraft ? () => onDiscardDraft(currentDraft) : undefined}
+      onDuplicateAsDraft={currentView?.type === "script" && !canWriteScripts() ? onDuplicateAsDraft : undefined}
     />
   ) : jsonView ? (
     <IconButton

--- a/ui/src/RunButton.tsx
+++ b/ui/src/RunButton.tsx
@@ -9,6 +9,7 @@ const isMac = navigator.platform.startsWith("Mac");
 export const runShortcutLabel = isMac ? "⌘⏎" : "Ctrl+⏎";
 export const runWithParametersShortcutLabel = isMac ? "⇧⌘⏎" : "Ctrl+Shift+⏎";
 export const copyDeeplinkShortcutLabel = isMac ? "⌘⇧C" : "Ctrl+Shift+C";
+export const nameShortcutLabel = isMac ? "⌘S" : "Ctrl+S";
 
 interface RunButtonProps {
   onRun: () => void;
@@ -18,13 +19,23 @@ interface RunButtonProps {
   startedAt?: number;
   // The first error stopping the run, if any. Run goes disabled and says so.
   error?: string;
-  // The second gesture, and the whole reason there is a caret: this file reads
-  // `kaja.input`, so there is something to ask for before it runs. A script
-  // that reads nothing gets a bare Run button, as before.
+  // The second gesture: this file reads `kaja.input`, so there is something to
+  // ask for before it runs. Omitted rather than disabled on a script that reads
+  // nothing — a greyed item makes people hunt for the way to enable it.
   onRunWithParameters?: () => void;
-  // A file's address outside Kaja. Absent on a draft, which has none, and on
-  // the web, which can't register a scheme.
+  // A file's address outside Kaja. Absent on the web, which can't register a
+  // scheme.
   onCopyDeeplink?: () => void;
+  // The file itself, on the disk this process owns.
+  onRevealInFinder?: () => void;
+  // What a draft has instead of an address: the sheet that gives it one, and
+  // the discard that closes the buffer. Absent on a file, which is already on
+  // disk and stays there as you type.
+  onNameDraft?: () => void;
+  onDiscardDraft?: () => void;
+  // A read-only file's only route to a copy you can change. Absent wherever a
+  // file can simply be copied to another file.
+  onDuplicateAsDraft?: () => void;
 }
 
 // Run is the last control before the utility icons in the command row: the same
@@ -35,12 +46,41 @@ interface RunButtonProps {
 // Plain Run keeps its place and its ⌘⏎ — the one-click path is untouched. The
 // caret beside it is where the gestures that need a sheet first live, so
 // pressing Run never opens anything.
-export function RunButton({ onRun, onStop, running, startedAt, error, onRunWithParameters, onCopyDeeplink }: RunButtonProps) {
+//
+// The caret is the script's action menu rather than a parameters affordance, so
+// it is on for every script and the menu is what varies. Keying it to
+// `kaja.input` instead is what made the pill two widths: it stepped 23px wider
+// the moment you moved from a script that declares a key to one that doesn't,
+// which is a control moving under the cursor for a reason nothing on screen
+// explains — and it also left `Copy deeplink…` in a menu that a file with no
+// parameters had no way to open.
+//
+// What fills the second group is what this script is once the run is over, and
+// every script has an answer to that: a file offers the address it has, a draft
+// offers the sheet that gives it one. That is why the group is never empty and
+// the caret never has to disappear.
+export function RunButton({
+  onRun,
+  onStop,
+  running,
+  startedAt,
+  error,
+  onRunWithParameters,
+  onCopyDeeplink,
+  onRevealInFinder,
+  onNameDraft,
+  onDiscardDraft,
+  onDuplicateAsDraft,
+}: RunButtonProps) {
   const elapsedMs = useElapsed(running, startedAt);
   const disabled = !running && error !== undefined;
+  // What the second group holds, which decides whether there is a separator
+  // above it.
+  const aboutTheScript = [onCopyDeeplink, onRevealInFinder, onNameDraft, onDiscardDraft, onDuplicateAsDraft].some(Boolean);
   // Mid-run the button is Stop, which is one thing to press and nothing to
-  // choose between.
-  const split = !running && onRunWithParameters !== undefined;
+  // choose between. Otherwise the caret is on whenever the menu says more than
+  // the button already does — which, by the rule above, is always.
+  const split = !running && (aboutTheScript || onRunWithParameters !== undefined);
 
   return (
     <div
@@ -86,20 +126,44 @@ export function RunButton({ onRun, onStop, running, startedAt, error, onRunWithP
                 <span className="flex-1">Run</span>
                 <Shortcut label={runShortcutLabel} />
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => onRunWithParameters()}>
-                <span className="flex-1">Run with parameters…</span>
-                <Shortcut label={runWithParametersShortcutLabel} />
-              </DropdownMenuItem>
+              {onRunWithParameters && (
+                <DropdownMenuItem onSelect={() => onRunWithParameters()}>
+                  <span className="flex-1">Run with parameters…</span>
+                  <Shortcut label={runWithParametersShortcutLabel} />
+                </DropdownMenuItem>
+              )}
+              {aboutTheScript && <DropdownMenuSeparator />}
               {/* The same sheet with the URL line, so the three doors sit in
                   one menu and read as one feature. */}
               {onCopyDeeplink && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onSelect={() => onCopyDeeplink()}>
-                    <span className="flex-1">Copy deeplink…</span>
-                    <Shortcut label={copyDeeplinkShortcutLabel} />
-                  </DropdownMenuItem>
-                </>
+                <DropdownMenuItem onSelect={() => onCopyDeeplink()}>
+                  <span className="flex-1">Copy deeplink…</span>
+                  <Shortcut label={copyDeeplinkShortcutLabel} />
+                </DropdownMenuItem>
+              )}
+              {onRevealInFinder && (
+                <DropdownMenuItem onSelect={() => onRevealInFinder()}>
+                  <span className="flex-1">Reveal in Finder</span>
+                </DropdownMenuItem>
+              )}
+              {/* A draft's counterpart to the address a file has: it has no
+                  deeplink because it has no name, and this is the sheet that
+                  fixes that. */}
+              {onNameDraft && (
+                <DropdownMenuItem onSelect={() => onNameDraft()}>
+                  <span className="flex-1">Name…</span>
+                  <Shortcut label={nameShortcutLabel} />
+                </DropdownMenuItem>
+              )}
+              {onDiscardDraft && (
+                <DropdownMenuItem onSelect={() => onDiscardDraft()}>
+                  <span className="flex-1">Discard</span>
+                </DropdownMenuItem>
+              )}
+              {onDuplicateAsDraft && (
+                <DropdownMenuItem onSelect={() => onDuplicateAsDraft()}>
+                  <span className="flex-1">Duplicate as draft</span>
+                </DropdownMenuItem>
               )}
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
The caret keyed off `kaja.input`, so the Run pill had two widths and `Copy deeplink…` sat in a menu a file with no parameters couldn't open. The caret is now on for every script and the menu varies instead: a file offers the address it has (`Copy deeplink…`, plus a `Reveal in Finder` on the file rather than the folder), a draft offers the sheet that gives it one (`Name…`, `Discard`), and a read-only file gets `Duplicate as draft` — the one place a file may become a draft, since the web has no second file to copy into.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGZnSau5qoLuQhvfEvzNuK)_