### PR TITLE
Named the import forms that bind nothing

### DIFF
--- a/ui/src/scriptRunner.test.ts
+++ b/ui/src/scriptRunner.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "bun:test";
 import { AskBlock } from "./blocks";
 import { Kaja } from "./kaja";
+import { App, createPendingApp } from "./apps";
+import { Source } from "./sources";
 import { runScriptCaptured } from "./scriptRunner";
 import { LogLevel } from "./server/api";
 
@@ -12,6 +14,14 @@ function makeKaja(answer: (question: AskBlock) => string = () => ""): Kaja {
     onBlockUpdate: () => {},
     onLog: () => {},
   });
+}
+
+// An app with one source and one service, which is all the import resolution reads.
+function teamsApp(): App {
+  const app = createPendingApp({ name: "teams", app: { oneofKind: undefined } });
+  app.services = [{ name: "Teams", packageName: "teams", sourcePath: "teams/teams", clientStubModuleId: "", methods: [] }];
+  app.sources = [{ importPath: "teams/teams" } as Source];
+  return app;
 }
 
 describe("kaja.variables injection", () => {
@@ -94,6 +104,39 @@ describe("orphaned imports", () => {
 
     expect(run.result).toBeUndefined();
     expect(run.error).toContain(`app "teams" was not found`);
+  });
+});
+
+describe("import forms that bind nothing", () => {
+  it("names the kaja import a default clause never made", async () => {
+    const run = await runScriptCaptured(`import kaja from "kaja";\nreturn kaja.uuidV4();`, makeKaja(), []);
+
+    expect(run.result).toBeUndefined();
+    expect(run.error).toBe(`Cannot resolve import "kaja": a default import does not resolve. Use a named import: import { kaja } from "kaja".`);
+  });
+
+  it("names the kaja import a namespace clause never made", async () => {
+    const run = await runScriptCaptured(`import * as kaja from "./kaja";\nreturn kaja.uuidV4();`, makeKaja(), []);
+
+    expect(run.error).toBe(`Cannot resolve import "./kaja": a namespace import does not resolve. Use a named import: import { kaja } from "./kaja".`);
+  });
+
+  it("suggests a service the source declares when an app is imported as a namespace", async () => {
+    const run = await runScriptCaptured(`import * as teams from "teams/teams";\nteams.Teams.GetAllTeams({});`, makeKaja(), [teamsApp()]);
+
+    expect(run.error).toBe(
+      `Cannot resolve import "teams/teams": a namespace import does not resolve. Use a named import: import { Teams } from "teams/teams".`,
+    );
+  });
+
+  it("leaves a named import alone", async () => {
+    const kaja = makeKaja();
+    kaja.variables = { HELLO: "world" };
+
+    const run = await runScriptCaptured(`import { kaja as runtime } from "kaja";\nreturn runtime.variables.HELLO;`, kaja, []);
+
+    expect(run.error).toBeUndefined();
+    expect(run.result).toBe("world");
   });
 });
 

--- a/ui/src/scriptRunner.ts
+++ b/ui/src/scriptRunner.ts
@@ -33,6 +33,20 @@ function formatDiagnostic(diagnostic: ts.Diagnostic): string {
   return message;
 }
 
+// Only named imports bind, because the bindings are looked up by name. A default or
+// namespace clause would otherwise drop through and surface as "X is not defined"
+// pointing at the use rather than at the import that never bound anything.
+function requireNamedImport(importClause: ts.ImportClause | undefined, path: string, example: string): void {
+  if (!importClause) return;
+  const form = importClause.name
+    ? "a default import"
+    : importClause.namedBindings && ts.isNamespaceImport(importClause.namedBindings)
+      ? "a namespace import"
+      : undefined;
+  if (!form) return;
+  throw new Error(`Cannot resolve import "${path}": ${form} does not resolve. Use a named import: import { ${example} } from "${path}".`);
+}
+
 // prepareTask resolves a script's imports against the loaded apps and splits out the
 // runnable body, returning the args every binding maps to plus the code.
 function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: string]: Client | Object }; runCode: string } {
@@ -52,6 +66,7 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
       // Monaco backs the kaja module with a model at ts:/kaja.ts, so its auto-import and
       // go-to-definition can emit the relative "./kaja" form.
       if (path === "kaja" || path === "./kaja") {
+        requireNamedImport(statement.importClause, path, "kaja");
         const importClause = statement.importClause;
         if (importClause && importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
           importClause.namedBindings.elements.forEach((importSpecifier) => {
@@ -74,6 +89,8 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
       if (!source) {
         throw new Error(`Cannot resolve import "${path}" in app "${app.configuration.name}".`);
       }
+
+      requireNamedImport(statement.importClause, path, app.services.find((service) => service.sourcePath === source.importPath)?.name ?? "Service");
 
       const importClause = statement.importClause;
       if (importClause && importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)) {


### PR DESCRIPTION
A default or namespace clause dropped through `prepareTask` silently, so `import * as kaja from "kaja"` surfaced as "kaja is not defined" pointing at the use rather than at the import that never bound anything — which is how an agent came to conclude that `kaja` is unavailable in inline runs. The error now says which form was written and what to write instead, naming a service the source declares for an app module.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etz5BUqsjJpw5QCmQUDQuV)_