### PR TITLE
Exposed deeplinks on the web, in the fragment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,24 @@ names which kind.
   `run` without knowing any of this exists. Putting the script in a `?script=`
   of its own is what would have created that collision, and the first script to
   want the name would have found it taken.
+- **A page can't register a scheme, so the web says the same thing after a
+  `#`**: `https://kaja.example.com/#run/slack-thread?url=…&note=…`. The fragment
+  is the `kaja://` link minus its scheme, which is why this is one grammar and
+  one parser rather than a second feature — `parseScriptLink` puts the scheme
+  back on and reads what it always read, and everything downstream (the arrived
+  sheet, `isLinkedScript`, `kaja.input`) never learns which door it came
+  through. It is the **fragment** rather than a path, because a fragment is
+  never sent to a server: nothing about how Kaja is served, or under what base
+  path, has to know deeplinks exist — no route to add, no SPA fallback, and the
+  relative `./main.js` and `./monaco.ts.worker.js` the page already loads stay
+  correct. A `?run=` of its own was the other candidate and is out for the
+  reason the desktop's host is the verb: a query key named here is one a script
+  can never take.
+- **The base is the one thing that differs, so it is the one thing passed in.**
+  `linkBase()` is the single function here that asks what it is running in —
+  `kaja://run/` under Wails, this page's own href minus its fragment in a
+  browser — and `scriptLink`/`scriptLinkParts` take it as an argument, so
+  everything else in `scriptLink.ts` is pure and unit-tested against both forms.
 - **The address carries no extension; a filename always does.** Two different
   things are being named, so there are two rules rather than one. The path
   segment is how the app finds the script (`linkName`, `isLinkedScript`), and a
@@ -494,9 +512,11 @@ then what this script is once the run is over.
   substitution — a draft has no deeplink *because* it has no name, so the item
   in that slot is the one that fixes it — and it is what lets the caret stay on
   everywhere without being a stub kept for alignment.
-- **`Copy deeplink…` and `Reveal in Finder` are desktop-only**: the web can't
-  register a scheme and doesn't own the disk. `⌘⇧C` falls through to the
-  browser's own Copy wherever the item isn't there.
+- **`Reveal in Finder` is desktop-only**, because the web doesn't own the disk.
+  `Copy deeplink…` is not: a file has an address on either platform, so it is on
+  a script row and in the caret's menu wherever there is a file. `⌘⇧C` falls
+  through to the browser's own Copy wherever the item isn't there — a draft, or
+  anything that isn't a script.
 - **A read-only file's answer is `Duplicate as draft`**, which is the one place
   a file may become a draft. Files never turn into drafts on their own and there
   is no forking — but a server serving a workspace it does not own has no second
@@ -525,13 +545,36 @@ then what this script is once the run is over.
   On a cold launch macOS delivers the URL long before there is a webview to hear
   it, so `openLink` buffers until the UI emits `link:ready` and then flushes
   (`main.go`). It rides on a Wails event in each direction rather than a bound
-  method, which is what keeps the generated bindings out of it.
+  method, which is what keeps the generated bindings out of it. Registering the
+  scheme is a bundle's to do (`info.protocols` in `wails.json` →
+  `CFBundleURLTypes`), which is the whole of why the web needs a form of its
+  own.
+- **The web needs no buffer, because the URL is one.** There is nothing to
+  deliver a link with: the link *is* the page load, or — Kaja already being open
+  in a tab — a `hashchange`, which the browser makes without reloading anything.
+  Both go through one door (`takeLinkFromLocation`), and a fragment that arrives
+  before the script list is in is simply **left where it is** until the same
+  readiness the desktop flushes on, which is the buffering done by not doing it.
+- **The fragment is cleared once it has been handed over**
+  (`history.replaceState`, which fires no `hashchange`, so clearing can't come
+  back around as a second arrival). The URL is a door, not a location: this
+  window shows whatever you last selected, and an address bar still naming a
+  script you have since navigated away from is claiming something false. Making
+  it a location would mean routing the whole app, which is a different feature.
 - **It comes from the row that runs it**: right-click a script → **Copy
   deeplink…**, which is where the pin used to be, and from the caret beside Run
   on the file already open. Nobody types one of these by hand.
-- **Desktop only**, because registering a scheme is a bundle's to do
-  (`info.protocols` in `wails.json` → `CFBundleURLTypes`). The web has no such
-  door and grows no menu item for one.
+- **The sheet says who can open one, and nothing else moves.** The `copy` door's
+  closing line is the one platform-dependent sentence — "anything on this Mac"
+  against "anything that opens a URL", a Shortcut against a bookmark — because
+  that is the one thing that genuinely differs. The URL line above it, the
+  parameter grid and the verb are the same either way.
+- **The web is the broader door, which is what the `arrived` sheet was already
+  for.** Anything that can open a URL can now reach a Kaja that is merely
+  served — a link in an email, a page you didn't write — so the rule that a
+  deeplink is never permission by itself, and that there is deliberately **no
+  "don't ask again"**, stops being belt-and-braces and becomes the thing holding
+  the door.
 
 ## A filename is one object, so it reads one way
 
@@ -1484,7 +1527,7 @@ the footer's plug. A port already in use is still reported through `MCPInfo.Erro
 rather than falling back to a random one; freeing the port and restarting is the
 fix, since there is no longer a toggle to cycle.
 
-- **Deeplinks** — `kaja://run/<script>?key=value&key=value` runs a script and hands it the query as `kaja.input.<key>` (`scriptLink.ts`, desktop only — a URL scheme is a bundle's to register). It replaced the macOS "Run Kaja Script" text service, which could only be reached from a *selection*, could only carry one unnamed string, and could only ever run the one script that was pinned. See **Deeplinks, and the sheet that asks** below.
+- **Deeplinks** — `kaja://run/<script>?key=value&key=value` on the desktop, `https://<kaja>/#run/<script>?key=value` on the web, runs a script and hands it the query as `kaja.input.<key>` (`scriptLink.ts`). A URL scheme is a bundle's to register, so the web says the same thing in a fragment — same grammar, same parser, no server route. It replaced the macOS "Run Kaja Script" text service, which could only be reached from a *selection*, could only carry one unnamed string, and could only ever run the one script that was pinned. See **Deeplinks, and the sheet that asks** below.
 - **Apps** (`featurePreview:previewApps`, labeled "Preview Apps") — **everything is an app.** A gRPC or Twirp service is an app of type `"grpc"`/`"twirp"`; built-in integrations like `"openapi"`, `"openai"`, `"folder"`, `"mcp"` are apps too. There is a single `apps` list in `kaja.json`. `ConfigurationApp` is a `name` plus a typed `oneof app { GrpcApp grpc; TwirpApp twirp; OpenApiApp openapi; OpenAiApp openai; FolderApp folder; McpApp mcp; }`, so an app reads `{ "name": "...", "grpc": { "url": "...", "proto_dir": "...", "headers": {...} } }`: the set field *is* the type, two types can never be mixed in one app (protojson rejects two oneof members), and each type's message declares exactly its own params — including `headers` (every type but the local Folder app forwards them). No separate `projects` list. The server flattens the set variant's scalar fields (the `headers` map is excluded — it is forwarded per request, not a creation param) to a `map[string]string` at the `OpenApp`/`App.Open` boundary (`flattenApp` via protoreflect), so the in-process app contract stays uniform. The sidebar's "+" button opens one **New** dialog whose list offers gRPC/Twirp/OpenAPI always; the experimental built-ins (mcp/openai/folder) appear only when the preview is on and carry a "Preview" pill. Picking a type opens the app settings tab for a new app of that type; the type is fixed at creation. Legacy `kaja.json` files with a top-level `projects` list are migrated to apps on load, as is a legacy `"markdown"` app — the same folder on disk, behind methods that each rendered one Markdown construct — which becomes a `"folder"` app.
 
 ### Apps architecture

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -103,7 +103,7 @@ import {
   renameScriptFolder,
   writeScriptFile,
 } from "./scriptFiles";
-import { isLinkedScript, parseScriptLink } from "./scriptLink";
+import { hasScriptLink, isLinkedScript, parseScriptLink } from "./scriptLink";
 import { readInputKeys } from "./scriptInputs";
 import { useInputKeys } from "./useInputKeys";
 import { lastRunInput, moveRunInput, rememberRunInput } from "./runInput";
@@ -1423,6 +1423,12 @@ export function App() {
       }
       // Open it first, so the question is asked over the script it is about.
       void onScriptSelect(script);
+      // And nothing may open over it. A first-time window with no view memory
+      // opens the first method it finds once the apps have compiled, which
+      // lands after this and takes the pane — on the web that is every new
+      // browser, and arriving by URL is exactly when somebody has none. A link
+      // naming a script is a stronger statement than the guess that rule makes.
+      hasViewMemory.current = true;
       setLinkPrompt({ script, input: parsed.link.input });
     },
     [onScriptSelect, showFileError],
@@ -1461,15 +1467,45 @@ export function App() {
     return () => unsub();
   }, []);
 
+  const linksReadyRef = useRef(false);
+
+  // On the web there is nothing to deliver a link: the link *is* the page load,
+  // or — Kaja already being open in a tab — a change of fragment, which the
+  // browser makes without reloading anything. Both are the same door.
+  //
+  // The fragment is cleared once it has been handed over, because the URL is a
+  // door rather than a location: this window shows whatever you last selected,
+  // and an address bar still naming a script you have since navigated away from
+  // is claiming something false. A `replaceState` fires no `hashchange`, so
+  // clearing it can't come back around as a second arrival.
+  //
+  // The desktop holds a link that arrives before the UI is listening; the web
+  // needs no buffer, because the URL is one — a fragment that arrives too
+  // early is simply left where it is, and the readiness effect below reads it.
+  const takeLinkFromLocation = useCallback(() => {
+    if (!linksReadyRef.current || !hasScriptLink(window.location.href)) return;
+    const href = window.location.href;
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+    openScriptLinkRef.current(href);
+  }, []);
+
+  useEffect(() => {
+    if (isWailsEnvironment()) return;
+    const onHashChange = () => takeLinkFromLocation();
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, [takeLinkFromLocation]);
+
   // A link that launched the app arrived long before any of this existed, and
   // the desktop holds those until we say we are here — which is once the script
-  // list is in, since before that there is nothing for a link to name.
-  const linksReadyRef = useRef(false);
+  // list is in, since before that there is nothing for a link to name. The web
+  // reaches the same moment by reading its own URL.
   useEffect(() => {
-    if (!isWailsEnvironment() || linksReadyRef.current || scripts === undefined) return;
+    if (linksReadyRef.current || scripts === undefined) return;
     linksReadyRef.current = true;
-    EventsEmit("link:ready");
-  }, [scripts]);
+    if (isWailsEnvironment()) EventsEmit("link:ready");
+    else takeLinkFromLocation();
+  }, [scripts, takeLinkFromLocation]);
 
   /**
    * A file auto-saves as you edit it (debounced), which is the other half of
@@ -2185,9 +2221,10 @@ export function App() {
 
   // The same sheet the sidebar's Copy deeplink opens, on the file already on
   // screen — so its parameters are read from the buffer rather than from disk.
-  // A draft has no address, and neither does anything the web is serving.
+  // A draft has no address; a file has one on either platform, since the web's
+  // is this page's own URL.
   const onCopyCurrentLink = useMemo(() => {
-    if (!isWailsEnvironment() || currentView?.type !== "script") return undefined;
+    if (currentView?.type !== "script") return undefined;
     const script = currentView.script;
     return () => setLinkSheet({ script, parameters: inputKeys });
   }, [currentView, inputKeys]);
@@ -2693,7 +2730,7 @@ export function App() {
                     onRenameScript={canWriteScripts() ? onRenameScript : undefined}
                     onMoveScript={canWriteScripts() ? onMoveScript : undefined}
                     onDeleteScript={canWriteScripts() ? (script) => setDeleteScript(script) : undefined}
-                    onCopyScriptLink={isWailsEnvironment() ? (script) => void onCopyScriptLink(script) : undefined}
+                    onCopyScriptLink={(script) => void onCopyScriptLink(script)}
                     onCreateFolder={canWriteScripts() ? onCreateFolder : undefined}
                     onRenameFolder={canWriteScripts() ? onRenameFolder : undefined}
                     onDeleteFolder={canWriteScripts() ? (path) => setDeleteFolder(path) : undefined}

--- a/ui/src/ParameterSheet.tsx
+++ b/ui/src/ParameterSheet.tsx
@@ -7,7 +7,7 @@ import { IconButton } from "./components/icon-button";
 import { Input } from "./components/input";
 import { SimpleTooltip } from "./components/tooltip";
 import { FileName } from "./FileName";
-import { scriptLinkParts } from "./scriptLink";
+import { LINK_SCHEME, scriptLinkParts } from "./scriptLink";
 
 /**
  * The three doors that need values for a script.
@@ -59,12 +59,16 @@ export function ParameterSheet({ door, fileName, address, parameters, values, la
   const input = useMemo(() => Object.fromEntries(parameters.map((key) => [key, entered[key] ?? ""])), [parameters, entered]);
   const parts = useMemo(() => (address === undefined ? [] : scriptLinkParts(address, input)), [address, input]);
   const link = parts.map((part) => part.text).join("");
+  // The desktop's own scheme, versus this page's address with the script in
+  // its fragment. The link is the same sentence either way; who can open one
+  // is not, so the closing line differs and nothing else does.
+  const schemeLink = link.startsWith(`${LINK_SCHEME}:`);
 
   // An illustration rather than the link again: the URL is already on screen
   // whole, and this line is about the shell, not about this script's values.
   const shellExample = useMemo(() => {
     const bare = parts
-      .filter((part) => part.kind === "scheme" || part.kind === "script")
+      .filter((part) => part.kind === "base" || part.kind === "script")
       .map((part) => part.text)
       .join("");
     const firstKey = parts.find((part) => part.kind === "key");
@@ -124,12 +128,12 @@ export function ParameterSheet({ door, fileName, address, parameters, values, la
       <div className={cn("flex flex-col py-3", parameters.length > 0 ? "gap-4" : "gap-3")}>
         {door === "copy" && (
           // The URL is the headline rather than a caption: shown whole, at body
-          // size, it teaches the scheme, the script's address and the query
+          // size, it teaches where Kaja is, the script's address and the query
           // syntax at once, and nothing on screen has to explain any of them.
           <div className="relative rounded-md border border-border bg-muted/40 p-3 pr-10">
             <p className="m-0 break-all font-mono text-sm leading-[1.55] text-foreground">
               {parts.map((part, index) => (
-                <span key={index} className={part.kind === "scheme" || part.kind === "key" ? "text-muted-foreground" : undefined}>
+                <span key={index} className={part.kind === "base" || part.kind === "key" ? "text-muted-foreground" : undefined}>
                   {part.text}
                 </span>
               ))}
@@ -203,7 +207,8 @@ export function ParameterSheet({ door, fileName, address, parameters, values, la
           (parameters.length > 0 ? (
             <div className="rounded-md border border-border px-3 py-2">
               <p className="m-0 text-xs leading-[1.6] text-muted-foreground">
-                Anything on this Mac that opens a URL can run this script: a Raycast quicklink, an Alfred workflow, a Shortcut, or{" "}
+                {schemeLink ? "Anything on this Mac that opens a URL can run this script" : "Anything that opens a URL can run this script"}: a{" "}
+                {schemeLink ? "Raycast quicklink, an Alfred workflow, a Shortcut" : "bookmark, a Raycast quicklink, a link in a document"}, or{" "}
                 <span className="font-mono text-foreground">open &ldquo;{shellExample}&rdquo;</span> in a shell.
               </p>
             </div>
@@ -211,7 +216,8 @@ export function ParameterSheet({ door, fileName, address, parameters, values, la
             // A script that takes nothing still gets the sheet: the URL is the
             // whole point of it, and this is the shortest version of the lesson.
             <p className="m-0 text-xs leading-[1.6] text-muted-foreground">
-              This script takes no parameters. Anything that opens a URL can run it — a Raycast quicklink, an Alfred workflow, a Shortcut, or{" "}
+              This script takes no parameters. Anything that opens a URL can run it — a{" "}
+              {schemeLink ? "Raycast quicklink, an Alfred workflow, a Shortcut" : "bookmark, a Raycast quicklink, a link in a document"}, or{" "}
               <span className="font-mono text-foreground">open</span> in a shell.
             </p>
           ))}

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -291,7 +291,10 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
                 agent={props.agentFileIds?.has(node.script.path)}
                 waiting={props.waitingFileIds?.has(node.script.path)}
                 active={active(`file:${node.script.path}`)}
-                hasMenu={canWrite}
+                // A file the web is serving is read-only, but it still has an
+                // address — so the row keeps its menu wherever there is an
+                // item to put in it.
+                hasMenu={canWrite || props.onCopyScriptLink !== undefined}
                 onHover={(on) => setHovered(on ? `file:${node.script.path}` : null)}
                 onSelect={() => props.onScriptSelect(node.script)}
                 onMenu={(event) => setScriptMenu({ script: node.script, top: event.clientY, left: event.clientX })}

--- a/ui/src/scriptLink.test.ts
+++ b/ui/src/scriptLink.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { isLinkedScript, linkName, parseScriptLink, scriptLink, scriptLinkParts } from "./scriptLink";
+import { DESKTOP_LINK_BASE, hasScriptLink, isLinkedScript, linkName, parseScriptLink, scriptLink, scriptLinkParts } from "./scriptLink";
+
+// The desktop's form, stated rather than read off whatever the test runner has
+// for a `window`: `scriptLink` defaults to a link to *this* Kaja, which is the
+// question these tests are not asking.
+const desktopLink = (fileName: string, input?: { [key: string]: string }) => scriptLink(fileName, input, DESKTOP_LINK_BASE);
+const desktopParts = (fileName: string, input?: { [key: string]: string }) => scriptLinkParts(fileName, input, DESKTOP_LINK_BASE);
 
 function parsed(text: string) {
   const result = parseScriptLink(text);
@@ -40,9 +46,11 @@ describe("parseScriptLink", () => {
     expect(parsed("kaja://RUN/nightly").script).toBe("nightly");
   });
 
-  test("refuses another scheme", () => {
-    const result = parseScriptLink("https://example.com/run/nightly");
-    expect(result.ok).toBe(false);
+  test("refuses an http link that carries nothing after its #", () => {
+    // The path is the page's, not Kaja's: only the fragment is a deeplink.
+    expect(parseScriptLink("https://example.com/run/nightly").ok).toBe(false);
+    expect(parseScriptLink("https://kaja.example.com/").ok).toBe(false);
+    expect(parseScriptLink("https://kaja.example.com/#somewhere-else").ok).toBe(false);
   });
 
   test("refuses a verb Kaja doesn't have", () => {
@@ -69,22 +77,22 @@ describe("parseScriptLink", () => {
 
 describe("scriptLink", () => {
   test("names the script without its extension", () => {
-    expect(scriptLink("nightly.ts")).toBe("kaja://run/nightly");
+    expect(desktopLink("nightly.ts")).toBe("kaja://run/nightly");
   });
 
   test("encodes the name and the input", () => {
-    expect(scriptLink("a night out.ts", { url: "https://example.com/a?b=1" })).toBe("kaja://run/a%20night%20out?url=https%3A%2F%2Fexample.com%2Fa%3Fb%3D1");
+    expect(desktopLink("a night out.ts", { url: "https://example.com/a?b=1" })).toBe("kaja://run/a%20night%20out?url=https%3A%2F%2Fexample.com%2Fa%3Fb%3D1");
   });
 
   test("round-trips what it built", () => {
     const input = { url: "https://example.com/x y", "odd key": "a&b=c" };
-    expect(parsed(scriptLink("thread.ts", input))).toEqual({ script: "thread", input });
+    expect(parsed(desktopLink("thread.ts", input))).toEqual({ script: "thread", input });
   });
 
   // What the sheet is for: a key with nothing behind it is where a launcher's
   // own token goes, so the link has to carry it.
   test("keeps a key whose value is blank", () => {
-    expect(scriptLink("thread.ts", { url: "", note: "" })).toBe("kaja://run/thread?url=&note=");
+    expect(desktopLink("thread.ts", { url: "", note: "" })).toBe("kaja://run/thread?url=&note=");
   });
 });
 
@@ -92,15 +100,15 @@ describe("scriptLinkParts", () => {
   test("is the link it splits", () => {
     const input = { url: "https://example.com/a?b=1", note: "" };
     expect(
-      scriptLinkParts("reports/weekly usage.ts", input)
+      desktopParts("reports/weekly usage.ts", input)
         .map((part) => part.text)
         .join(""),
-    ).toBe(scriptLink("reports/weekly usage.ts", input));
+    ).toBe(desktopLink("reports/weekly usage.ts", input));
   });
 
-  test("separates what the scheme says from what the script says", () => {
-    expect(scriptLinkParts("thread.ts", { url: "abc", note: "" })).toEqual([
-      { kind: "scheme", text: "kaja://run/" },
+  test("separates what Kaja's address says from what the script says", () => {
+    expect(desktopParts("thread.ts", { url: "abc", note: "" })).toEqual([
+      { kind: "base", text: DESKTOP_LINK_BASE },
       { kind: "script", text: "thread" },
       { kind: "key", text: "?url=" },
       { kind: "value", text: "abc" },
@@ -126,7 +134,7 @@ describe("isLinkedScript", () => {
 // can share a base name, and the link has to say which one it means.
 describe("a script in a folder", () => {
   test("keeps the folder in the link, with each segment encoded on its own", () => {
-    expect(scriptLink("reports/weekly usage.ts")).toBe("kaja://run/reports/weekly%20usage");
+    expect(desktopLink("reports/weekly usage.ts")).toBe("kaja://run/reports/weekly%20usage");
     expect(parseScriptLink("kaja://run/reports/weekly%20usage")).toEqual({ ok: true, link: { script: "reports/weekly usage", input: {} } });
   });
 
@@ -134,5 +142,54 @@ describe("a script in a folder", () => {
     expect(isLinkedScript("reports/churn.ts", "reports/churn")).toBe(true);
     expect(isLinkedScript("reports/churn.ts", "churn")).toBe(true);
     expect(isLinkedScript("billing/churn.ts", "reports/churn")).toBe(false);
+  });
+});
+
+// The web's own form. A page can't register a scheme, so the link is the page
+// again with the deeplink in its fragment — the same grammar after the `#`.
+describe("the web's link", () => {
+  const base = "https://kaja.example.com/#run/";
+
+  test("says the same thing after a #", () => {
+    const input = { url: "https://example.com/p1", note: "later" };
+    expect(scriptLink("slack-thread.ts", input, base)).toBe("https://kaja.example.com/#run/slack-thread?url=https%3A%2F%2Fexample.com%2Fp1&note=later");
+    expect(parsed(scriptLink("slack-thread.ts", input, base))).toEqual({ script: "slack-thread", input });
+  });
+
+  test("round-trips a script in a folder, and one whose name had to be encoded", () => {
+    expect(parsed(scriptLink("reports/weekly usage.ts", {}, base)).script).toBe("reports/weekly usage");
+  });
+
+  test("reads a link served from a base path, which is what keeps it out of the server", () => {
+    expect(parsed("https://example.com/tools/kaja/#run/nightly?tag=q3")).toEqual({ script: "nightly", input: { tag: "q3" } });
+  });
+
+  test("leaves the page's own query alone", () => {
+    // Everything before the `#` belongs to whoever is serving Kaja; the
+    // script's parameters are the ones inside the fragment.
+    expect(parsed("https://kaja.example.com/?theme=dark#run/nightly?tag=q3").input).toEqual({ tag: "q3" });
+  });
+
+  test("reads the verb whatever case it was written in", () => {
+    expect(parsed("https://kaja.example.com/#RUN/nightly").script).toBe("nightly");
+  });
+
+  test("refuses a fragment that names no script", () => {
+    expect(parseScriptLink("https://kaja.example.com/#run").ok).toBe(false);
+    expect(parseScriptLink("https://kaja.example.com/#run/").ok).toBe(false);
+  });
+});
+
+// A page is handed every fragment it is ever opened with, so it has to be able
+// to say "not mine" about somebody else's anchor without reporting an error.
+describe("hasScriptLink", () => {
+  test("knows a deeplink from any other fragment", () => {
+    expect(hasScriptLink("https://kaja.example.com/#run/nightly?tag=q3")).toBe(true);
+    expect(hasScriptLink("https://kaja.example.com/#run")).toBe(true);
+    expect(hasScriptLink("https://kaja.example.com/#RUN/nightly")).toBe(true);
+    expect(hasScriptLink("https://kaja.example.com/")).toBe(false);
+    expect(hasScriptLink("https://kaja.example.com/#section-2")).toBe(false);
+    expect(hasScriptLink("https://kaja.example.com/#running-late")).toBe(false);
+    expect(hasScriptLink("not a url")).toBe(false);
   });
 });

--- a/ui/src/scriptLink.ts
+++ b/ui/src/scriptLink.ts
@@ -1,3 +1,5 @@
+import { isWailsEnvironment } from "./wails";
+
 /**
  * `kaja://run/<script>?key=value&key=value` — the deeplink that runs a script.
  *
@@ -11,9 +13,24 @@
  * and only text, and every value arrives as a string. "Deeplink" is the word
  * for it in the UI, because it is the word the launcher on the other end of it
  * already uses; "link" names a browser URL, a file alias and a share sheet too.
+ *
+ * **A page can't register a scheme, so the web says the same thing after a
+ * `#`**: `https://kaja.example.com/#run/<script>?key=value`. The fragment is
+ * the `kaja://` link minus its scheme, and is read as exactly that — one
+ * grammar, one parser, one `ScriptLink`. It is the fragment rather than a path
+ * (`/run/<script>`) because the fragment is never sent to the server and never
+ * has to be routed by one: nothing about how Kaja is served or under what base
+ * path has to know that deeplinks exist. And it is the fragment rather than a
+ * `?run=` of its own for the reason the desktop's host is the verb — a query
+ * parameter named here is one a script can never take.
  */
 
 export const LINK_SCHEME = "kaja";
+/** The verb, which is the host of a `kaja://` link and the head of a fragment. */
+export const LINK_VERB = "run";
+
+/** Where a `kaja://` deeplink starts. What the desktop copies. */
+export const DESKTOP_LINK_BASE = `${LINK_SCHEME}://${LINK_VERB}/`;
 
 export interface ScriptLink {
   /** The script the link names, without its extension. */
@@ -23,6 +40,29 @@ export interface ScriptLink {
 }
 
 export type ParsedScriptLink = { ok: true; link: ScriptLink } | { ok: false; error: string };
+
+/**
+ * Where a deeplink to *this* Kaja starts — the one function here that asks
+ * what it is running in. The desktop registered a scheme, so it owns
+ * `kaja://run/`; a browser can only address itself, so the link is this page
+ * again with the script in its fragment. The pathname rides along, so a Kaja
+ * served under a base path copies links that come back to it.
+ */
+export function linkBase(): string {
+  if (isWailsEnvironment()) return DESKTOP_LINK_BASE;
+  try {
+    // This page again, with the script after its `#` — where Kaja is served
+    // from rather than where it currently points, so a Kaja under a base path
+    // copies links that come back to it and one opened with a query of its own
+    // doesn't bake that query into everything it hands out.
+    const here = new URL(window.location.href);
+    here.search = "";
+    here.hash = "";
+    return `${here.href}#${LINK_VERB}/`;
+  } catch {
+    return DESKTOP_LINK_BASE;
+  }
+}
 
 /**
  * The name a deeplink spells a script with: its name within the scripts folder,
@@ -52,27 +92,27 @@ export function isLinkedScript(scriptName: string, named: string): boolean {
 }
 
 /** The deeplink that runs a script. What Copy deeplink puts on the clipboard. */
-export function scriptLink(fileName: string, input?: { [key: string]: string }): string {
-  return scriptLinkParts(fileName, input)
+export function scriptLink(fileName: string, input?: { [key: string]: string }, base: string = linkBase()): string {
+  return scriptLinkParts(fileName, input, base)
     .map((part) => part.text)
     .join("");
 }
 
 /**
  * The same deeplink, split into what it is made of. The sheet shows it whole
- * and dims everything that is the scheme rather than the script's own — so the
- * link it displays is the link it copies, by construction rather than by two
- * functions agreeing.
+ * and dims everything that is the address of Kaja rather than the script's own
+ * — so the link it displays is the link it copies, by construction rather than
+ * by two functions agreeing.
  */
-export type LinkPart = { kind: "scheme" | "script" | "key" | "value"; text: string };
+export type LinkPart = { kind: "base" | "script" | "key" | "value"; text: string };
 
-export function scriptLinkParts(fileName: string, input?: { [key: string]: string }): LinkPart[] {
+export function scriptLinkParts(fileName: string, input?: { [key: string]: string }, base: string = linkBase()): LinkPart[] {
   const path = linkName(fileName)
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
   const parts: LinkPart[] = [
-    { kind: "scheme", text: `${LINK_SCHEME}://run/` },
+    { kind: "base", text: base },
     { kind: "script", text: path },
   ];
 
@@ -94,6 +134,16 @@ function baseName(path: string): string {
   return at === -1 ? path : path.slice(at + 1);
 }
 
+/**
+ * Whether a page's URL carries a deeplink in its fragment. Anything else after
+ * a `#` is somebody else's anchor and is left alone — a page that is asked
+ * about every fragment it is ever given must be able to say "not mine" without
+ * reporting an error about it.
+ */
+export function hasScriptLink(href: string): boolean {
+  return scriptLinkFragment(href) !== undefined;
+}
+
 export function parseScriptLink(text: string): ParsedScriptLink {
   let url: URL;
   try {
@@ -102,17 +152,39 @@ export function parseScriptLink(text: string): ParsedScriptLink {
     return { ok: false, error: `Not a link: ${text}` };
   }
   if (url.protocol !== `${LINK_SCHEME}:`) {
-    return { ok: false, error: `A Kaja link starts with ${LINK_SCHEME}://` };
+    // The web's own form: the fragment is the link minus its scheme, so it is
+    // read by putting the scheme back on rather than by a second parser.
+    const fragment = scriptLinkFragment(text);
+    if (fragment === undefined) {
+      return { ok: false, error: `A Kaja link is ${DESKTOP_LINK_BASE}<script>, or #${LINK_VERB}/<script> on the web.` };
+    }
+    try {
+      url = new URL(`${LINK_SCHEME}://${fragment}`);
+    } catch {
+      return { ok: false, error: `Not a link: ${text}` };
+    }
   }
   // A kaja:// host is opaque, so it keeps the case it was written in.
-  if (url.host.toLowerCase() !== "run") {
-    return { ok: false, error: `${LINK_SCHEME}://${url.host} is not something Kaja does. Links run a script: ${LINK_SCHEME}://run/<script>` };
+  if (url.host.toLowerCase() !== LINK_VERB) {
+    return { ok: false, error: `${LINK_SCHEME}://${url.host} is not something Kaja does. Links run a script: ${DESKTOP_LINK_BASE}<script>` };
   }
   const script = url.pathname.replace(/^\/+/, "").split("/").map(decodeSegment).join("/").trim();
   if (!script) {
-    return { ok: false, error: `This link names no script. Links run a script: ${LINK_SCHEME}://run/<script>` };
+    return { ok: false, error: `This link names no script. Links run a script: ${DESKTOP_LINK_BASE}<script>` };
   }
   return { ok: true, link: { script: linkName(script), input: Object.fromEntries(url.searchParams) } };
+}
+
+/** The `run/…` a page URL carries after its `#`, if that is what it carries. */
+function scriptLinkFragment(href: string): string | undefined {
+  let hash: string;
+  try {
+    hash = new URL(href.trim()).hash;
+  } catch {
+    return undefined;
+  }
+  const fragment = hash.slice(1);
+  return new RegExp(`^${LINK_VERB}(?:$|[/?])`, "i").test(fragment) ? fragment : undefined;
 }
 
 // A path this malformed is the caller's typing rather than an encoding, so it

--- a/ui/src/server/connection.test.ts
+++ b/ui/src/server/connection.test.ts
@@ -38,3 +38,17 @@ test("getBaseUrlForAi", () => {
   const baseUrl = getBaseUrlForAi();
   expect(baseUrl).toBe("http://example.com/path/ai");
 });
+
+// A deeplink is `/#run/<script>?…`, so the page's own URL routinely carries a
+// fragment now. It says where the page points, not where it is served from.
+test("ignores a fragment and a query the page happens to carry", () => {
+  globalThis.window = {
+    location: {
+      href: "http://example.com/path/?theme=dark#run/nightly?tag=q3",
+    },
+  } as any;
+
+  expect(getBaseUrlForApi()).toBe("http://example.com/path/twirp");
+  expect(getBaseUrlForTarget()).toBe("http://example.com/path/target");
+  expect(getBaseUrlForAi()).toBe("http://example.com/path/ai");
+});

--- a/ui/src/server/connection.ts
+++ b/ui/src/server/connection.ts
@@ -19,18 +19,29 @@ export function getApiClient(): ApiClient {
 }
 
 export function getBaseUrlForApi(): string {
-  const currentUrl = trimTrailingSlash(window.location.href);
-  return `${currentUrl}/twirp`;
+  return `${servedFrom()}/twirp`;
 }
 
 export function getBaseUrlForTarget(): string {
-  const currentUrl = trimTrailingSlash(window.location.href);
-  return `${currentUrl}/target`;
+  return `${servedFrom()}/target`;
 }
 
 export function getBaseUrlForAi(): string {
-  const currentUrl = trimTrailingSlash(window.location.href);
-  return `${currentUrl}/ai`;
+  return `${servedFrom()}/ai`;
+}
+
+/**
+ * Where this page is served from, which is not the same as where it currently
+ * points. A deeplink names its script in the fragment (`/#run/<script>?…`), and
+ * appending `/twirp` to a URL that carries a query or a fragment puts the path
+ * inside one — `…/#run/nightly/twirp` resolves back to `/`, so every call lands
+ * on index.html and comes back as a protobuf that won't decode.
+ */
+function servedFrom(): string {
+  const url = new URL(window.location.href);
+  url.search = "";
+  url.hash = "";
+  return trimTrailingSlash(url.href);
 }
 
 function trimTrailingSlash(s: string): string {


### PR DESCRIPTION
A page can't register a scheme, so the web says what `kaja://run/<script>?key=value` says after a `#` — `https://kaja.example.com/#run/<script>?key=value` — read by putting the scheme back on rather than by a second parser, so no server route and no asset-path changes are needed.

Also fixes two things it turned up: every RPC base URL was built from `window.location.href`, so any fragment broke all calls; and a first-time window's auto-open landed after the link and took the pane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01293qBuGrfgAGbYnNrZwZhf)_