### PR TITLE
Added a Stats view to the run console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ Expansion is a record of where you have been (`treeExpansion.ts`). Three inputs,
 - **There are no fold-all/unfold-all buttons.** **⌥click a row** takes its subtree instead. Folding the **Apps** section writes nothing into the fold map.
 - The old `expandedApps`/`expandedServices` keys are **not migrated**.
 
-## A run has two views
+## A run has three views
 
 **A run is the unit** (`runs.ts`): one press of Run, one duration, one verdict, everything it produced under it.
 
@@ -230,9 +230,9 @@ Expansion is a record of where you have been (`treeExpansion.ts`). Three inputs,
 - **A run leaves the live list one way, and that way gives it its duration** (`endRuns`). Settling and dropping are one act: the list is where the settle check looks, so a record taken off it without a duration is a run nothing can settle — and a run without a duration is a *running* run to everything that reports one.
 - **Stop is about one run**: it aborts the runs of the file the button is on and cancels only the questions those runs are parked on. It **ends** the run rather than asking the script to end it — a run parked on a question that will never be asked again has nothing left to settle it.
 
-The **log** is the flat audit log — one row per call, in wall order, always complete. The **canvas** is the rendered output, free to fold what is repetitive. A segmented control (**Calls** / **Canvas**, `ConsoleView`, in-memory only) switches them and **everything else about the header stops moving**; that is what pays for the split. Request/Response/Headers moved down onto the payload pane, so the pane never reflows as you step through the log.
+The **log** is the flat audit log — one row per call, in wall order, always complete. The **canvas** is the rendered output, free to fold what is repetitive. The **stats** are what the calls add up to. A segmented control (**Calls** / **Canvas** / **Stats**, `ConsoleView`, in-memory only) switches them and **everything else about the header stops moving**; that is what pays for the split. Request/Response/Headers moved down onto the payload pane, so the pane never reflows as you step through the log.
 
-`RunLog.tsx`, `Canvas.tsx` and `Console.tsx` are peers: `RunLog.CallRow` / `TailBar` / `PayloadPane` belong to the log, `Console.RunSelect` / `RunRow` to the frame.
+`RunLog.tsx`, `Canvas.tsx`, `Stats.tsx` and `Console.tsx` are peers: `RunLog.CallRow` / `TailBar` / `PayloadPane` belong to the log, `Console.RunSelect` / `RunRow` to the frame.
 
 ### What a script printed
 
@@ -249,6 +249,20 @@ The **log** is the flat audit log — one row per call, in wall order, always co
 ### The payload pane
 
 **A response is printed, not formatted** (`payloadText.ts`). The pane follows the selection, which follows a run as it happens, so prettier's ~2 ms and a parser download per payload buy nothing over `JSON.stringify`. Being synchronous is the other half: a slow payload can't land over a newer one. Prettier stays where it earns its keep — generated TypeScript, and the JSON *documents* in the app form and Variables. Past 2 MB the pane draws the head and says how much it left.
+
+### What the calls added up to
+
+`runStats.ts` computes it, `statsChart.ts` is the arithmetic behind the drawing, `Stats.tsx` draws it. **Nothing on the page is specific to a perf test** — everything is derived from what a call already records, so a paging loop has latency, throughput and concurrency like anything else; they are just not *shaped*.
+
+- **The segment is always there**, on the same rule as the other two. A Stats tab that appeared once a run was big enough would be a control you have to notice to know exists, and a run of twelve calls has percentiles worth reading.
+- **Charts are plain SVG in the view and numbers in a module.** Every one of them is a linear scale into a fixed box, so there is no axis to negotiate and no library to take: `fill="currentColor"` over a `text-foreground` element is what makes day and night free, and there is no second hex table to keep in step the way `monacoTheme.ts` is. **The hard half is bucketing, not drawing** — which is the half no chart library does.
+- **The metrics are a buffer, maintained as the run happens** (`RunGroup.metrics`, added to beside `strip` in `consoles.ts`), never re-derived per repaint. `RunMetrics.version` is what the view memoises against.
+- **Percentiles are exact while the values are few and a log histogram once they are many** (`Latencies`, `EXACT_LIMIT`). A script making a dozen calls reads its own numbers back; a perf test gets 4.4%-at-worst accuracy in bounded memory, and the histogram *is* the distribution chart.
+- **Time buckets double rather than being sized in advance** — a run has no length while it is running. A bucket index is derived from a timestamp rather than remembered, so the pairwise collapse that halves every index leaves a call that settles afterwards landing where it belongs. **Concurrency rides on the same buckets as a delta** (+1 issued, −1 settled): summing two deltas is what makes them mergeable, and prefix-summing is the line.
+- **A slice is never finer than the calls it holds.** Eighty slices over fourteen calls is a chart that is mostly gaps.
+- **Failures say the same thing three times**: red marks on the chart floor, a red segment at the foot of the rps bar, a red count in the method table. The segment has a floor, because one failure in three hundred calls rounds to nothing and still has to be visible.
+- **The tile strip is the only thing pinned**; the charts, distribution and table scroll under it as one column, so a console at 300px is the same page as one dragged open. Its trailing empty cell is where a schedule states what it excluded.
+- **Two degenerate cases are stated rather than drawn.** One call has a duration and an outcome, so the tiles collapse to those two and the table is the rest. Zero calls is one line of muted text — not an empty dashboard with six dashes in it.
 
 ### The console belongs to the file
 

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -12,6 +12,7 @@ import { Spinner } from "./components/spinner";
 import { consoles } from "./consoles";
 import { JsonViewerHandle } from "./JsonViewer";
 import { RunLog } from "./RunLog";
+import { Stats } from "./Stats";
 import {
   callRows,
   ConsoleItem,
@@ -293,7 +294,9 @@ export function Console({
     );
   }
 
-  const showUtilities = activeView === "canvas" || selectedCall !== undefined;
+  // Fold, unfold and copy are about a payload, and full screen is about the canvas.
+  // Stats has neither, so it carries none of them.
+  const showUtilities = activeView === "canvas" || (activeView === "calls" && selectedCall !== undefined);
 
   const canvas = selectedGroup && (
     <Canvas
@@ -362,6 +365,18 @@ export function Console({
                 script — the others are the tail of the log and the run pill. */}
             {waiting && activeView !== "canvas" && <span data-testid="canvas-badge" className="h-1.5 w-1.5 rounded-full bg-amber-500" />}
           </SegmentedControl.Button>
+          {/* Always there, and never carrying a count: a run has statistics whether
+              or not anyone shaped it as a test, and a segment that appears once a
+              run is big enough would be a control you have to notice to know
+              exists. */}
+          <SegmentedControl.Button
+            selected={activeView === "stats"}
+            className="h-[20px] px-2.5 py-0 text-xs"
+            onClick={() => onViewChange("stats")}
+            data-testid="console-view-stats"
+          >
+            Stats
+          </SegmentedControl.Button>
         </SegmentedControl>
         {/* Only there when the run printed something, on the same rule as
             everything else in this header: a control over nothing is chrome. */}
@@ -418,6 +433,8 @@ export function Console({
           {selectedGroup.strip.calls > 0 && <Canvas.RunStrip group={selectedGroup} onSelectCall={selectFromCanvas} />}
           {canvas}
         </>
+      ) : selectedGroup && activeView === "stats" ? (
+        <Stats group={selectedGroup} onSelectCall={selectFromCanvas} />
       ) : selectedGroup ? (
         <RunLog
           group={selectedGroup}

--- a/ui/src/Stats.tsx
+++ b/ui/src/Stats.tsx
@@ -1,0 +1,381 @@
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { callDurationMs } from "./kaja";
+import { cn } from "./cn";
+import { RunGroup } from "./runs";
+import { MethodRow, RunStats, StatsSlot } from "./runStats";
+import {
+  bandPoints,
+  barsFor,
+  CHART_WIDTH,
+  failurePositions,
+  formatErrorRate,
+  formatMs,
+  formatMsBare,
+  formatRps,
+  linePoints,
+  niceCeiling,
+  slotsFor,
+  stepPoints,
+  timeTicks,
+} from "./statsChart";
+
+/**
+ * What a run's calls add up to. The third view of one run: the log is every call in
+ * wall order, the canvas is what the script drew, and this is the shape of the whole
+ * of it — percentiles, throughput, concurrency and a breakdown per method.
+ *
+ * Nothing here is specific to a perf test. Everything is computed from what a call
+ * already records, so a paging loop has latency and throughput like anything else.
+ */
+
+const LATENCY_HEIGHT = 104;
+const RPS_HEIGHT = 52;
+const IN_FLIGHT_HEIGHT = 36;
+const DISTRIBUTION_HEIGHT = 56;
+// A serial loop must not read as a saturated one, so the concurrency axis has a floor
+// rather than being the run's own maximum.
+const MIN_IN_FLIGHT_CEILING = 4;
+// A bucket with one failure in three hundred calls still has to be a mark you can see.
+const MIN_FAILURE_SEGMENT = 2;
+
+interface StatsProps {
+  group: RunGroup;
+  // Opens a call in the log, which is where the page hands off whenever it names one.
+  onSelectCall: (itemId: string) => void;
+}
+
+export function Stats({ group, onSelectCall }: StatsProps) {
+  const body = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = body.current;
+    if (!element) return;
+    const measure = () => setWidth(element.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const slots = slotsFor(width);
+  const bars = barsFor(width);
+  const stats = useMemo(
+    () => group.metrics.view(slots, bars, group.run.durationMs),
+    // The metrics are a buffer rather than React state, so its own version is what
+    // says a chart would draw differently — walking the run to find out is the thing
+    // this whole module exists not to do.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [group.metrics, group.metrics.version, slots, bars, group.run.durationMs],
+  );
+
+  if (stats.calls === 0) {
+    return (
+      <div ref={body} className="flex min-h-0 flex-1 items-start bg-background px-3 py-3">
+        <span className="text-xs text-muted-foreground">This run made no calls.</span>
+      </div>
+    );
+  }
+
+  // One call has no distribution, no throughput and no concurrency — it has a
+  // duration and an outcome, and the table is the rest of what there is to say.
+  const single = stats.calls === 1;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
+      <Stats.Tiles group={group} stats={stats} single={single} />
+      <div ref={body} className="min-h-0 flex-1 overflow-y-auto">
+        {!single && (
+          <>
+            <Stats.Latency stats={stats} />
+            <Stats.Throughput stats={stats} />
+            <Stats.InFlight stats={stats} />
+            <Stats.Distribution stats={stats} />
+          </>
+        )}
+        <Stats.Methods stats={stats} onSelectCall={onSelectCall} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One row of borderless cells divided by hairlines, not cards — the same weight as
+ * the tail bar. It is the only thing on the page that is pinned, so the charts, the
+ * distribution and the table scroll under it as one column and a console dragged open
+ * is the same page it was at 300px.
+ */
+Stats.Tiles = function ({ group, stats, single }: { group: RunGroup; stats: RunStats; single: boolean }) {
+  const only = single ? group.calls[0] : undefined;
+  const cells: { label: string; value: string; className?: string }[] = only
+    ? [
+        { label: "duration", value: formatMs(callDurationMs(only.call!) ?? undefined) },
+        {
+          label: "outcome",
+          value: only.call?.error !== undefined ? "failed" : "ok",
+          className: only.call?.error !== undefined ? "text-destructive" : "text-emerald-600 dark:text-emerald-400",
+        },
+      ]
+    : [
+        { label: "requests", value: stats.calls.toLocaleString() },
+        {
+          label: "error rate",
+          value: formatErrorRate(stats.errorRate, stats.failures),
+          className: stats.failures > 0 ? "text-destructive" : "text-emerald-600 dark:text-emerald-400",
+        },
+        { label: "mean rps", value: formatRps(stats.meanRps) },
+        { label: "p50", value: formatMs(stats.p50) },
+        { label: "p95", value: formatMs(stats.p95) },
+        { label: "p99", value: formatMs(stats.p99) },
+      ];
+
+  return (
+    <div data-testid="stats-tiles" className="flex shrink-0 items-stretch overflow-hidden border-b border-border bg-card">
+      {cells.map((cell, index) => (
+        <div key={cell.label} className={cn("flex min-w-[96px] shrink flex-col justify-center px-3 py-2", index > 0 && "border-l border-border")}>
+          <span className="truncate text-xs text-muted-foreground">{cell.label}</span>
+          <span className={cn("truncate font-mono text-sm", cell.className ?? "text-foreground")}>{cell.value}</span>
+        </div>
+      ))}
+      {/* The cell that closes the strip. A schedule states what it excluded here;
+          a run that is only a run has nothing to put in it, and says so by leaving
+          it empty rather than by ending the row early. */}
+      <div className="flex flex-1 items-center border-l border-border px-3" />
+    </div>
+  );
+};
+
+/**
+ * p50 with the p50–p95 and p95–p99 envelopes behind it. Three bands rather than three
+ * lines: the tail is a region the run spent time in, and drawing it as a line invites
+ * reading a p99 spike as one call's story.
+ */
+Stats.Latency = function ({ stats }: { stats: RunStats }) {
+  const ceiling = niceCeiling(Math.max(...stats.slots.map((slot) => slot.p99 ?? 0), 0));
+  const tail = bandPoints(
+    stats.slots,
+    (slot) => slot.p95,
+    (slot) => slot.p99,
+    ceiling,
+    LATENCY_HEIGHT,
+  );
+  const body = bandPoints(
+    stats.slots,
+    (slot) => slot.p50,
+    (slot) => slot.p95,
+    ceiling,
+    LATENCY_HEIGHT,
+  );
+  const median = linePoints(stats.slots, (slot) => slot.p50, ceiling, LATENCY_HEIGHT);
+
+  return (
+    <div className="px-3 pt-3">
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <span className="text-xs text-muted-foreground">Latency</span>
+        <div className="flex items-center gap-3 overflow-hidden">
+          <span className="font-mono text-xs text-muted-foreground">p50</span>
+          <span className="font-mono text-xs text-muted-foreground opacity-75">p50–p95</span>
+          <span className="font-mono text-xs text-muted-foreground opacity-55">p95–p99</span>
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">{formatMs(ceiling)}</span>
+        </div>
+      </div>
+      <div data-testid="stats-latency" className="relative rounded border border-border" style={{ height: LATENCY_HEIGHT }}>
+        <svg
+          viewBox={`0 0 ${CHART_WIDTH} ${LATENCY_HEIGHT}`}
+          preserveAspectRatio="none"
+          className="absolute inset-0 h-full w-full text-foreground"
+          aria-hidden="true"
+        >
+          {tail && <polygon points={tail} fill="currentColor" opacity={0.1} />}
+          {body && <polygon points={body} fill="currentColor" opacity={0.2} />}
+          {median && <polyline points={median} fill="none" stroke="currentColor" strokeWidth={1.5} opacity={0.85} vectorEffect="non-scaling-stroke" />}
+        </svg>
+        <Stats.FailureMarks stats={stats} />
+      </div>
+    </div>
+  );
+};
+
+/** Where the run failed, along the same clock — the first of the three places it says so. */
+Stats.FailureMarks = function ({ stats }: { stats: RunStats }) {
+  const marks = failurePositions(stats.slots);
+  if (marks.length === 0) return null;
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[5px]">
+      {marks.map((mark) => (
+        <span
+          key={mark.position}
+          data-testid="stats-failure-mark"
+          className="absolute bottom-0 h-[5px] w-[2px] bg-destructive"
+          style={{ left: `${mark.position * 100}%` }}
+        />
+      ))}
+    </div>
+  );
+};
+
+Stats.Throughput = function ({ stats }: { stats: RunStats }) {
+  const ceiling = niceCeiling(stats.peakRps);
+  return (
+    <div className="px-3 pt-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">Requests / s</span>
+        <span className="font-mono text-xs text-muted-foreground">peak {formatRps(stats.peakRps)}</span>
+      </div>
+      <div data-testid="stats-throughput" className="mt-1 flex items-end gap-0.5 rounded border border-border px-1" style={{ height: RPS_HEIGHT }}>
+        {stats.slots.map((slot, index) => (
+          <Stats.Bar key={index} slot={slot} ceiling={ceiling} height={RPS_HEIGHT} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * One slice of throughput, with the share of it that failed in red at the foot. A
+ * failure is a fraction of a bar and would round to nothing on its own, so the
+ * segment has a floor: what it says is "some", and the count is in the table.
+ */
+Stats.Bar = function ({ slot, ceiling, height }: { slot: StatsSlot; ceiling: number; height: number }) {
+  const full = Math.min(1, slot.rps / ceiling) * height;
+  const failed = slot.failures === 0 ? 0 : Math.max(MIN_FAILURE_SEGMENT, (slot.failures / slot.calls) * full);
+  const label = `${slot.calls} ${slot.calls === 1 ? "call" : "calls"} · ${formatRps(slot.rps)} rps${slot.failures > 0 ? ` · ${slot.failures} failed` : ""}`;
+  return (
+    <span className="flex flex-1 flex-col justify-end" style={{ height }} title={label}>
+      <span className="w-full bg-muted" style={{ height: Math.max(0, full - failed) }} />
+      {failed > 0 && <span className="w-full bg-destructive" style={{ height: failed }} />}
+    </span>
+  );
+};
+
+/**
+ * How many calls were in the air, as a step: the number holds until something changes
+ * it. Flatlining at one is the honest reading of a serial loop and explains a low rps
+ * better than the throughput chart does.
+ */
+Stats.InFlight = function ({ stats }: { stats: RunStats }) {
+  const ceiling = Math.max(MIN_IN_FLIGHT_CEILING, stats.maxInFlight);
+  const ticks = timeTicks(stats.spanMs);
+  return (
+    <div className="px-3 pt-3">
+      <span className="text-xs text-muted-foreground">In flight</span>
+      <div data-testid="stats-in-flight" className="relative mt-1 rounded border border-border" style={{ height: IN_FLIGHT_HEIGHT }}>
+        <svg viewBox={`0 0 ${CHART_WIDTH} ${IN_FLIGHT_HEIGHT}`} preserveAspectRatio="none" className="absolute inset-0 h-full w-full" aria-hidden="true">
+          <polyline
+            points={stepPoints(stats.slots, ceiling, IN_FLIGHT_HEIGHT)}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.25}
+            className="text-muted-foreground"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+        <span className="absolute right-1.5 top-1 font-mono text-[9px] text-muted-foreground">max {stats.maxInFlight}</span>
+      </div>
+      {/* The one axis the three charts share, stated once under all of them. */}
+      <div className="relative h-[16px] pt-1 pb-2">
+        {ticks.map((tick) => (
+          <span
+            key={tick.position}
+            className="absolute top-1 font-mono text-[10px] text-muted-foreground"
+            style={tick.position === 0 ? { left: 0 } : tick.position === 1 ? { right: 0 } : { left: `${tick.position * 100}%`, transform: "translateX(-50%)" }}
+          >
+            {tick.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Where the run's calls actually landed, on a log axis — a long tail reads as a tail
+ * rather than as one bar at the far left and nothing else. The percentiles sit on it
+ * as the three lines they are.
+ */
+Stats.Distribution = function ({ stats }: { stats: RunStats }) {
+  if (stats.distribution.length === 0) return null;
+  const tallest = Math.max(...stats.distribution.map((bar) => bar.calls), 1);
+  return (
+    <div className="border-t border-border px-3 pt-2">
+      <span className="text-xs text-muted-foreground">Distribution</span>
+      <div data-testid="stats-distribution" className="relative mt-1 flex items-end gap-0.5" style={{ height: DISTRIBUTION_HEIGHT }}>
+        {stats.distribution.map((bar) => (
+          <span
+            key={bar.position}
+            className="flex-1 bg-muted"
+            style={{ height: `${Math.max(bar.calls > 0 ? 2 : 0, (bar.calls / tallest) * 100)}%` }}
+            title={`${formatMs(bar.fromMs)} – ${formatMs(bar.toMs)} · ${bar.calls.toLocaleString()} ${bar.calls === 1 ? "call" : "calls"}`}
+          />
+        ))}
+        {stats.markers.map((marker) => (
+          <span key={marker.label} className="absolute inset-y-0 border-l border-border" style={{ left: `${marker.position * 100}%` }} />
+        ))}
+      </div>
+      <div className="relative h-[16px] pt-1 pb-2">
+        {stats.markers.map((marker) => (
+          <span
+            key={marker.label}
+            className="absolute top-1 font-mono text-[9px] text-muted-foreground"
+            style={{ left: `${marker.position * 100}%`, transform: marker.position > 0.9 ? "translateX(-100%)" : undefined }}
+            title={formatMs(marker.valueMs)}
+          >
+            {marker.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const COLUMN = "w-[56px] shrink-0 text-right";
+
+/**
+ * The breakdown per method, and the one call worth naming. One method and one row is
+ * fine — the table is where a run with no shape to it earns the page.
+ */
+Stats.Methods = function ({ stats, onSelectCall }: { stats: RunStats; onSelectCall: (itemId: string) => void }) {
+  return (
+    <div className="border-t border-border">
+      <div className="flex h-[22px] items-center gap-2 border-b border-border px-3">
+        <span className="min-w-0 flex-1 text-xs text-muted-foreground">Method</span>
+        {["calls", "err", "p50", "p95", "p99", "max", "rps"].map((column) => (
+          <span key={column} className={cn(COLUMN, "text-xs text-muted-foreground")}>
+            {column}
+          </span>
+        ))}
+      </div>
+      {stats.methods.map((row) => (
+        <Stats.MethodRow key={row.method} row={row} />
+      ))}
+      {stats.slowest && (
+        <div className="flex h-[24px] items-center gap-2 px-3">
+          <span className="shrink-0 text-xs text-muted-foreground">slowest</span>
+          <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+            {[stats.slowest.method, stats.slowest.key, formatMs(stats.slowest.durationMs)].filter(Boolean).join(" · ")}
+          </span>
+          <button type="button" className="ml-auto shrink-0 font-mono text-xs text-primary hover:underline" onClick={() => onSelectCall(stats.slowest!.itemId)}>
+            Open in log
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+Stats.MethodRow = function ({ row }: { row: MethodRow }) {
+  return (
+    <div data-testid="stats-method-row" className="flex h-[24px] items-center gap-2 border-b border-border px-3">
+      <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground" title={row.method}>
+        {row.method}
+      </span>
+      <span className={cn(COLUMN, "font-mono text-xs text-foreground")}>{row.calls.toLocaleString()}</span>
+      <span className={cn(COLUMN, "font-mono text-xs", row.failures > 0 ? "text-destructive" : "text-muted-foreground")}>{row.failures.toLocaleString()}</span>
+      <span className={cn(COLUMN, "font-mono text-xs text-foreground")}>{formatMsBare(row.p50)}</span>
+      <span className={cn(COLUMN, "font-mono text-xs text-foreground")}>{formatMsBare(row.p95)}</span>
+      <span className={cn(COLUMN, "font-mono text-xs text-foreground")}>{formatMsBare(row.p99)}</span>
+      <span className={cn(COLUMN, "font-mono text-xs text-foreground")}>{formatMsBare(row.max)}</span>
+      <span className={cn(COLUMN, "font-mono text-xs text-foreground")}>{formatRps(row.rps)}</span>
+    </div>
+  );
+};

--- a/ui/src/consoles.ts
+++ b/ui/src/consoles.ts
@@ -15,6 +15,7 @@ import {
   RunSelection,
   RunStatus,
 } from "./runs";
+import { RunMetrics } from "./runStats";
 import { RunStrip } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
 
@@ -54,6 +55,7 @@ class Group implements RunGroup {
   readonly drawn: ConsoleItem[] = [];
   readonly stats = new ItemStats();
   readonly strip = new RunStrip();
+  readonly metrics: RunMetrics;
   drew = false;
   dropped = 0;
   // There are a handful in a run at most, so the one it is parked on is found rather
@@ -69,7 +71,9 @@ class Group implements RunGroup {
   #drawnAt = 0;
   readonly #failed = new Map<string, { item: ConsoleItem; seq: number }>();
 
-  constructor(public run: Run) {}
+  constructor(public run: Run) {
+    this.metrics = new RunMetrics(run.startedAt);
+  }
 
   // A script that reports its own — a table with a result column — keeps drawing past
   // them, and the canvas stays quiet.
@@ -119,6 +123,7 @@ class Group implements RunGroup {
     if (item.block !== undefined && isAwaitingUser(item.block)) this.#asked.push(item);
     this.stats.add(item);
     this.strip.add(item);
+    this.metrics.add(item);
     this.#mark(item);
     return true;
   }
@@ -129,6 +134,7 @@ class Group implements RunGroup {
     if (item.block !== undefined && isAwaitingUser(item.block) && !this.#asked.includes(item)) this.#asked.push(item);
     this.stats.add(item);
     this.strip.add(item);
+    this.metrics.add(item);
     this.#mark(item);
   }
 

--- a/ui/src/runStats.test.ts
+++ b/ui/src/runStats.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "bun:test";
+import { MethodCall } from "./kaja";
+import { ConsoleItem } from "./runs";
+import { distributionBars, latencyBucket, latencyBucketFloor, Latencies, RunMetrics } from "./runStats";
+
+const START = 1_700_000_000_000;
+
+function call(
+  id: string,
+  { at = 0, durationMs, method = "ListShows", error, key }: { at?: number; durationMs?: number; method?: string; error?: unknown; key?: string } = {},
+): ConsoleItem {
+  const methodCall = {
+    id,
+    appName: "app",
+    service: { name: "Shows" },
+    method: { name: method },
+    input: {},
+    output: durationMs === undefined ? undefined : {},
+    error,
+    timestamp: START + at,
+    durationMs,
+  } as MethodCall;
+  return { id, runId: "run-1", timestamp: methodCall.timestamp, call: methodCall, key };
+}
+
+// A call as it arrives twice: issued with nothing settled, then again with what it took.
+function issueThenSettle(metrics: RunMetrics, item: ConsoleItem, durationMs: number, error?: unknown): void {
+  metrics.add(item);
+  item.call!.durationMs = durationMs;
+  item.call!.output = {};
+  if (error !== undefined) item.call!.error = error;
+  metrics.add(item);
+}
+
+describe("latency buckets", () => {
+  it("rises with the value and stays inside its own bounds", () => {
+    for (const ms of [0.3, 1, 7, 41, 96, 214, 1_204, 60_000]) {
+      const bucket = latencyBucket(ms);
+      expect(latencyBucketFloor(bucket)).toBeLessThanOrEqual(ms);
+      expect(latencyBucketFloor(bucket + 1)).toBeGreaterThan(ms);
+    }
+  });
+
+  it("puts a zero and a negative duration at the floor rather than off the axis", () => {
+    expect(latencyBucket(0)).toBe(0);
+    expect(latencyBucket(-5)).toBe(0);
+  });
+});
+
+describe("Latencies", () => {
+  it("reports exact percentiles while the values are still kept", () => {
+    const latencies = new Latencies();
+    for (let value = 1; value <= 100; value++) latencies.add(value);
+    expect(latencies.percentile(0.5)).toBe(50);
+    expect(latencies.percentile(0.95)).toBe(95);
+    expect(latencies.percentile(0.99)).toBe(99);
+    expect(latencies.max).toBe(100);
+    expect(latencies.min).toBe(1);
+  });
+
+  it("stays within a bucket's width once it falls back on the histogram", () => {
+    const latencies = new Latencies();
+    for (let index = 0; index < 10_000; index++) latencies.add(1 + (index % 500));
+    const p50 = latencies.percentile(0.5)!;
+    // Nearest-rank over 1..500 repeated puts the median at 250; the histogram may
+    // report any value inside that bucket, and no more.
+    expect(Math.abs(p50 - 250) / 250).toBeLessThan(0.05);
+    expect(latencies.total).toBe(10_000);
+    expect(latencies.max).toBe(500);
+  });
+
+  it("has nothing to say about an empty set", () => {
+    const latencies = new Latencies();
+    expect(latencies.percentile(0.5)).toBeUndefined();
+    expect(latencies.max).toBeUndefined();
+    expect(latencies.mean).toBeUndefined();
+  });
+
+  it("merges two sets into one that reads the same as adding them in order", () => {
+    const merged = new Latencies();
+    const other = new Latencies();
+    for (let value = 1; value <= 50; value++) merged.add(value);
+    for (let value = 51; value <= 100; value++) other.add(value);
+    merged.merge(other);
+    expect(merged.total).toBe(100);
+    expect(merged.percentile(0.5)).toBe(50);
+    expect(merged.max).toBe(100);
+  });
+});
+
+describe("RunMetrics", () => {
+  it("counts a call once however many times it arrives", () => {
+    const metrics = new RunMetrics(START);
+    const item = call("a", { at: 0 });
+    issueThenSettle(metrics, item, 40);
+    metrics.add(item);
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.calls).toBe(1);
+    expect(stats.settled).toBe(1);
+    expect(stats.failures).toBe(0);
+  });
+
+  it("counts a failure once and states it as a rate over the calls", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 8; index++) issueThenSettle(metrics, call(`ok-${index}`, { at: index * 10 }), 10);
+    const failed = call("bad", { at: 90 });
+    issueThenSettle(metrics, failed, 10, { code: "UNAVAILABLE" });
+    metrics.add(failed);
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.calls).toBe(9);
+    expect(stats.failures).toBe(1);
+    expect(stats.errorRate).toBeCloseTo(1 / 9);
+  });
+
+  it("keeps the run's own clock rather than the reach of its calls", () => {
+    const metrics = new RunMetrics(START);
+    issueThenSettle(metrics, call("a", { at: 0 }), 20);
+    // The script slept for the rest of the run, so the calls say 20ms and the run 5s.
+    const stats = metrics.view(20, 16, 5_000);
+    expect(stats.spanMs).toBe(5_000);
+    expect(stats.meanRps).toBeCloseTo(0.2);
+  });
+
+  it("splits a run across slices and gives each its own throughput", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 100; index++) issueThenSettle(metrics, call(`c-${index}`, { at: index * 10 }), 5);
+    const stats = metrics.view(10, 16, 1_000);
+    expect(stats.slots.length).toBeLessThanOrEqual(10);
+    expect(stats.slots.reduce((total, slot) => total + slot.calls, 0)).toBe(100);
+    // A hundred calls over a second, however the slices fall.
+    expect(stats.meanRps).toBeCloseTo(100);
+  });
+
+  it("holds its counts as the buckets double under a long run", () => {
+    const metrics = new RunMetrics(START);
+    // Far past MAX_TIME_BUCKETS at the starting resolution, so the timeline collapses
+    // several times over.
+    for (let index = 0; index < 400; index++) issueThenSettle(metrics, call(`c-${index}`, { at: index * 500 }), 20);
+    const stats = metrics.view(60, 16, 200_000);
+    expect(stats.calls).toBe(400);
+    expect(stats.slots.reduce((total, slot) => total + slot.calls, 0)).toBe(400);
+    expect(stats.slots.length).toBeLessThanOrEqual(60);
+  });
+
+  it("reads concurrency off calls that overlap, and one off a serial loop", () => {
+    const serial = new RunMetrics(START);
+    for (let index = 0; index < 20; index++) issueThenSettle(serial, call(`s-${index}`, { at: index * 100 }), 90);
+    expect(serial.view(20, 16, 2_000).maxInFlight).toBe(1);
+
+    const parallel = new RunMetrics(START);
+    const items = Array.from({ length: 10 }, (unused, index) => call(`p-${index}`, { at: 0 }));
+    for (const item of items) parallel.add(item);
+    expect(parallel.view(20, 16, 1_000).maxInFlight).toBe(10);
+  });
+
+  it("names the slowest call and the value that identifies it", () => {
+    const metrics = new RunMetrics(START);
+    issueThenSettle(metrics, call("a", { at: 0, key: "page 1" }), 40);
+    issueThenSettle(metrics, call("b", { at: 100, key: "vera-lune", method: "GetShow" }), 1_204);
+    issueThenSettle(metrics, call("c", { at: 200, key: "page 3" }), 60);
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.slowest).toMatchObject({ itemId: "b", method: "Shows.GetShow", key: "vera-lune", durationMs: 1_204 });
+  });
+
+  it("breaks the run down per method, busiest first", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 6; index++) issueThenSettle(metrics, call(`l-${index}`, { at: index * 10 }), 31);
+    for (let index = 0; index < 4; index++) issueThenSettle(metrics, call(`g-${index}`, { at: index * 10, method: "GetShow" }), 48);
+    const failed = call("g-bad", { at: 90, method: "GetShow" });
+    issueThenSettle(metrics, failed, 48, { status: 503 });
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.methods.map((row) => row.method)).toEqual(["Shows.ListShows", "Shows.GetShow"]);
+    expect(stats.methods[0]).toMatchObject({ calls: 6, failures: 0, p50: 31, max: 31 });
+    expect(stats.methods[1]).toMatchObject({ calls: 5, failures: 1 });
+  });
+
+  it("says nothing about a run whose calls have not settled", () => {
+    const metrics = new RunMetrics(START);
+    metrics.add(call("a", { at: 0 }));
+    const stats = metrics.view(20, 16, undefined);
+    expect(stats.calls).toBe(1);
+    expect(stats.settled).toBe(0);
+    expect(stats.p50).toBeUndefined();
+    expect(stats.distribution).toEqual([]);
+    expect(stats.markers).toEqual([]);
+  });
+
+  it("uses the upstream duration where one was measured", () => {
+    const metrics = new RunMetrics(START);
+    const item = call("a", { at: 0 });
+    metrics.add(item);
+    item.call!.durationMs = 90;
+    item.call!.upstreamDurationMs = 40;
+    item.call!.output = {};
+    metrics.add(item);
+    expect(metrics.view(20, 16, 1_000).p50).toBe(40);
+  });
+
+  it("bumps its version only for something a chart would draw", () => {
+    const metrics = new RunMetrics(START);
+    const item = call("a", { at: 0 });
+    metrics.add(item);
+    const issued = metrics.version;
+    metrics.add(item);
+    expect(metrics.version).toBe(issued);
+    item.call!.durationMs = 40;
+    metrics.add(item);
+    expect(metrics.version).toBeGreaterThan(issued);
+  });
+});
+
+describe("distributionBars", () => {
+  it("covers every sample and stays inside the room it is given", () => {
+    const latencies = new Latencies();
+    for (const ms of [10, 12, 14, 40, 45, 300, 1_200]) latencies.add(ms);
+    const bars = distributionBars(latencies, 16);
+    expect(bars.length).toBeLessThanOrEqual(16);
+    expect(bars.reduce((total, bar) => total + bar.calls, 0)).toBe(7);
+    expect(bars[0].position).toBe(0);
+    expect(bars[bars.length - 1].position + bars[bars.length - 1].width).toBeCloseTo(1);
+  });
+
+  it("draws one bar for a run whose calls all took the same time", () => {
+    const latencies = new Latencies();
+    for (let index = 0; index < 5; index++) latencies.add(40);
+    const bars = distributionBars(latencies, 16);
+    expect(bars).toHaveLength(1);
+    expect(bars[0].calls).toBe(5);
+  });
+
+  it("has nothing to draw for a run with no calls", () => {
+    expect(distributionBars(new Latencies(), 16)).toEqual([]);
+  });
+});
+
+describe("percentile markers", () => {
+  it("says once where two percentiles landed on the same value", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 12; index++) issueThenSettle(metrics, call(`c-${index}`, { at: index * 10 }), index < 6 ? 40 : 260);
+    const stats = metrics.view(20, 16, 1_000);
+    // Over twelve samples p95 and p99 are the same call, so one label covers both
+    // rather than one being drawn silently under the other.
+    expect(stats.markers.map((marker) => marker.label)).toEqual(["p50", "p95\u00b7p99"]);
+  });
+
+  it("keeps them apart where the run's tail actually separates them", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 200; index++) {
+      const ms = index < 180 ? 30 : index < 195 ? 400 : 3_000;
+      issueThenSettle(metrics, call(`c-${index}`, { at: index * 5 }), ms);
+    }
+    const stats = metrics.view(40, 20, 1_000);
+    expect(stats.markers.map((marker) => marker.label)).toEqual(["p50", "p95", "p99"]);
+    expect(stats.markers[0].position).toBeLessThan(stats.markers[1].position);
+    expect(stats.markers[1].position).toBeLessThan(stats.markers[2].position);
+  });
+});
+
+describe("slicing", () => {
+  it("never slices a run finer than the calls it made", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 20; index++) issueThenSettle(metrics, call(`c-${index}`, { at: index * 50 }), 10);
+    // Eighty slices over twenty calls is a chart that is mostly gaps.
+    expect(metrics.view(80, 16, 1_000).slots.length).toBeLessThanOrEqual(20);
+  });
+
+  it("keeps a floor, so three calls still draw a timeline rather than three columns", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 3; index++) issueThenSettle(metrics, call(`c-${index}`, { at: index * 300 }), 10);
+    expect(metrics.view(80, 16, 1_000).slots.length).toBeGreaterThan(3);
+  });
+});

--- a/ui/src/runStats.ts
+++ b/ui/src/runStats.ts
@@ -1,0 +1,544 @@
+import { callDurationMs } from "./kaja";
+import { ConsoleItem } from "./runs";
+
+/**
+ * What a run's calls add up to: percentiles, throughput and concurrency over the
+ * run's own clock, plus a breakdown per method.
+ *
+ * Everything here is computed from what a call already records — when it was issued,
+ * how long it took, whether it failed — and maintained as the run happens, the same
+ * way the strip is. A perf test run of twenty thousand calls is re-derived per repaint
+ * otherwise, which is the one thing this console refuses to do.
+ */
+
+// Where a bucket starts before the run has a length to size itself against. It
+// doubles from here, so boundaries stay aligned as the run outgrows them.
+const START_BUCKET_MS = 50;
+// Kept at twice what any chart draws, so `view` has something to merge down from and
+// a narrow console does not cost the wide one its resolution.
+const MAX_TIME_BUCKETS = 240;
+/**
+ * Below this many samples the values themselves are kept and the percentiles are
+ * exact. A script making a dozen calls deserves to read its own numbers back, and
+ * `p50 41 ms` from a histogram would be `p50 42 ms` for no reason anyone can see.
+ */
+const EXACT_LIMIT = 256;
+// Fewer than this and the timeline is a handful of marks either way, so the floor
+// costs nothing and keeps a short run's charts the same shape as a long one's.
+const MIN_SLOTS = 8;
+// Closer than this across the distribution's axis and two labels overlap.
+const MARKER_GAP = 0.03;
+
+// Eight buckets per octave: 4.4% at worst between a sample and the value reported for
+// it, which is finer than the pixel it is drawn in.
+const BUCKETS_PER_OCTAVE = 8;
+// The floor, so that log2 of a sub-millisecond call is still an index.
+const MIN_MS = 0.25;
+const INDEX_OFFSET = 2 * BUCKETS_PER_OCTAVE;
+
+/** The histogram bucket a duration falls in. Log-spaced, so the tail costs nothing. */
+export function latencyBucket(ms: number): number {
+  const value = ms > MIN_MS ? ms : MIN_MS;
+  return Math.max(0, Math.floor(Math.log2(value) * BUCKETS_PER_OCTAVE) + INDEX_OFFSET);
+}
+
+/** The lower bound of a bucket — what the axis is labelled with. */
+export function latencyBucketFloor(bucket: number): number {
+  return 2 ** ((bucket - INDEX_OFFSET) / BUCKETS_PER_OCTAVE);
+}
+
+// The geometric middle of a bucket, which is the honest single value to report for
+// everything that landed in it.
+function latencyBucketValue(bucket: number): number {
+  return latencyBucketFloor(bucket) * 2 ** (0.5 / BUCKETS_PER_OCTAVE);
+}
+
+/**
+ * A set of durations, summarised. The log-scale counts are always kept — they are
+ * what the distribution chart draws — and the values themselves as well while there
+ * are few enough for that to be free.
+ */
+export class Latencies {
+  readonly counts = new Map<number, number>();
+  #exact: number[] | null = [];
+  #sorted: number[] | null = null;
+  #total = 0;
+  #sum = 0;
+  #min = Infinity;
+  #max = 0;
+
+  add(ms: number): void {
+    const bucket = latencyBucket(ms);
+    this.counts.set(bucket, (this.counts.get(bucket) ?? 0) + 1);
+    this.#total++;
+    this.#sum += ms;
+    if (ms < this.#min) this.#min = ms;
+    if (ms > this.#max) this.#max = ms;
+    if (this.#exact !== null) {
+      if (this.#exact.length >= EXACT_LIMIT) this.#exact = null;
+      else this.#exact.push(ms);
+    }
+    this.#sorted = null;
+  }
+
+  merge(other: Latencies): void {
+    for (const [bucket, count] of other.counts) this.counts.set(bucket, (this.counts.get(bucket) ?? 0) + count);
+    this.#total += other.#total;
+    this.#sum += other.#sum;
+    if (other.#min < this.#min) this.#min = other.#min;
+    if (other.#max > this.#max) this.#max = other.#max;
+    const exact = other.#exact;
+    if (this.#exact === null || exact === null || this.#exact.length + exact.length > EXACT_LIMIT) this.#exact = null;
+    else this.#exact.push(...exact);
+    this.#sorted = null;
+  }
+
+  get total(): number {
+    return this.#total;
+  }
+
+  get max(): number | undefined {
+    return this.#total === 0 ? undefined : this.#max;
+  }
+
+  get min(): number | undefined {
+    return this.#total === 0 ? undefined : this.#min;
+  }
+
+  get mean(): number | undefined {
+    return this.#total === 0 ? undefined : this.#sum / this.#total;
+  }
+
+  /** Nearest-rank, so every value reported is one a call actually took. */
+  percentile(quantile: number): number | undefined {
+    if (this.#total === 0) return undefined;
+    const rank = Math.min(this.#total, Math.max(1, Math.ceil(quantile * this.#total)));
+    if (this.#exact !== null) {
+      if (this.#sorted === null) this.#sorted = [...this.#exact].sort((a, b) => a - b);
+      return this.#sorted[rank - 1];
+    }
+    let seen = 0;
+    for (const bucket of [...this.counts.keys()].sort((a, b) => a - b)) {
+      seen += this.counts.get(bucket)!;
+      if (seen >= rank) return latencyBucketValue(bucket);
+    }
+    return this.#max;
+  }
+}
+
+/** One slice of the run's clock, as the charts read it. */
+export interface StatsSlot {
+  calls: number;
+  failures: number;
+  // Where the slice starts, in milliseconds from the run's first call.
+  offsetMs: number;
+  widthMs: number;
+  rps: number;
+  p50?: number;
+  p95?: number;
+  p99?: number;
+  // Calls still in the air when the slice ended.
+  inFlight: number;
+}
+
+interface TimeBucket {
+  calls: number;
+  failures: number;
+  latencies: Latencies;
+  // What the number of calls in flight moves by across this bucket: +1 where a call
+  // was issued, −1 where it settled. Prefix-summing gives the concurrency line, and
+  // summing two of them is what makes buckets mergeable.
+  inFlightDelta: number;
+}
+
+function emptyBucket(): TimeBucket {
+  return { calls: 0, failures: 0, latencies: new Latencies(), inFlightDelta: 0 };
+}
+
+interface Seen {
+  startedAt: number;
+  failed: boolean;
+  settled: boolean;
+}
+
+/**
+ * The run's calls over its own clock. A bucket index is derived from a timestamp
+ * rather than remembered, so when the buckets double — pairwise, which halves every
+ * index — a call that settles afterwards still lands where it belongs.
+ */
+class Timeline {
+  #buckets: TimeBucket[] = [];
+  #bucketMs = START_BUCKET_MS;
+  #startedAt: number;
+  #endedAt: number;
+
+  constructor(startedAt: number) {
+    this.#startedAt = startedAt;
+    this.#endedAt = startedAt;
+  }
+
+  get bucketMs(): number {
+    return this.#bucketMs;
+  }
+
+  get spanMs(): number {
+    return this.#endedAt - this.#startedAt;
+  }
+
+  issued(timestamp: number): TimeBucket {
+    const bucket = this.#at(timestamp);
+    bucket.calls++;
+    bucket.inFlightDelta++;
+    return bucket;
+  }
+
+  failed(timestamp: number): void {
+    this.#at(timestamp).failures++;
+  }
+
+  settled(startedAt: number, durationMs: number, reportedMs: number): void {
+    this.#at(startedAt + durationMs).inFlightDelta--;
+    this.#at(startedAt).latencies.add(reportedMs);
+  }
+
+  /**
+   * The slices a chart draws, merged down to the room it has. Merging on the way out
+   * rather than rebuilding is what keeps a resize a pass over at most 240 buckets.
+   */
+  view(slots: number): StatsSlot[] {
+    if (slots <= 0 || this.#buckets.length === 0) return [];
+    const factor = Math.max(1, Math.ceil(this.#buckets.length / slots));
+    const widthMs = this.#bucketMs * factor;
+    const merged: StatsSlot[] = [];
+    let inFlight = 0;
+    for (let index = 0; index < this.#buckets.length; index += factor) {
+      const group = this.#buckets.slice(index, index + factor);
+      const latencies = new Latencies();
+      let calls = 0;
+      let failures = 0;
+      for (const bucket of group) {
+        calls += bucket.calls;
+        failures += bucket.failures;
+        inFlight += bucket.inFlightDelta;
+        latencies.merge(bucket.latencies);
+      }
+      merged.push({
+        calls,
+        failures,
+        offsetMs: (index / factor) * widthMs,
+        widthMs,
+        rps: (calls * 1000) / widthMs,
+        p50: latencies.percentile(0.5),
+        p95: latencies.percentile(0.95),
+        p99: latencies.percentile(0.99),
+        // A delta can leave this below zero only if a call settled before the bucket
+        // its issue landed in, which the clock does not allow.
+        inFlight: Math.max(0, inFlight),
+      });
+    }
+    return merged;
+  }
+
+  /**
+   * The most calls that were ever in the air at once, read at the finest resolution
+   * the timeline still holds. A coarser bucket hides a spike that opened and closed
+   * inside it, so this is a floor rather than a promise.
+   */
+  get peakInFlight(): number {
+    let inFlight = 0;
+    let peak = 0;
+    for (const bucket of this.#buckets) {
+      inFlight += bucket.inFlightDelta;
+      if (inFlight > peak) peak = inFlight;
+    }
+    return peak;
+  }
+
+  #at(timestamp: number): TimeBucket {
+    if (timestamp > this.#endedAt) this.#endedAt = timestamp;
+    let index = this.#index(timestamp);
+    while (index >= MAX_TIME_BUCKETS) {
+      this.#collapse();
+      index = this.#index(timestamp);
+    }
+    while (this.#buckets.length <= index) this.#buckets.push(emptyBucket());
+    return this.#buckets[index];
+  }
+
+  #index(timestamp: number): number {
+    return Math.max(0, Math.floor((timestamp - this.#startedAt) / this.#bucketMs));
+  }
+
+  // Pairs, so a bucket still covers a contiguous stretch of the clock and every index
+  // is exactly halved.
+  #collapse(): void {
+    const collapsed: TimeBucket[] = [];
+    for (let index = 0; index < this.#buckets.length; index += 2) {
+      const first = this.#buckets[index];
+      const second = this.#buckets[index + 1];
+      if (second !== undefined) {
+        first.calls += second.calls;
+        first.failures += second.failures;
+        first.inFlightDelta += second.inFlightDelta;
+        first.latencies.merge(second.latencies);
+      }
+      collapsed.push(first);
+    }
+    this.#buckets = collapsed;
+    this.#bucketMs *= 2;
+  }
+}
+
+/** One method's share of the run, as the table below the charts reads it. */
+export interface MethodRow {
+  method: string;
+  calls: number;
+  failures: number;
+  p50?: number;
+  p95?: number;
+  p99?: number;
+  max?: number;
+  rps: number;
+}
+
+/** The one call worth naming — and the row in the log it opens. */
+export interface SlowestCall {
+  itemId: string;
+  method: string;
+  // The identifying value read off the request, which is what tells two hundred calls
+  // of one method apart.
+  key?: string;
+  durationMs: number;
+}
+
+/** One bar of the distribution chart, over the log-scaled latency axis. */
+export interface DistributionBar {
+  // Where the bar sits across the axis, 0 to 1.
+  position: number;
+  width: number;
+  calls: number;
+  fromMs: number;
+  toMs: number;
+}
+
+export interface RunStats {
+  calls: number;
+  settled: number;
+  failures: number;
+  errorRate: number;
+  meanRps: number;
+  peakRps: number;
+  maxInFlight: number;
+  p50?: number;
+  p95?: number;
+  p99?: number;
+  // The window the charts cover: the run's own wall clock where it has one, else how
+  // far its calls reach.
+  spanMs: number;
+  slots: StatsSlot[];
+  distribution: DistributionBar[];
+  // Where the percentiles fall across the distribution's axis, 0 to 1. Absent while
+  // there is nothing to place them against.
+  markers: { label: string; position: number; valueMs: number }[];
+  methods: MethodRow[];
+  slowest?: SlowestCall;
+}
+
+class MethodTotals {
+  calls = 0;
+  failures = 0;
+  readonly latencies = new Latencies();
+}
+
+/**
+ * A run's statistics, accumulated as its calls arrive. `add` is called again for the
+ * same item when it settles, so everything it counts is guarded by what it has already
+ * seen of that item.
+ */
+export class RunMetrics {
+  // Bumped by anything that changes what a chart would draw, which is what the view
+  // memoises against rather than walking the run to find out.
+  version = 0;
+
+  readonly #timeline: Timeline;
+  readonly #overall = new Latencies();
+  readonly #methods = new Map<string, MethodTotals>();
+  readonly #of = new Map<string, Seen>();
+  #calls = 0;
+  #failures = 0;
+  #slowest: SlowestCall | undefined;
+
+  constructor(startedAt: number) {
+    this.#timeline = new Timeline(startedAt);
+  }
+
+  get calls(): number {
+    return this.#calls;
+  }
+
+  get settled(): number {
+    return this.#overall.total;
+  }
+
+  add(item: ConsoleItem): void {
+    const call = item.call;
+    if (call === undefined) return;
+
+    const method = `${call.service.name}.${call.method.name}`;
+    let seen = this.#of.get(item.id);
+    if (seen === undefined) {
+      seen = { startedAt: item.timestamp, failed: false, settled: false };
+      this.#of.set(item.id, seen);
+      this.#calls++;
+      this.#totals(method).calls++;
+      this.#timeline.issued(item.timestamp);
+      this.version++;
+    }
+
+    if (call.error !== undefined && !seen.failed) {
+      seen.failed = true;
+      this.#failures++;
+      this.#totals(method).failures++;
+      this.#timeline.failed(seen.startedAt);
+      this.version++;
+    }
+
+    if (call.durationMs !== undefined && !seen.settled) {
+      seen.settled = true;
+      // What the rows and bars are drawn against everywhere else: the upstream
+      // exchange where Kaja measured it, the whole round trip where nothing did.
+      const reported = callDurationMs(call) ?? call.durationMs;
+      this.#overall.add(reported);
+      this.#totals(method).latencies.add(reported);
+      this.#timeline.settled(seen.startedAt, call.durationMs, reported);
+      if (this.#slowest === undefined || reported > this.#slowest.durationMs) {
+        this.#slowest = { itemId: item.id, method, key: item.key, durationMs: reported };
+      }
+      this.version++;
+    }
+  }
+
+  /**
+   * Everything the page states, in the room it has. `slots` is how many slices the
+   * timeline is drawn in and `bars` how many the distribution is.
+   */
+  view(slots: number, bars: number, runDurationMs?: number): RunStats {
+    const spanMs = Math.max(runDurationMs ?? 0, this.#timeline.spanMs);
+    // Slicing a run finer than its own calls draws a chart that is mostly gaps and
+    // says nothing the coarser one didn't.
+    const timeline = this.#timeline.view(Math.max(MIN_SLOTS, Math.min(slots, this.#calls)));
+    const methods = [...this.#methods]
+      .map(([method, totals]) => ({
+        method,
+        calls: totals.calls,
+        failures: totals.failures,
+        p50: totals.latencies.percentile(0.5),
+        p95: totals.latencies.percentile(0.95),
+        p99: totals.latencies.percentile(0.99),
+        max: totals.latencies.max,
+        rps: spanMs > 0 ? (totals.calls * 1000) / spanMs : 0,
+      }))
+      .sort((a, b) => b.calls - a.calls || a.method.localeCompare(b.method));
+
+    const distribution = distributionBars(this.#overall, bars);
+    const percentiles: [string, number | undefined][] = [
+      ["p50", this.#overall.percentile(0.5)],
+      ["p95", this.#overall.percentile(0.95)],
+      ["p99", this.#overall.percentile(0.99)],
+    ];
+
+    return {
+      calls: this.#calls,
+      settled: this.#overall.total,
+      failures: this.#failures,
+      errorRate: this.#calls === 0 ? 0 : this.#failures / this.#calls,
+      meanRps: spanMs > 0 ? (this.#calls * 1000) / spanMs : 0,
+      peakRps: timeline.reduce((peak, slot) => Math.max(peak, slot.rps), 0),
+      maxInFlight: this.#timeline.peakInFlight,
+      p50: percentiles[0][1],
+      p95: percentiles[1][1],
+      p99: percentiles[2][1],
+      spanMs,
+      slots: timeline,
+      distribution,
+      markers: mergeMarkers(
+        percentiles
+          .filter((entry): entry is [string, number] => entry[1] !== undefined)
+          .map(([label, valueMs]) => ({ label, valueMs, position: distributionPosition(this.#overall, valueMs) })),
+      ),
+      methods,
+      slowest: this.#slowest,
+    };
+  }
+
+  #totals(method: string): MethodTotals {
+    let totals = this.#methods.get(method);
+    if (totals === undefined) {
+      totals = new MethodTotals();
+      this.#methods.set(method, totals);
+    }
+    return totals;
+  }
+}
+
+// The occupied stretch of the latency axis, which is what both the bars and the
+// percentile markers are laid out across. One bucket wide is still a range.
+function occupied(latencies: Latencies): { from: number; to: number } | undefined {
+  if (latencies.total === 0) return undefined;
+  const buckets = [...latencies.counts.keys()];
+  return { from: Math.min(...buckets), to: Math.max(...buckets) + 1 };
+}
+
+/**
+ * The distribution, binned down to the bars there is room for. The axis is the
+ * histogram's own log scale, which is why a long tail reads as a tail rather than as
+ * one bar at the far left and nothing else.
+ */
+export function distributionBars(latencies: Latencies, bars: number): DistributionBar[] {
+  const range = occupied(latencies);
+  if (range === undefined || bars <= 0) return [];
+  const span = range.to - range.from;
+  const perBar = Math.max(1, Math.ceil(span / bars));
+  const count = Math.ceil(span / perBar);
+  const result: DistributionBar[] = [];
+  for (let index = 0; index < count; index++) {
+    const from = range.from + index * perBar;
+    const to = Math.min(range.to, from + perBar);
+    let calls = 0;
+    for (let bucket = from; bucket < to; bucket++) calls += latencies.counts.get(bucket) ?? 0;
+    result.push({
+      position: index / count,
+      width: 1 / count,
+      calls,
+      fromMs: latencyBucketFloor(from),
+      toMs: latencyBucketFloor(to),
+    });
+  }
+  return result;
+}
+
+/** Where a duration falls across the distribution's axis, 0 to 1. */
+export function distributionPosition(latencies: Latencies, ms: number): number {
+  const range = occupied(latencies);
+  if (range === undefined || range.to <= range.from) return 0;
+  const at = Math.log2(Math.max(ms, MIN_MS)) * BUCKETS_PER_OCTAVE + INDEX_OFFSET;
+  return Math.min(1, Math.max(0, (at - range.from) / (range.to - range.from)));
+}
+
+/**
+ * Percentile markers that landed on the same place, said once. Two of them a pixel
+ * apart draw one label over the other, so the lower is silently the one you cannot
+ * read — `p95·p99` is what the axis actually has to say.
+ */
+function mergeMarkers(markers: { label: string; position: number; valueMs: number }[]): { label: string; position: number; valueMs: number }[] {
+  const merged: { label: string; position: number; valueMs: number }[] = [];
+  for (const marker of markers) {
+    const last = merged[merged.length - 1];
+    if (last !== undefined && Math.abs(marker.position - last.position) < MARKER_GAP) {
+      merged[merged.length - 1] = { label: `${last.label}\u00b7${marker.label}`, position: last.position, valueMs: Math.max(last.valueMs, marker.valueMs) };
+      continue;
+    }
+    merged.push(marker);
+  }
+  return merged;
+}

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -2,6 +2,7 @@ import { Block, blockLabel, isAwaitingUser } from "./blocks";
 import { callDurationMs, isCallInFlight, MethodCall } from "./kaja";
 // Type only: the strip is maintained in runStrip, which reads its items from here.
 // Importing the value would close the circle.
+import type { RunMetrics } from "./runStats";
 import type { RunStrip } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
 
@@ -60,7 +61,12 @@ export type RunStatus = "pending" | "streaming" | "success" | "error";
 // Remembered per file along with the selection.
 export type ConsoleTab = "request" | "response" | "headers";
 
-export type ConsoleView = "calls" | "canvas";
+/**
+ * The three readings of one run: every call in wall order, what the script drew, and
+ * what the calls add up to. Stats is always there — a run has statistics whether or
+ * not it was shaped as a test.
+ */
+export type ConsoleView = "calls" | "canvas" | "stats";
 
 /**
  * How much of what the script printed the calls view mixes in. A floor rather than
@@ -100,6 +106,9 @@ export interface RunGroup {
   // A call is not a block and is not in here — the strip is where the run's calls are.
   drawn: ConsoleItem[];
   strip: RunStrip;
+  // What the Stats view reads. Accumulated as the run happens for the same reason the
+  // strip is: a perf test's twenty thousand calls are not re-walked per repaint.
+  metrics: RunMetrics;
   // The only kind of failure the canvas interrupts itself for.
   unreported: FailureNotice[];
   stats: ItemStats;

--- a/ui/src/statsChart.test.ts
+++ b/ui/src/statsChart.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { StatsSlot } from "./runStats";
+import {
+  bandPoints,
+  barsFor,
+  CHART_WIDTH,
+  failurePositions,
+  formatErrorRate,
+  formatMs,
+  formatRps,
+  linePoints,
+  niceCeiling,
+  slotsFor,
+  stepPoints,
+  timeTicks,
+} from "./statsChart";
+
+function slot(changes: Partial<StatsSlot> = {}): StatsSlot {
+  return { calls: 1, failures: 0, offsetMs: 0, widthMs: 100, rps: 10, inFlight: 1, ...changes };
+}
+
+function pairs(points: string): [number, number][] {
+  return points.split(" ").map((point) => point.split(",").map(Number) as [number, number]);
+}
+
+describe("niceCeiling", () => {
+  it("rounds up to a number a reader recognises", () => {
+    expect(niceCeiling(0.9)).toBe(1);
+    expect(niceCeiling(38)).toBe(40);
+    expect(niceCeiling(124)).toBe(150);
+    expect(niceCeiling(311)).toBe(400);
+    expect(niceCeiling(1_204)).toBe(1_500);
+  });
+
+  it("never hands back a zero to divide by", () => {
+    expect(niceCeiling(0)).toBe(1);
+    expect(niceCeiling(-4)).toBe(1);
+  });
+});
+
+describe("linePoints", () => {
+  it("spans the chart and puts the ceiling at the top", () => {
+    const slots = [slot({ p50: 0 }), slot({ p50: 50 }), slot({ p50: 100 })];
+    const points = pairs(linePoints(slots, (each) => each.p50, 100, 100));
+    expect(points[0]).toEqual([0, 100]);
+    expect(points[2]).toEqual([CHART_WIDTH, 0]);
+    expect(points[1]).toEqual([CHART_WIDTH / 2, 50]);
+  });
+
+  it("leaves out a slice nothing has settled in rather than drawing it at zero", () => {
+    const slots = [slot({ p50: 40 }), slot({ p50: undefined }), slot({ p50: 60 })];
+    expect(pairs(linePoints(slots, (each) => each.p50, 100, 100))).toHaveLength(2);
+  });
+
+  it("clamps a value past the ceiling to the top of the box", () => {
+    const points = pairs(linePoints([slot({ p50: 500 }), slot({ p50: 500 })], (each) => each.p50, 100, 100));
+    expect(points.every(([, at]) => at === 0)).toBe(true);
+  });
+});
+
+describe("bandPoints", () => {
+  it("runs out along the lower series and back along the upper", () => {
+    const slots = [slot({ p50: 20, p95: 80 }), slot({ p50: 40, p95: 60 })];
+    const points = pairs(
+      bandPoints(
+        slots,
+        (each) => each.p50,
+        (each) => each.p95,
+        100,
+        100,
+      ),
+    );
+    expect(points).toHaveLength(4);
+    expect(points[0]).toEqual([0, 80]);
+    expect(points[1]).toEqual([CHART_WIDTH, 60]);
+    expect(points[2]).toEqual([CHART_WIDTH, 40]);
+    expect(points[3]).toEqual([0, 20]);
+  });
+
+  it("draws nothing where there is not a second point to close against", () => {
+    expect(
+      bandPoints(
+        [slot({ p50: 20, p95: 80 })],
+        (each) => each.p50,
+        (each) => each.p95,
+        100,
+        100,
+      ),
+    ).toBe("");
+    expect(
+      bandPoints(
+        [slot({ p50: 20 }), slot({ p50: 40 })],
+        (each) => each.p50,
+        (each) => each.p95,
+        100,
+        100,
+      ),
+    ).toBe("");
+  });
+});
+
+describe("stepPoints", () => {
+  it("holds a level until something changes it", () => {
+    const points = pairs(stepPoints([slot({ inFlight: 2 }), slot({ inFlight: 6 })], 10, 100));
+    expect(points).toEqual([
+      [0, 80],
+      [CHART_WIDTH, 80],
+      [CHART_WIDTH, 40],
+    ]);
+  });
+});
+
+describe("failurePositions", () => {
+  it("marks only the slices that failed, where they fall on the clock", () => {
+    const marks = failurePositions([slot(), slot({ failures: 2 }), slot(), slot({ failures: 1 })]);
+    expect(marks).toEqual([
+      { position: 1 / 3, failures: 2 },
+      { position: 1, failures: 1 },
+    ]);
+  });
+});
+
+describe("timeTicks", () => {
+  it("ends on the run's own length rather than a round number past it", () => {
+    const ticks = timeTicks(41_600);
+    expect(ticks[0].label).toBe("0 s");
+    expect(ticks[ticks.length - 1]).toEqual({ label: "41.6 s", position: 1 });
+    expect(ticks.length).toBeLessThanOrEqual(6);
+  });
+
+  it("keeps its steps round and inside the run", () => {
+    const ticks = timeTicks(18_200);
+    expect(ticks.map((tick) => tick.label)).toEqual(["0 s", "5 s", "10 s", "15 s", "18.2 s"]);
+    expect(ticks.every((tick) => tick.position >= 0 && tick.position <= 1)).toBe(true);
+  });
+
+  it("scales down to a run that took a moment", () => {
+    expect(timeTicks(400).map((tick) => tick.label)).toEqual(["0 s", "0.1 s", "0.2 s", "0.3 s", "0.4 s"]);
+  });
+
+  it("has no axis to draw for a run with no length", () => {
+    expect(timeTicks(0)).toEqual([]);
+  });
+});
+
+describe("formatting", () => {
+  it("states a latency in the unit that fits it", () => {
+    expect(formatMs(41)).toBe("41 ms");
+    expect(formatMs(41.4)).toBe("41 ms");
+    expect(formatMs(1_204)).toBe("1.20 s");
+    expect(formatMs(41_600)).toBe("41.6 s");
+    expect(formatMs(undefined)).toBe("—");
+  });
+
+  it("keeps a throughput readable at both ends", () => {
+    expect(formatRps(0)).toBe("0");
+    expect(formatRps(2.64)).toBe("2.6");
+    expect(formatRps(240.4)).toBe("240");
+    expect(formatRps(1_204)).toBe("1,204");
+  });
+
+  it("never rounds a run that failed down to zero", () => {
+    expect(formatErrorRate(0, 0)).toBe("0%");
+    expect(formatErrorRate(0.004, 40)).toBe("0.4%");
+    expect(formatErrorRate(0.00002, 1)).toBe("<0.1%");
+    expect(formatErrorRate(0.5, 5)).toBe("50%");
+  });
+});
+
+describe("slotsFor and barsFor", () => {
+  it("give a narrow console fewer slices rather than thinner ones", () => {
+    expect(slotsFor(300)).toBeLessThan(slotsFor(900));
+    expect(barsFor(300)).toBeLessThan(barsFor(900));
+  });
+
+  it("stay inside their bounds however much or little room there is", () => {
+    expect(slotsFor(40)).toBe(8);
+    expect(slotsFor(4_000)).toBe(80);
+    expect(barsFor(4_000)).toBe(28);
+    expect(slotsFor(0)).toBe(0);
+    expect(barsFor(0)).toBe(0);
+  });
+});

--- a/ui/src/statsChart.ts
+++ b/ui/src/statsChart.ts
@@ -1,0 +1,163 @@
+import { StatsSlot } from "./runStats";
+
+/**
+ * The arithmetic behind the Stats charts. Every one of them is a linear scale into a
+ * fixed box — there is no axis to negotiate and no curve to fit — so the drawing is
+ * plain SVG in the view and the numbers are here, where they can be tested.
+ */
+
+// The charts are drawn in these units and stretched to whatever width the console
+// has (`preserveAspectRatio="none"`), so a resize costs no re-render.
+export const CHART_WIDTH = 600;
+
+/** The y axis, rounded up to a number a reader recognises. */
+export function niceCeiling(max: number): number {
+  if (!(max > 0)) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(max));
+  for (const step of [1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10]) {
+    if (max <= step * magnitude) return step * magnitude;
+  }
+  return 10 * magnitude;
+}
+
+function x(index: number, count: number): number {
+  return count <= 1 ? 0 : (index / (count - 1)) * CHART_WIDTH;
+}
+
+function y(value: number, ceiling: number, height: number): number {
+  return height - Math.min(1, Math.max(0, value / ceiling)) * height;
+}
+
+type Series = (slot: StatsSlot) => number | undefined;
+
+/**
+ * A polyline through one series, skipping the slices that have nothing to say. A
+ * slice where no call has settled yet is a gap in the measurement, and joining across
+ * it would draw a value nothing measured.
+ */
+export function linePoints(slots: StatsSlot[], series: Series, ceiling: number, height: number): string {
+  const points: string[] = [];
+  slots.forEach((slot, index) => {
+    const value = series(slot);
+    if (value === undefined) return;
+    points.push(`${x(index, slots.length).toFixed(1)},${y(value, ceiling, height).toFixed(1)}`);
+  });
+  return points.join(" ");
+}
+
+/**
+ * The polygon between two series: forward along the lower one, back along the upper.
+ * Only the slices where both are known are in it, so the band ends where the
+ * measurement does rather than collapsing to the floor.
+ */
+export function bandPoints(slots: StatsSlot[], lower: Series, upper: Series, ceiling: number, height: number): string {
+  const forward: string[] = [];
+  const backward: string[] = [];
+  slots.forEach((slot, index) => {
+    const low = lower(slot);
+    const high = upper(slot);
+    if (low === undefined || high === undefined) return;
+    const at = x(index, slots.length).toFixed(1);
+    forward.push(`${at},${y(low, ceiling, height).toFixed(1)}`);
+    backward.unshift(`${at},${y(high, ceiling, height).toFixed(1)}`);
+  });
+  return forward.length < 2 ? "" : [...forward, ...backward].join(" ");
+}
+
+/**
+ * The concurrency line, drawn as a step: the number of calls in the air holds until
+ * something changes it, and a slope between two slices would claim it drifted.
+ */
+export function stepPoints(slots: StatsSlot[], ceiling: number, height: number): string {
+  const points: string[] = [];
+  let previous: number | undefined;
+  slots.forEach((slot, index) => {
+    const at = x(index, slots.length).toFixed(1);
+    const level = y(slot.inFlight, ceiling, height);
+    if (previous !== undefined) points.push(`${at},${previous.toFixed(1)}`);
+    points.push(`${at},${level.toFixed(1)}`);
+    previous = level;
+  });
+  return points.join(" ");
+}
+
+/** Where a failure sits along the run's clock, 0 to 1 — the marks on the chart floor. */
+export function failurePositions(slots: StatsSlot[]): { position: number; failures: number }[] {
+  return slots
+    .map((slot, index) => ({ position: slots.length <= 1 ? 0 : index / (slots.length - 1), failures: slot.failures }))
+    .filter((mark) => mark.failures > 0);
+}
+
+const TICK_STEPS_MS = [100, 250, 500, 1_000, 2_000, 5_000, 10_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000, 1_800_000, 3_600_000];
+
+/**
+ * The labels under the timeline. Round steps up to the run's own length, which is
+ * stated exactly — a run is 41.6 s and rounding that to 40 makes the axis disagree
+ * with the tile above it.
+ */
+export function timeTicks(spanMs: number): { label: string; position: number }[] {
+  if (!(spanMs > 0)) return [];
+  const step = TICK_STEPS_MS.find((candidate) => spanMs / candidate <= 5) ?? TICK_STEPS_MS[TICK_STEPS_MS.length - 1];
+  const ticks: { label: string; position: number }[] = [];
+  for (let at = 0; at < spanMs; at += step) {
+    // The last round tick is dropped when the run's own length would land on top of it.
+    if ((spanMs - at) / spanMs < 0.08) break;
+    ticks.push({ label: formatSeconds(at), position: at / spanMs });
+  }
+  ticks.push({ label: formatSeconds(spanMs), position: 1 });
+  return ticks;
+}
+
+function formatSeconds(ms: number): string {
+  const seconds = ms / 1000;
+  if (seconds === 0) return "0 s";
+  if (seconds < 1) return `${seconds.toFixed(1)} s`;
+  if (seconds < 100) return `${Number(seconds.toFixed(1))} s`;
+  return `${Math.round(seconds)} s`;
+}
+
+/** A latency, as the tiles and table state it: whole milliseconds, seconds past a second. */
+export function formatMs(ms: number | undefined): string {
+  if (ms === undefined) return "—";
+  if (ms < 1000) return `${Math.round(ms).toLocaleString()} ms`;
+  return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)} s`;
+}
+
+/** The same value in a column that already says what it is, so without the unit. */
+export function formatMsBare(ms: number | undefined): string {
+  return ms === undefined ? "—" : Math.round(ms).toLocaleString();
+}
+
+export function formatRps(rps: number): string {
+  if (rps === 0) return "0";
+  if (rps < 10) return rps.toFixed(1);
+  return Math.round(rps).toLocaleString();
+}
+
+/**
+ * An error rate reads as zero only when nothing failed. Anything that did failed, and
+ * `0.0%` over four thousand calls with forty failures in them is the one thing this
+ * number must never say.
+ */
+export function formatErrorRate(rate: number, failures: number): string {
+  if (failures === 0) return "0%";
+  const percent = rate * 100;
+  if (percent < 0.1) return "<0.1%";
+  return `${Number(percent.toFixed(percent < 10 ? 1 : 0))}%`;
+}
+
+/**
+ * How many slices the timeline is drawn in, from the room it has. All three charts
+ * take the same count — one axis is the whole point of stacking them, so a slice has
+ * to mean the same thing in each.
+ */
+export function slotsFor(width: number): number {
+  if (width <= 0) return 0;
+  return Math.min(80, Math.max(8, Math.floor(width / 14)));
+}
+
+/** The same question for the distribution, which is read across rather than along. */
+export function barsFor(width: number): number {
+  if (width <= 0) return 0;
+  return Math.min(28, Math.max(6, Math.floor(width / 26)));
+}


### PR DESCRIPTION
Added a Stats segment to the run console — tiles, latency bands, throughput, concurrency, distribution and a per-method table, all derived from what a call already records. Plain SVG and no charting dependency; phases and the errors table are the perf-test half.