### PR TITLE
Added kaja.perfTest and the phase bands it draws

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,9 +260,24 @@ The **log** is the flat audit log — one row per call, in wall order, always co
 - **Percentiles are exact while the values are few and a log histogram once they are many** (`Latencies`, `EXACT_LIMIT`). A script making a dozen calls reads its own numbers back; a perf test gets 4.4%-at-worst accuracy in bounded memory, and the histogram *is* the distribution chart.
 - **Time buckets double rather than being sized in advance** — a run has no length while it is running. A bucket index is derived from a timestamp rather than remembered, so the pairwise collapse that halves every index leaves a call that settles afterwards landing where it belongs. **Concurrency rides on the same buckets as a delta** (+1 issued, −1 settled): summing two deltas is what makes them mergeable, and prefix-summing is the line.
 - **A slice is never finer than the calls it holds.** Eighty slices over fourteen calls is a chart that is mostly gaps.
+- **A schedule is the only perf-test-specific ink on the page** (`Run.perf`, drawn by `Stats.PhaseBands`). Bands behind all three charts so they read as one ruler, named only in the tall one; the plateau gets no tint, because the bands exist to show where the schedule was doing something other than holding still. A plain run has none and loses nothing else.
+- **The percentiles are of the calls that succeeded outside the warm-up**, and the tile strip's trailing cell says what that left out (`excl. 50 warm-up · 40 failed`). A failed call's latency is how long it took to be refused; a warm-up call measured a cold server. Both are counted in requests, throughput, concurrency and the error rate — the exclusion is from the latency alone, and it is stated rather than silently applied.
 - **Failures say the same thing three times**: red marks on the chart floor, a red segment at the foot of the rps bar, a red count in the method table. The segment has a floor, because one failure in three hundred calls rounds to nothing and still has to be visible.
 - **The tile strip is the only thing pinned**; the charts, distribution and table scroll under it as one column, so a console at 300px is the same page as one dragged open. Its trailing empty cell is where a schedule states what it excluded.
 - **Two degenerate cases are stated rather than drawn.** One call has a duration and an outcome, so the tiles collapse to those two and the table is the rest. Zero calls is one line of muted text — not an empty dashboard with six dashes in it.
+
+### The run a script asks for
+
+`kaja.perfTest(body, options)` runs a body over and over on a schedule (`perfTest.ts`). **The body is one iteration**: `concurrency` virtual users each run it in a loop, and every call inside it is sampled. It is what makes a run *shaped* for the Stats page — and the page is a view over any run, so the two halves stay independent.
+
+- **The budget is `iterations` or `duration`, never both**, and `duration` is the whole test with its ramps inside it. `rampDown` needs `duration`: with iterations the test ends when the last one does, which is nothing to ramp down from.
+- **A numeric `warmup` is iterations and a string is time** — the unit a warm-up is naturally said in depends on what is being primed. Either way it resolves to one boundary in time, which is the whole of what the stats are told.
+- **A warm-up whose end is not known yet holds its samples** (`RunMetrics.declareWarmup`), because a sample counted under the wrong phase cannot be taken back out of a histogram. It runs at one virtual user, so no call issued after the boundary started before it. A test stopped inside its own warm-up excludes nothing.
+- **A failed call fails the iteration, not the test.** It runs to the end and the failures are the data. A body that throws is counted the same way and reported as `failedIterations`, which is not the same number as a failed call.
+- **The report is the same computation the page is** — `perfTest` feeds a `RunMetrics` from the same funnel every call already passes through (`KajaInternal.watchers`), so a script's own assertion and the Stats page can never disagree.
+- **Asks and approvals throw inside the body.** Ten virtual users parked on one question is a deadlock wearing a dialog, so the verb refuses and names where the value should have come from — before the test, or `kaja.input`.
+- **The plan is made once and never chases the run.** A schedule that adjusted to the observed rate would report the server's behaviour as if it were the test's.
+- **A perf run opens on its stats** (`defaultView`), outranking the canvas it drew on: the block it leaves there is a headline and a way to the page the charts are on, not a second copy of them.
 
 ### The console belongs to the file
 
@@ -302,7 +317,7 @@ The **log** is the flat audit log — one row per call, in wall order, always co
 
 ## The canvas is what a run drew
 
-**A script says what it made, never how it looks.** The block set is closed and tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask*`, `kaja.approve` — and that is the guard, not a starting point: the moment a script can paint pixels the console is a rendering engine. There is no `kaja.html`, no styling arguments, no layout control. Blocks stack in emission order; free 2D positioning would turn this into a quarter of work.
+**A script says what it made, never how it looks.** The block set is closed and tiny (`blocks.ts`) — `kaja.text`, `kaja.code`, `kaja.table`, `kaja.ask*`, `kaja.approve`, `kaja.perfTest` — and that is the guard, not a starting point: the moment a script can paint pixels the console is a rendering engine. There is no `kaja.html`, no styling arguments, no layout control. Blocks stack in emission order; free 2D positioning would turn this into a quarter of work.
 
 - **A table is a handle, because a loop is why tables exist here.** `kaja.table` returns something with `.row(...)`, and rows land one at a time so the canvas repaints as the loop runs. Blocks are recorded against their own id (`recordBlock`), so a block that fills in stays where it was emitted.
 - **A row is a handle too**, with one verb: `.update(...cells)`, taking the same cells in the same order — a row is declared when its work starts and rewritten when it finishes. The block is unchanged by any of it: `rows` is `string[][]` and an update is the same wholesale re-emit an append is. **A row is as wide as the table** (`padCells`): fewer cells draws blanks, and `.column(name)` widens rows already drawn along with the header. Extra cells are left alone. Renaming a column, removing a row and flashing a changed cell are all **out**. A handle into a table filled from a **source** goes quiet rather than throwing, since a restart makes it point at a row nobody is asking about.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -460,6 +460,7 @@ export function App() {
           logScriptLine(logFileLevel(level), message);
           consoles.recordPrinted(run.fileId, run.id, level, message, Date.now());
         },
+        onPerfSchedule: (schedule) => consoles.recordPerfSchedule(run.fileId, run.id, schedule, Date.now()),
         // Blocks arrive more than once — a table paints row by row — so they are recorded
         // against their own id rather than appended.
         onBlockUpdate: (blockId: string, block: Block) => {

--- a/ui/src/Canvas.tsx
+++ b/ui/src/Canvas.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, ChevronDown, ChevronLeft, ChevronRight, CircleCheck, CircleX, RotateCw, Search, ShieldQuestionMark, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { answerPlaceholder, answerProblem, AskAnswerType, normalizeAnswer } from "./ask";
-import { ApproveBlock, ApproveGesture, AskBlock, Block, CellStatus, cellStatus, CodeBlock, TableBlock, TextBlock } from "./blocks";
+import { ApproveBlock, ApproveGesture, AskBlock, Block, CellStatus, cellStatus, CodeBlock, PerfBlock, TableBlock, TextBlock } from "./blocks";
 import { formatBytes, formatDuration } from "./callFormat";
 import { cn } from "./cn";
 import { Button } from "./components/button";
@@ -23,6 +23,8 @@ import {
 } from "./tableView";
 import { ConsoleItem, FailureNotice, RunGroup } from "./runs";
 import { barHeight, BAR_MAX_HEIGHT, slotsFor, SLOT_WIDTH, StripSlot, TICK_HEIGHT, TICK_WIDTH } from "./runStrip";
+import { exclusionNote, StatTiles, TileCell } from "./Stats";
+import { formatErrorRate, formatMs, formatRps } from "./statsChart";
 import { Log, LogLevel } from "./server/api";
 
 // What the counts and the label at the end of the strip need before the marks get
@@ -51,6 +53,9 @@ interface CanvasProps {
   onDecide: (blockId: string, gesture: ApproveGesture) => void;
   onSelectCall: (itemId: string) => void;
   onFullScreen?: () => void;
+  // Handed down to a perf block, which is a headline and the way to the page
+  // its charts are on.
+  onOpenStats?: () => void;
   // Carried across entering and leaving full-screen, so the way back lands where you
   // left rather than at the top.
   scrollRef?: React.MutableRefObject<number>;
@@ -74,6 +79,7 @@ export function Canvas({
   onDecide,
   onSelectCall,
   onFullScreen,
+  onOpenStats,
   scrollRef,
   tableViews,
   onTableView,
@@ -129,6 +135,7 @@ export function Canvas({
             onCancelAsk={onCancelAsk}
             onDecide={onDecide}
             onFullScreen={onFullScreen}
+            onOpenStats={onOpenStats}
             tableViews={tableViews}
             onTableView={onTableView}
             onTablePull={onTablePull}
@@ -231,13 +238,27 @@ interface EntryProps {
   onCancelAsk: (blockId: string) => void;
   onDecide: (blockId: string, gesture: ApproveGesture) => void;
   onFullScreen?: () => void;
+  // The perf block's way to the page its charts are on.
+  onOpenStats?: () => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
   onTableCells: (blockId: string, cells: CellRef[]) => void;
 }
 
-Canvas.Entry = function ({ item, fullScreen, onAnswer, onCancelAsk, onDecide, onFullScreen, tableViews, onTableView, onTablePull, onTableCells }: EntryProps) {
+Canvas.Entry = function ({
+  item,
+  fullScreen,
+  onAnswer,
+  onCancelAsk,
+  onDecide,
+  onFullScreen,
+  onOpenStats,
+  tableViews,
+  onTableView,
+  onTablePull,
+  onTableCells,
+}: EntryProps) {
   if (item.logs) return <Canvas.Logs logs={item.logs} />;
   if (!item.block) return null;
   return (
@@ -249,6 +270,7 @@ Canvas.Entry = function ({ item, fullScreen, onAnswer, onCancelAsk, onDecide, on
       onCancelAsk={onCancelAsk}
       onDecide={onDecide}
       onFullScreen={onFullScreen}
+      onOpenStats={onOpenStats}
       tableViews={tableViews}
       onTableView={onTableView}
       onTablePull={onTablePull}
@@ -265,6 +287,8 @@ interface BlockProps {
   onCancelAsk: (blockId: string) => void;
   onDecide: (blockId: string, gesture: ApproveGesture) => void;
   onFullScreen?: () => void;
+  // The perf block's way to the page its charts are on.
+  onOpenStats?: () => void;
   tableViews: { [blockId: string]: TableView };
   onTableView: (blockId: string, view: TableView) => void;
   onTablePull: (blockId: string, search: string, want: number) => void;
@@ -279,6 +303,7 @@ Canvas.Block = function ({
   onCancelAsk,
   onDecide,
   onFullScreen,
+  onOpenStats,
   tableViews,
   onTableView,
   onTablePull,
@@ -295,7 +320,48 @@ Canvas.Block = function ({
       return <Canvas.Ask id={id} block={block} onAnswer={onAnswer} onCancelAsk={onCancelAsk} />;
     case "approve":
       return <Canvas.Approve id={id} block={block} fullScreen={fullScreen} onDecide={onDecide} onFullScreen={onFullScreen} />;
+    case "perf":
+      return <Canvas.Perf block={block} onOpenStats={onOpenStats} />;
   }
+};
+
+/**
+ * What a perf test leaves on the canvas: the headline, and the way to the rest of it.
+ * A test that ran for a minute has to show for itself here — a presented run has no
+ * other surface — but the charts belong on the page built for them, so this is the
+ * tile strip and a link rather than a second copy of it.
+ */
+Canvas.Perf = function ({ block, onOpenStats }: { block: PerfBlock; onOpenStats?: () => void }) {
+  const cells: TileCell[] = [
+    { label: "requests", value: block.requests.toLocaleString() },
+    {
+      label: "error rate",
+      value: formatErrorRate(block.errorRate, block.failures),
+      className: block.failures > 0 ? "text-destructive" : "text-emerald-600 dark:text-emerald-400",
+    },
+    { label: "mean rps", value: formatRps(block.meanRps) },
+    { label: "p50", value: formatMs(block.p50) },
+    { label: "p95", value: formatMs(block.p95) },
+    { label: "p99", value: formatMs(block.p99) },
+  ];
+  return (
+    <div data-testid="canvas-perf" className="overflow-hidden rounded-lg border border-border">
+      <div className="flex h-[28px] items-center gap-2 border-b border-border bg-card px-3">
+        {block.running && <Spinner className="h-3 w-3 shrink-0" />}
+        <span className="shrink-0 text-xs text-muted-foreground">perf test</span>
+        <span className="min-w-0 truncate font-mono text-xs text-foreground">{block.schedule}</span>
+        {block.durationMs !== undefined && (
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">{formatDuration(Math.round(block.durationMs))}</span>
+        )}
+        {onOpenStats && (
+          <button type="button" className="ml-auto shrink-0 font-mono text-xs text-primary hover:underline" onClick={onOpenStats}>
+            Open stats
+          </button>
+        )}
+      </div>
+      <StatTiles cells={cells} note={exclusionNote({ excludedWarmup: block.excludedWarmup ?? 0, excludedFailures: block.excludedFailures ?? 0 })} />
+    </div>
+  );
 };
 
 // Prose is measured rather than left to the container: a table wants the whole

--- a/ui/src/Console.tsx
+++ b/ui/src/Console.tsx
@@ -12,7 +12,7 @@ import { Spinner } from "./components/spinner";
 import { consoles } from "./consoles";
 import { JsonViewerHandle } from "./JsonViewer";
 import { RunLog } from "./RunLog";
-import { Stats } from "./Stats";
+import { scheduleNote, Stats } from "./Stats";
 import {
   callRows,
   ConsoleItem,
@@ -307,6 +307,7 @@ export function Console({
       onDecide={onDecide}
       onSelectCall={selectFromCanvas}
       onFullScreen={enterFullScreen}
+      onOpenStats={() => onViewChange("stats")}
       scrollRef={canvasScroll}
       tableViews={tableViews}
       onTableView={onTableView}
@@ -382,6 +383,11 @@ export function Console({
             everything else in this header: a control over nothing is chrome. */}
         {activeView === "calls" && printed.lines > 0 && (
           <Console.LogFloorSelect floor={logFloor} lines={printed.lines} errors={printed.errors} onChange={onLogFloorChange} />
+        )}
+        {/* What the run was told to do. It belongs to the page the schedule is
+            drawn on, and that page is the one with nothing in this slot. */}
+        {activeView === "stats" && selectedGroup?.run.perf !== undefined && (
+          <span className="ml-auto shrink-0 truncate font-mono text-xs text-muted-foreground @max-[520px]:hidden">{scheduleNote(selectedGroup.run.perf)}</span>
         )}
         {showUtilities && (
           <div className="ml-auto flex shrink-0 items-center gap-2 @max-[430px]:hidden">

--- a/ui/src/Stats.tsx
+++ b/ui/src/Stats.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { callDurationMs } from "./kaja";
 import { cn } from "./cn";
+import { PerfPhase, PerfSchedule } from "./perfTest";
 import { RunGroup } from "./runs";
 import { MethodRow, RunStats, StatsSlot } from "./runStats";
 import {
@@ -80,6 +81,8 @@ export function Stats({ group, onSelectCall }: StatsProps) {
   // One call has no distribution, no throughput and no concurrency — it has a
   // duration and an outcome, and the table is the rest of what there is to say.
   const single = stats.calls === 1;
+  const schedule = group.run.perf;
+  const bands = schedule === undefined ? [] : phaseBands(schedule.phases, group.run.startedAt, stats.spanMs, group.run.startedAt + stats.spanMs);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
@@ -87,9 +90,9 @@ export function Stats({ group, onSelectCall }: StatsProps) {
       <div ref={body} className="min-h-0 flex-1 overflow-y-auto">
         {!single && (
           <>
-            <Stats.Latency stats={stats} />
-            <Stats.Throughput stats={stats} />
-            <Stats.InFlight stats={stats} />
+            <Stats.Latency stats={stats} bands={bands} />
+            <Stats.Throughput stats={stats} bands={bands} />
+            <Stats.InFlight stats={stats} bands={bands} />
             <Stats.Distribution stats={stats} />
           </>
         )}
@@ -107,7 +110,7 @@ export function Stats({ group, onSelectCall }: StatsProps) {
  */
 Stats.Tiles = function ({ group, stats, single }: { group: RunGroup; stats: RunStats; single: boolean }) {
   const only = single ? group.calls[0] : undefined;
-  const cells: { label: string; value: string; className?: string }[] = only
+  const cells: TileCell[] = only
     ? [
         { label: "duration", value: formatMs(callDurationMs(only.call!) ?? undefined) },
         {
@@ -129,6 +132,24 @@ Stats.Tiles = function ({ group, stats, single }: { group: RunGroup; stats: RunS
         { label: "p99", value: formatMs(stats.p99) },
       ];
 
+  // The cell that closes the strip. A schedule states what it left out of the numbers
+  // beside it; a run that is only a run has nothing to put there and says so by
+  // leaving it empty rather than by ending the row early.
+  return <StatTiles cells={cells} note={exclusionNote(stats)} />;
+};
+
+export interface TileCell {
+  label: string;
+  value: string;
+  className?: string;
+}
+
+/**
+ * One row of borderless cells divided by hairlines, not cards — the same weight as
+ * the tail bar. Shared with the canvas's perf block, which is this strip and the way
+ * to the rest of the page.
+ */
+export function StatTiles({ cells, note }: { cells: TileCell[]; note?: string }) {
   return (
     <div data-testid="stats-tiles" className="flex shrink-0 items-stretch overflow-hidden border-b border-border bg-card">
       {cells.map((cell, index) => (
@@ -137,20 +158,100 @@ Stats.Tiles = function ({ group, stats, single }: { group: RunGroup; stats: RunS
           <span className={cn("truncate font-mono text-sm", cell.className ?? "text-foreground")}>{cell.value}</span>
         </div>
       ))}
-      {/* The cell that closes the strip. A schedule states what it excluded here;
-          a run that is only a run has nothing to put in it, and says so by leaving
-          it empty rather than by ending the row early. */}
-      <div className="flex flex-1 items-center border-l border-border px-3" />
+      <div className="flex flex-1 items-center overflow-hidden border-l border-border px-3">
+        {note !== undefined && <span className="truncate text-xs text-muted-foreground">{note}</span>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What the percentiles beside it are not of. A failed call's latency is the time it
+ * took to be refused, which is not the number anyone reads a p99 for; a warm-up call
+ * measured a cold server. Both are counted everywhere else, so the exclusion has to
+ * be said rather than silently applied.
+ */
+export function exclusionNote(stats: { excludedWarmup: number; excludedFailures: number }): string | undefined {
+  const parts: string[] = [];
+  if (stats.excludedWarmup > 0) parts.push(`${stats.excludedWarmup.toLocaleString()} warm-up`);
+  if (stats.excludedFailures > 0) parts.push(`${stats.excludedFailures.toLocaleString()} failed`);
+  return parts.length === 0 ? undefined : `excl. ${parts.join(" · ")}`;
+}
+
+/** The header note: what the run was told to do. */
+export function scheduleNote(schedule: PerfSchedule): string {
+  const budget = schedule.iterations !== undefined ? `${schedule.iterations.toLocaleString()} iter` : formatScheduleSeconds(schedule.durationMs ?? 0);
+  return `perf test · ${budget} · ${schedule.concurrency} vu`;
+}
+
+function formatScheduleSeconds(ms: number): string {
+  const seconds = ms / 1000;
+  return seconds < 100 ? `${Number(seconds.toFixed(1))}s` : `${Math.round(seconds)}s`;
+}
+
+// A tint per phase, and none for the plateau: the bands exist to show where the
+// schedule was doing something other than holding still.
+const PHASE_TINT: { [name: string]: string } = {
+  "warm-up": "bg-foreground/[0.06]",
+  "ramp-up": "bg-foreground/[0.03]",
+  "ramp-down": "bg-foreground/[0.03]",
+  steady: "",
+};
+
+/**
+ * The schedule, drawn behind the charts. The only perf-test-specific ink on the page,
+ * and the only background tint on it — a plain run has none and loses nothing else.
+ *
+ * The same bands go behind all three charts so they read as one ruler; only the tall
+ * one has the room to name them.
+ */
+Stats.PhaseBands = function ({ bands, labels }: { bands: PhaseBand[]; labels?: boolean }) {
+  if (bands.length === 0) return null;
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
+      {bands.map((band) => (
+        <div
+          key={`${band.name}-${band.left}`}
+          className={cn("absolute inset-y-0", PHASE_TINT[band.name] ?? "")}
+          style={{ left: `${band.left}%`, width: `${band.width}%` }}
+        >
+          {labels && <span className="absolute left-1.5 top-1 whitespace-nowrap text-[9px] text-muted-foreground">{band.name}</span>}
+        </div>
+      ))}
     </div>
   );
 };
+
+export interface PhaseBand {
+  name: string;
+  left: number;
+  width: number;
+}
+
+/**
+ * The phases as percentages of the chart's own axis. The schedule is in epoch
+ * milliseconds and the axis starts at the run, which began before the test did — a
+ * script that fetched its fixtures first has a stretch of chart before the bands.
+ */
+export function phaseBands(phases: PerfPhase[], runStartedAt: number, spanMs: number, endedAt: number): PhaseBand[] {
+  if (spanMs <= 0) return [];
+  const bands: PhaseBand[] = [];
+  for (const phase of phases) {
+    const from = ((phase.startedAt - runStartedAt) / spanMs) * 100;
+    const to = (((phase.endedAt ?? endedAt) - runStartedAt) / spanMs) * 100;
+    const left = Math.max(0, Math.min(100, from));
+    const width = Math.max(0, Math.min(100, to) - left);
+    if (width > 0) bands.push({ name: phase.name, left, width });
+  }
+  return bands;
+}
 
 /**
  * p50 with the p50–p95 and p95–p99 envelopes behind it. Three bands rather than three
  * lines: the tail is a region the run spent time in, and drawing it as a line invites
  * reading a p99 spike as one call's story.
  */
-Stats.Latency = function ({ stats }: { stats: RunStats }) {
+Stats.Latency = function ({ stats, bands }: { stats: RunStats; bands: PhaseBand[] }) {
   const ceiling = niceCeiling(Math.max(...stats.slots.map((slot) => slot.p99 ?? 0), 0));
   const tail = bandPoints(
     stats.slots,
@@ -180,6 +281,8 @@ Stats.Latency = function ({ stats }: { stats: RunStats }) {
         </div>
       </div>
       <div data-testid="stats-latency" className="relative rounded border border-border" style={{ height: LATENCY_HEIGHT }}>
+        {/* The only chart with the room to name them, so it is the one that does. */}
+        <Stats.PhaseBands bands={bands} labels />
         <svg
           viewBox={`0 0 ${CHART_WIDTH} ${LATENCY_HEIGHT}`}
           preserveAspectRatio="none"
@@ -214,7 +317,7 @@ Stats.FailureMarks = function ({ stats }: { stats: RunStats }) {
   );
 };
 
-Stats.Throughput = function ({ stats }: { stats: RunStats }) {
+Stats.Throughput = function ({ stats, bands }: { stats: RunStats; bands: PhaseBand[] }) {
   const ceiling = niceCeiling(stats.peakRps);
   return (
     <div className="px-3 pt-3">
@@ -222,7 +325,8 @@ Stats.Throughput = function ({ stats }: { stats: RunStats }) {
         <span className="text-xs text-muted-foreground">Requests / s</span>
         <span className="font-mono text-xs text-muted-foreground">peak {formatRps(stats.peakRps)}</span>
       </div>
-      <div data-testid="stats-throughput" className="mt-1 flex items-end gap-0.5 rounded border border-border px-1" style={{ height: RPS_HEIGHT }}>
+      <div data-testid="stats-throughput" className="relative mt-1 flex items-end gap-0.5 rounded border border-border px-1" style={{ height: RPS_HEIGHT }}>
+        <Stats.PhaseBands bands={bands} />
         {stats.slots.map((slot, index) => (
           <Stats.Bar key={index} slot={slot} ceiling={ceiling} height={RPS_HEIGHT} />
         ))}
@@ -253,13 +357,14 @@ Stats.Bar = function ({ slot, ceiling, height }: { slot: StatsSlot; ceiling: num
  * it. Flatlining at one is the honest reading of a serial loop and explains a low rps
  * better than the throughput chart does.
  */
-Stats.InFlight = function ({ stats }: { stats: RunStats }) {
+Stats.InFlight = function ({ stats, bands }: { stats: RunStats; bands: PhaseBand[] }) {
   const ceiling = Math.max(MIN_IN_FLIGHT_CEILING, stats.maxInFlight);
   const ticks = timeTicks(stats.spanMs);
   return (
     <div className="px-3 pt-3">
       <span className="text-xs text-muted-foreground">In flight</span>
       <div data-testid="stats-in-flight" className="relative mt-1 rounded border border-border" style={{ height: IN_FLIGHT_HEIGHT }}>
+        <Stats.PhaseBands bands={bands} />
         <svg viewBox={`0 0 ${CHART_WIDTH} ${IN_FLIGHT_HEIGHT}`} preserveAspectRatio="none" className="absolute inset-0 h-full w-full" aria-hidden="true">
           <polyline
             points={stepPoints(stats.slots, ceiling, IN_FLIGHT_HEIGHT)}

--- a/ui/src/blocks.ts
+++ b/ui/src/blocks.ts
@@ -106,7 +106,30 @@ export interface ApproveBlock {
  */
 export type ApproveGesture = "approved" | "all" | "rejected";
 
-export type Block = TextBlock | CodeBlock | TableBlock | AskBlock | ApproveBlock;
+/**
+ * What a perf test drew: the same tiles the Stats page opens with, and the way there.
+ * A test that ran for a minute has to leave something on the canvas — a presented run
+ * (a deeplink, an agent) would otherwise have nothing to show for it — but the canvas
+ * is not where the charts belong, so the block is the headline and a link.
+ */
+export interface PerfBlock {
+  kind: "perf";
+  // What the schedule was: "1000 iter · 10 vu", or "30s · 10 vu".
+  schedule: string;
+  running?: boolean;
+  requests: number;
+  failures: number;
+  errorRate: number;
+  meanRps: number;
+  p50?: number;
+  p95?: number;
+  p99?: number;
+  durationMs?: number;
+  excludedWarmup?: number;
+  excludedFailures?: number;
+}
+
+export type Block = TextBlock | CodeBlock | TableBlock | AskBlock | ApproveBlock | PerfBlock;
 
 export function cellStatus(block: TableBlock, row: number, column: number): CellStatus | undefined {
   return block.cells?.[row]?.[column];
@@ -180,6 +203,8 @@ export function blockLabel(block: Block): string {
         default:
           return `Approve ${block.method}`;
       }
+    case "perf":
+      return block.running ? `Perf test · ${block.schedule}` : `Perf test · ${block.requests.toLocaleString()} requests`;
   }
 }
 

--- a/ui/src/consoles.ts
+++ b/ui/src/consoles.ts
@@ -15,6 +15,7 @@ import {
   RunSelection,
   RunStatus,
 } from "./runs";
+import { PerfSchedule } from "./perfTest";
 import { RunMetrics } from "./runStats";
 import { RunStrip } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
@@ -292,6 +293,27 @@ export class FileConsole {
     return true;
   }
 
+  /**
+   * What the perf test running in this run has done so far. The schedule rides on the
+   * run so a stale one still draws its bands, and the warm-up boundary reaches the
+   * metrics here rather than through the calls — one boundary, not a mark per call.
+   */
+  recordPerfSchedule(runId: string, schedule: PerfSchedule): boolean {
+    const index = this.runs.findIndex((run) => run.id === runId);
+    if (index === -1) return false;
+    this.runs[index] = { ...this.runs[index], perf: schedule };
+    const group = this.#groups.get(runId);
+    if (group) {
+      group.run = this.runs[index];
+      // Held until the boundary is known, because a sample counted under the wrong
+      // phase cannot be taken back out of a histogram.
+      if (schedule.warmupEndsAt !== undefined || schedule.endedAt !== undefined) group.metrics.resolveWarmup(schedule.warmupEndsAt);
+      else group.metrics.declareWarmup();
+    }
+    this.#ordered = null;
+    return true;
+  }
+
   findBlock(blockId: string): { run: Run; block: Block } | undefined {
     const known = this.#byItem.get(blockId);
     return known?.item.block ? { run: known.group.run, block: known.item.block } : undefined;
@@ -452,6 +474,14 @@ export class Consoles {
     this.#touch(fileId, file.waiting !== wasWaiting);
     if (file.waiting !== wasWaiting) this.#flagsChanged();
     this.#maybeQuiet(fileId, runId);
+  }
+
+  recordPerfSchedule(fileId: string | undefined, runId: string, schedule: PerfSchedule, now: number): void {
+    if (!fileId) return;
+    const file = this.#ensure(fileId, now);
+    // A phase opening or closing is a gesture's worth of news: the bands move under
+    // the cursor and the page has to keep up with the run rather than with the frame.
+    if (file.recordPerfSchedule(runId, schedule)) this.#touch(fileId, true);
   }
 
   recordLogs(fileId: string | undefined, runId: string, logs: Log[], now: number): void {

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -15,7 +15,10 @@ import {
   TextBlock,
   withCellStatus,
   withoutRowStatus,
+  PerfBlock,
 } from "./blocks";
+import { describeSchedule, PerfBody, PerfPlan, PerfReport, perfReport, PerfSchedule, PerfTestOptions, runPerfTest } from "./perfTest";
+import { RunMetrics } from "./runStats";
 import { LogSink } from "./scriptConsole";
 import { CellRef, pageSizeOf } from "./tableView";
 import { rememberValues } from "./typeMemory";
@@ -306,6 +309,9 @@ export interface RunContext {
   onApprove: ApproveRequest;
   onBlockUpdate: BlockUpdate;
   onLog: LogSink;
+  // The phases a perf test ran through. The only thing the perf half tells the console
+  // about itself, and what the Stats page draws its bands from.
+  onPerfSchedule?: (schedule: PerfSchedule) => void;
   // Given at the start rather than assigned afterwards, so one link's parameters can
   // never be found by the next run.
   input?: { [key: string]: string };
@@ -390,6 +396,7 @@ export class Kaja {
   #onAsk: AskRequest;
   #onApprove: ApproveRequest;
   #onBlockUpdate: BlockUpdate;
+  #onPerfSchedule?: (schedule: PerfSchedule) => void;
 
   constructor(context: RunContext, host: KajaHost = new KajaHost()) {
     this._internal = new KajaInternal(context.onMethodCallUpdate, context.onLog);
@@ -398,6 +405,7 @@ export class Kaja {
     this.#onAsk = context.onAsk;
     this.#onApprove = context.onApprove;
     this.#onBlockUpdate = context.onBlockUpdate;
+    this.#onPerfSchedule = context.onPerfSchedule;
   }
 
   // Read through to the host, so every run in flight sees the same values.
@@ -434,6 +442,7 @@ export class Kaja {
   }
 
   async #ask<T>(question: AskBlock, take: (answer: string) => T): Promise<T> {
+    this.#refuseInsidePerfTest("kaja.ask*");
     const blockId = newBlockId();
     this.#onBlockUpdate(blockId, question);
     try {
@@ -452,6 +461,7 @@ export class Kaja {
    * never learns of it.
    */
   async approve<T>(call: Call<T>): Promise<T> {
+    this.#refuseInsidePerfTest("kaja.approve");
     if (call.started) {
       throw new Error(`kaja.approve: ${call.label} has already been sent. Write the call inside it — kaja.approve(${call.label}({ … })).`);
     }
@@ -480,6 +490,77 @@ export class Kaja {
       this.#onBlockUpdate(blockId, { ...block, decision: "approved" });
     }
     return call.start();
+  }
+
+  /**
+   * Run a body over and over on a schedule. The body is one iteration: `concurrency`
+   * virtual users each run it in a loop, and every call inside it is sampled.
+   *
+   * A failed call fails the iteration, not the test — running to the end is half of
+   * what a perf test is for, and the failures are the data. The report mirrors what
+   * the Stats page shows, so a script can assert its own threshold.
+   */
+  async perfTest(body: PerfBody, options: PerfTestOptions = {}): Promise<PerfReport> {
+    if (this._internal.inPerfTest) throw new Error("kaja.perfTest: a perf test cannot be run inside another one.");
+    const plan = new PerfPlan(options);
+    const blockId = newBlockId();
+    const scheduleLabel = describeSchedule(plan);
+
+    // Its own metrics, fed from the same funnel the console's are, so the report and
+    // the Stats page are two readings of one computation rather than two of them.
+    const metrics = new RunMetrics(Date.now());
+    if (plan.warmupIterations !== undefined) metrics.declareWarmup();
+    const watch: MethodCallUpdate = (methodCall) => metrics.add({ id: methodCall.id, runId: "", timestamp: methodCall.timestamp, call: methodCall });
+    this._internal.watchers.add(watch);
+    this._internal.inPerfTest = true;
+
+    let latest: PerfSchedule | undefined;
+    const draw = (running: boolean) => {
+      const stats = metrics.view(1, 1, latest === undefined ? undefined : (latest.endedAt ?? Date.now()) - latest.startedAt);
+      const block: PerfBlock = {
+        kind: "perf",
+        schedule: scheduleLabel,
+        running: running || undefined,
+        requests: stats.calls,
+        failures: stats.failures,
+        errorRate: stats.errorRate,
+        meanRps: stats.meanRps,
+        p50: stats.p50,
+        p95: stats.p95,
+        p99: stats.p99,
+        durationMs: latest?.endedAt === undefined ? undefined : latest.endedAt - latest.startedAt,
+        excludedWarmup: stats.excludedWarmup || undefined,
+        excludedFailures: stats.excludedFailures || undefined,
+      };
+      this.#onBlockUpdate(blockId, block);
+      return stats;
+    };
+
+    draw(true);
+    try {
+      const outcome = await runPerfTest(body, plan, {
+        signal: this._internal.abortSignal,
+        onSchedule: (schedule) => {
+          latest = schedule;
+          // The boundary is what the exclusion is, so the console's metrics learn it
+          // the moment the test does.
+          if (schedule.warmupEndsAt !== undefined || schedule.endedAt !== undefined) metrics.resolveWarmup(schedule.warmupEndsAt);
+          this.#onPerfSchedule?.(schedule);
+        },
+      });
+      const stats = draw(false);
+      return perfReport(outcome.iterations, outcome.failedIterations, stats);
+    } finally {
+      this._internal.inPerfTest = false;
+      this._internal.watchers.delete(watch);
+    }
+  }
+
+  #refuseInsidePerfTest(verb: string): void {
+    if (!this._internal.inPerfTest) return;
+    throw new Error(
+      `${verb} cannot be used inside kaja.perfTest — ${verb === "kaja.approve" ? "a held call" : "a question"} would park every virtual user on one answer. Ask before the test, or take the value from kaja.input.`,
+    );
   }
 
   text(text: string): void {
@@ -887,6 +968,14 @@ export function isCallInFlight(methodCall: MethodCall): boolean {
 class KajaInternal {
   abortSignal?: AbortSignal;
   /**
+   * Set while a perf test's body is running. Ten virtual users parked on one question
+   * is a deadlock wearing a dialog, so the asks refuse rather than deadlock.
+   */
+  inPerfTest = false;
+  // Every call in the run passes through methodCallUpdate, which is what lets a perf
+  // test total up its own calls without a second path for them to arrive by.
+  readonly watchers = new Set<MethodCallUpdate>();
+  /**
    * Methods approved for the rest of the run, by their "Service.Method" label. The set
    * belongs to one run's `Kaja` and goes when it does, so the guard is back the next
    * time Run is pressed and a concurrent script can't be let through on it.
@@ -918,6 +1007,7 @@ class KajaInternal {
         }
       }
     }
+    for (const watch of this.watchers) watch(methodCall);
     this.#onMethodCallUpdate(methodCall);
   }
 }

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -297,6 +297,34 @@ export declare const kaja: {
    */
   table(columns: string[], rows?: RowSource, options?: { pageSize?: number }): Table;
   /**
+   * Run a body over and over on a schedule, and give the run's Stats page a shape
+   * worth charting. The body is one iteration: \`concurrency\` virtual users each
+   * run it in a loop, and every call inside it is sampled.
+   *
+   *   const report = await kaja.perfTest(
+   *     async ({ iteration }) => {
+   *       await Shows.GetShow({ showId: ids[iteration % ids.length] });
+   *     },
+   *     { iterations: 1000, concurrency: 10, warmup: 50, rampUp: "10s" },
+   *   );
+   *   kaja.text(\`p95 \${report.latency.p95} ms over \${report.requests} requests\`);
+   *
+   * The budget is \`iterations\` or \`duration\` ("30s"), not both; \`duration\` is the
+   * whole test, ramps included. A numeric \`warmup\` is iterations and a string is
+   * time; either way those calls are measured and then left out of the percentiles.
+   * \`rampDown\` needs \`duration\` — with iterations the test ends when the last one
+   * does, which is nothing to ramp down from.
+   *
+   * A failed call fails the iteration, not the test: it runs to the end and the
+   * failures are the data. Failed calls are left out of the latency and counted
+   * everywhere else.
+   *
+   * kaja.askStr and kaja.approve throw inside the body — ten virtual users parked
+   * on one question is a deadlock wearing a dialog. Ask before the test, or take
+   * the value from kaja.input.
+   */
+  perfTest(body: (context: { iteration: number; vu: number }) => unknown, options?: PerfTestOptions): Promise<PerfReport>;
+  /**
    * Generate a random version 4 UUID, e.g. "9b2b1a94-3c6e-4f6e-9d2a-0f6b7c8d9e0f".
    *
    *   const id = kaja.uuidV4();
@@ -323,5 +351,43 @@ export declare const kaja: {
    */
   listValue(input: JsonValue[]): ListValue;
 };
+
+/** How a perf test is shaped. The budget is iterations or duration, never both. */
+export interface PerfTestOptions {
+  iterations?: number;
+  /** The whole test, ramps and warm-up included: "30s", "2m", or milliseconds. */
+  duration?: number | string;
+  /** Virtual users at the plateau. Default 1. */
+  concurrency?: number;
+  /** A number is iterations, a string is time. Measured, then left out of the percentiles. */
+  warmup?: number | string;
+  rampUp?: number | string;
+  /** Needs duration: with iterations there is no moment to start draining from. */
+  rampDown?: number | string;
+}
+
+/** Of the calls that succeeded outside the warm-up — the sample set Stats describes. */
+export interface PerfLatency {
+  min?: number;
+  p50?: number;
+  p90?: number;
+  p95?: number;
+  p99?: number;
+  max?: number;
+  mean?: number;
+}
+
+export interface PerfReport {
+  iterations: number;
+  /** An iteration whose body threw. A failed call does not throw, so this is not that. */
+  failedIterations: number;
+  requests: number;
+  failures: number;
+  errorRate: number;
+  durationMs: number;
+  rps: number;
+  latency: PerfLatency;
+  methods: { method: string; calls: number; failures: number; p50?: number; p95?: number; p99?: number; max?: number; rps: number }[];
+}
 `;
 }

--- a/ui/src/perfTest.test.ts
+++ b/ui/src/perfTest.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "bun:test";
+import { parseDuration, PerfPlan, PerfSchedule, phaseAt, runPerfTest } from "./perfTest";
+
+describe("parseDuration", () => {
+  it("reads the unit the value names", () => {
+    expect(parseDuration("500ms", "d")).toBe(500);
+    expect(parseDuration("30s", "d")).toBe(30_000);
+    expect(parseDuration("2m", "d")).toBe(120_000);
+    expect(parseDuration("1.5s", "d")).toBe(1_500);
+    expect(parseDuration("1h", "d")).toBe(3_600_000);
+  });
+
+  it("takes a number as the milliseconds it already is", () => {
+    expect(parseDuration(250, "d")).toBe(250);
+    expect(parseDuration(0, "d")).toBe(0);
+  });
+
+  it("refuses what it cannot read rather than guessing a unit", () => {
+    expect(() => parseDuration("30", "duration")).toThrow(/duration/);
+    expect(() => parseDuration("soon", "duration")).toThrow(/duration/);
+    expect(() => parseDuration(-1, "duration")).toThrow(/duration/);
+  });
+});
+
+describe("PerfPlan", () => {
+  it("is a hundred iterations at one user when nothing is said", () => {
+    const plan = new PerfPlan({});
+    expect(plan.iterations).toBe(100);
+    expect(plan.concurrency).toBe(1);
+    expect(plan.durationMs).toBeUndefined();
+  });
+
+  it("refuses two ways of saying the same budget", () => {
+    expect(() => new PerfPlan({ iterations: 10, duration: "5s" })).toThrow(/not both/);
+  });
+
+  it("refuses a ramp-down it has no room to start", () => {
+    expect(() => new PerfPlan({ iterations: 100, rampDown: "5s" })).toThrow(/rampDown needs duration/);
+  });
+
+  it("refuses a shape longer than the test that holds it", () => {
+    expect(() => new PerfPlan({ duration: "10s", rampUp: "8s", rampDown: "5s" })).toThrow(/longer than/);
+  });
+
+  it("refuses a concurrency that is not a count of users", () => {
+    expect(() => new PerfPlan({ concurrency: 0 })).toThrow(/whole number/);
+    expect(() => new PerfPlan({ concurrency: 2.5 })).toThrow(/whole number/);
+  });
+
+  it("reads a numeric warmup as iterations and a string as time", () => {
+    expect(new PerfPlan({ warmup: 50 }).warmupIterations).toBe(50);
+    expect(new PerfPlan({ warmup: 50 }).warmupMs).toBeUndefined();
+    expect(new PerfPlan({ warmup: "5s" }).warmupMs).toBe(5_000);
+    expect(new PerfPlan({ warmup: "5s" }).warmupIterations).toBeUndefined();
+  });
+});
+
+describe("PerfPlan.vusAt", () => {
+  it("primes at one user through the warm-up, whatever the test ramps to", () => {
+    const plan = new PerfPlan({ duration: "40s", concurrency: 10, warmup: "4s", rampUp: "6s" });
+    expect(plan.vusAt(0, 4_000)).toBe(1);
+    expect(plan.vusAt(3_999, 4_000)).toBe(1);
+  });
+
+  it("climbs linearly to the plateau and holds there", () => {
+    const plan = new PerfPlan({ duration: "40s", concurrency: 10, rampUp: "10s" });
+    expect(plan.vusAt(0, 0)).toBe(1);
+    expect(plan.vusAt(5_000, 0)).toBe(5);
+    expect(plan.vusAt(9_000, 0)).toBe(9);
+    expect(plan.vusAt(10_000, 0)).toBe(10);
+    expect(plan.vusAt(25_000, 0)).toBe(10);
+  });
+
+  it("never rounds to nothing on the way up", () => {
+    const plan = new PerfPlan({ duration: "40s", concurrency: 10, rampUp: "10s" });
+    expect(plan.vusAt(1, 0)).toBe(1);
+  });
+
+  it("drains to nothing over the ramp-down", () => {
+    const plan = new PerfPlan({ duration: "40s", concurrency: 10, rampDown: "10s" });
+    expect(plan.vusAt(29_000, 0)).toBe(10);
+    expect(plan.vusAt(30_000, 0)).toBe(10);
+    expect(plan.vusAt(35_000, 0)).toBe(5);
+    expect(plan.vusAt(40_000, 0)).toBe(0);
+  });
+
+  it("holds the plateau for a test with no ramps at all", () => {
+    const plan = new PerfPlan({ iterations: 100, concurrency: 4 });
+    expect(plan.vusAt(0, 0)).toBe(4);
+    expect(plan.vusAt(99_000, 0)).toBe(4);
+  });
+});
+
+describe("phaseAt", () => {
+  it("walks warm-up, ramp-up, steady and ramp-down in order", () => {
+    const plan = new PerfPlan({ duration: "40s", concurrency: 10, warmup: "4s", rampUp: "6s", rampDown: "8s" });
+    expect(phaseAt(plan, 0, 4_000)).toBe("warm-up");
+    expect(phaseAt(plan, 5_000, 4_000)).toBe("ramp-up");
+    expect(phaseAt(plan, 20_000, 4_000)).toBe("steady");
+    expect(phaseAt(plan, 35_000, 4_000)).toBe("ramp-down");
+  });
+
+  it("stays in the warm-up while its end is still unknown", () => {
+    const plan = new PerfPlan({ iterations: 100, warmup: 50 });
+    expect(phaseAt(plan, 10_000, undefined)).toBe("warm-up");
+  });
+
+  it("is steady the whole way for a test with no shape", () => {
+    const plan = new PerfPlan({ iterations: 10 });
+    expect(phaseAt(plan, 0, 0)).toBe("steady");
+    expect(phaseAt(plan, 5_000, 0)).toBe("steady");
+  });
+});
+
+describe("runPerfTest", () => {
+  const schedules: PerfSchedule[] = [];
+  const collect = (schedule: PerfSchedule) => schedules.push(schedule);
+
+  it("runs the body exactly as many times as the budget says", async () => {
+    let ran = 0;
+    const outcome = await runPerfTest(() => void ran++, new PerfPlan({ iterations: 25 }), { onSchedule: collect });
+    expect(ran).toBe(25);
+    expect(outcome.iterations).toBe(25);
+    expect(outcome.failedIterations).toBe(0);
+  });
+
+  it("hands the body its iteration and its virtual user", async () => {
+    const seen: { iteration: number; vu: number }[] = [];
+    await runPerfTest((context) => void seen.push(context), new PerfPlan({ iterations: 12, concurrency: 3 }), { onSchedule: collect });
+    expect(seen).toHaveLength(12);
+    expect([...new Set(seen.map((entry) => entry.iteration))]).toHaveLength(12);
+    expect(Math.max(...seen.map((entry) => entry.vu))).toBeLessThan(3);
+  });
+
+  it("counts a thrown iteration and keeps going", async () => {
+    let ran = 0;
+    const outcome = await runPerfTest(
+      () => {
+        ran++;
+        if (ran % 2 === 0) throw new Error("nope");
+      },
+      new PerfPlan({ iterations: 10 }),
+      { onSchedule: collect },
+    );
+    expect(outcome.iterations).toBe(10);
+    expect(outcome.failedIterations).toBe(5);
+  });
+
+  it("stamps the warm-up boundary at the iteration that ends it", async () => {
+    const outcome = await runPerfTest(() => {}, new PerfPlan({ iterations: 20, warmup: 5 }), { onSchedule: collect });
+    expect(outcome.schedule.warmupIterations).toBe(5);
+    expect(outcome.schedule.warmupEndsAt).toBeDefined();
+    expect(outcome.schedule.phases.map((phase) => phase.name)).toEqual(["warm-up", "steady"]);
+  });
+
+  it("closes every phase it opened and the schedule itself", async () => {
+    const outcome = await runPerfTest(() => {}, new PerfPlan({ iterations: 8, warmup: 2 }), { onSchedule: collect });
+    expect(outcome.schedule.endedAt).toBeDefined();
+    expect(outcome.schedule.phases.every((phase) => phase.endedAt !== undefined)).toBe(true);
+    for (const phase of outcome.schedule.phases) expect(phase.endedAt!).toBeGreaterThanOrEqual(phase.startedAt);
+  });
+
+  it("stops where it was told to, leaving the budget unspent", async () => {
+    const controller = new AbortController();
+    let ran = 0;
+    const outcome = await runPerfTest(
+      () => {
+        ran++;
+        if (ran === 4) controller.abort();
+      },
+      new PerfPlan({ iterations: 1_000 }),
+      { onSchedule: collect, signal: controller.signal },
+    );
+    expect(outcome.iterations).toBeLessThan(1_000);
+    expect(ran).toBeLessThan(20);
+  });
+
+  it("excludes nothing when it was stopped inside its own warm-up", async () => {
+    const controller = new AbortController();
+    let ran = 0;
+    const outcome = await runPerfTest(
+      () => {
+        ran++;
+        if (ran === 3) controller.abort();
+      },
+      new PerfPlan({ iterations: 1_000, warmup: 500 }),
+      { onSchedule: collect, signal: controller.signal },
+    );
+    expect(outcome.schedule.warmupEndsAt).toBeUndefined();
+    expect(outcome.schedule.warmupIterations).toBeUndefined();
+  });
+
+  it("reports the schedule as it goes, not only at the end", async () => {
+    schedules.length = 0;
+    await runPerfTest(() => {}, new PerfPlan({ iterations: 6, warmup: 2 }), { onSchedule: collect });
+    expect(schedules.length).toBeGreaterThan(1);
+    // Every report is a copy, so a caller holding an earlier one is not rewritten under.
+    expect(schedules[0]).not.toBe(schedules[schedules.length - 1]);
+  });
+
+  it("holds a duration budget open for its whole length", async () => {
+    let ran = 0;
+    const outcome = await runPerfTest(() => void ran++, new PerfPlan({ duration: 120, concurrency: 2 }), { onSchedule: collect });
+    expect(ran).toBeGreaterThan(0);
+    expect(outcome.schedule.durationMs).toBe(120);
+    expect(outcome.schedule.endedAt! - outcome.schedule.startedAt).toBeGreaterThanOrEqual(110);
+  });
+});
+
+describe("the warm-up boundary", () => {
+  it("publishes a time warm-up's end before anything has run", async () => {
+    const seen: (number | undefined)[] = [];
+    const outcome = await runPerfTest(() => {}, new PerfPlan({ duration: 150, warmup: "50ms" }), {
+      onSchedule: (schedule) => seen.push(schedule.warmupEndsAt),
+    });
+    // Known from the plan, so the exclusion is in force for the very first call
+    // rather than stamped once the warm-up is over.
+    expect(seen[0]).toBe(outcome.schedule.startedAt + 50);
+    expect(outcome.schedule.warmupEndsAt).toBe(outcome.schedule.startedAt + 50);
+  });
+
+  it("cannot be given a warm-up longer than the test that holds it", () => {
+    expect(() => new PerfPlan({ duration: "10s", warmup: "40s" })).toThrow(/longer than/);
+  });
+
+  it("excludes nothing when the test was stopped inside its time warm-up", async () => {
+    const controller = new AbortController();
+    const outcome = await runPerfTest(() => controller.abort(), new PerfPlan({ duration: "20s", warmup: "10s" }), {
+      onSchedule: () => {},
+      signal: controller.signal,
+    });
+    expect(outcome.schedule.warmupEndsAt).toBeUndefined();
+  });
+});

--- a/ui/src/perfTest.ts
+++ b/ui/src/perfTest.ts
@@ -1,0 +1,361 @@
+import type { RunStats } from "./runStats";
+
+/**
+ * A run shaped for the Stats view: a body run over and over on a schedule, with
+ * controlled concurrency and a warm-up that is measured but left out of the headline.
+ *
+ * The schedule is pure and the runner is thin over it. What the runner adds is a
+ * budget, a set of virtual users it grows and drains, and the phase boundaries it
+ * stamps as it crosses them — which is the only thing the perf half tells the stats
+ * half about itself.
+ */
+
+/** Milliseconds as a number, or `"30s"` / `"2m"` / `"500ms"` as a string. */
+export type Duration = number | string;
+
+export type PerfPhaseName = "warm-up" | "ramp-up" | "steady" | "ramp-down";
+
+export interface PerfTestOptions {
+  // One of these two is the budget. Iterations counts runs of the body; duration is
+  // the whole test, ramps and warm-up included.
+  iterations?: number;
+  duration?: Duration;
+  // Virtual users at the plateau. Each runs the body in a loop.
+  concurrency?: number;
+  // A number is iterations, a string is time — the unit a warm-up is naturally said
+  // in depends on which one you are trying to prime.
+  warmup?: number | Duration;
+  rampUp?: Duration;
+  rampDown?: Duration;
+}
+
+export interface PerfContext {
+  // Zero-based and unique across the test, so a body can vary its request data.
+  iteration: number;
+  vu: number;
+}
+
+export type PerfBody = (context: PerfContext) => unknown;
+
+/**
+ * A stretch of the test, in epoch milliseconds. Absolute rather than relative because
+ * the stats draw them against the run's clock, which started before the test did.
+ */
+export interface PerfPhase {
+  name: PerfPhaseName;
+  startedAt: number;
+  // Absent while the phase is the one being run.
+  endedAt?: number;
+}
+
+/** What the perf half tells the stats half. Stored with the run, so a stale one still draws its bands. */
+export interface PerfSchedule {
+  concurrency: number;
+  iterations?: number;
+  durationMs?: number;
+  startedAt: number;
+  phases: PerfPhase[];
+  // Calls issued before this are warm-up: counted everywhere, left out of the
+  // percentiles. Absent until the warm-up is over.
+  warmupEndsAt?: number;
+  // How many iterations the warm-up covered, which is what the tile strip states.
+  warmupIterations?: number;
+  endedAt?: number;
+}
+
+const DURATION_PATTERN = /^\s*(\d+(?:\.\d+)?)\s*(ms|s|m|h)\s*$/;
+const UNIT_MS: { [unit: string]: number } = { ms: 1, s: 1_000, m: 60_000, h: 3_600_000 };
+
+/** A duration in milliseconds. A number is already that; a string names its own unit. */
+export function parseDuration(value: Duration, field: string): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) throw new Error(`kaja.perfTest: ${field} must be a duration, got ${value}.`);
+    return value;
+  }
+  const match = DURATION_PATTERN.exec(value);
+  if (!match) throw new Error(`kaja.perfTest: ${field} must be a duration like "30s", "2m" or "500ms", got ${JSON.stringify(value)}.`);
+  return Number(match[1]) * UNIT_MS[match[2]];
+}
+
+/**
+ * The shape of the test before it is run: what concurrency to hold at each moment,
+ * and the phases that shape describes. A plan is made once and never adjusts to what
+ * the run turns out to do — a schedule that chased the observed rate would report the
+ * server's behaviour as if it were the test's.
+ */
+export class PerfPlan {
+  readonly concurrency: number;
+  readonly iterations?: number;
+  readonly durationMs?: number;
+  readonly warmupMs?: number;
+  readonly warmupIterations?: number;
+  readonly rampUpMs: number;
+  readonly rampDownMs: number;
+
+  constructor(options: PerfTestOptions) {
+    const concurrency = options.concurrency ?? 1;
+    if (!Number.isInteger(concurrency) || concurrency < 1) {
+      throw new Error(`kaja.perfTest: concurrency must be a whole number of virtual users, got ${options.concurrency}.`);
+    }
+    if (options.iterations !== undefined && options.duration !== undefined) {
+      throw new Error("kaja.perfTest: give iterations or duration, not both — they are two ways to say the same budget.");
+    }
+    if (options.iterations !== undefined && (!Number.isInteger(options.iterations) || options.iterations < 1)) {
+      throw new Error(`kaja.perfTest: iterations must be a whole number above zero, got ${options.iterations}.`);
+    }
+
+    this.concurrency = concurrency;
+    this.iterations = options.duration === undefined ? (options.iterations ?? DEFAULT_ITERATIONS) : undefined;
+    this.durationMs = options.duration === undefined ? undefined : parseDuration(options.duration, "duration");
+    this.rampUpMs = options.rampUp === undefined ? 0 : parseDuration(options.rampUp, "rampUp");
+    this.rampDownMs = options.rampDown === undefined ? 0 : parseDuration(options.rampDown, "rampDown");
+
+    if (typeof options.warmup === "number") {
+      if (!Number.isInteger(options.warmup) || options.warmup < 0) {
+        throw new Error(`kaja.perfTest: a numeric warmup is a count of iterations, got ${options.warmup}.`);
+      }
+      this.warmupIterations = options.warmup;
+    } else if (options.warmup !== undefined) {
+      this.warmupMs = parseDuration(options.warmup, "warmup");
+    }
+
+    // Draining takes time the test has to have. With a budget in iterations there is
+    // no moment to start draining from — the last iteration is the end.
+    if (this.rampDownMs > 0 && this.durationMs === undefined) {
+      throw new Error("kaja.perfTest: rampDown needs duration — with iterations the test ends when the last one does, which is nothing to ramp down from.");
+    }
+    const shaped = (this.warmupMs ?? 0) + this.rampUpMs + this.rampDownMs;
+    if (this.durationMs !== undefined && shaped > this.durationMs) {
+      throw new Error(`kaja.perfTest: warmup, rampUp and rampDown come to ${shaped} ms, which is longer than the ${this.durationMs} ms the test has.`);
+    }
+  }
+
+  get warmupEndsMs(): number | undefined {
+    return this.warmupMs;
+  }
+
+  // Where ramp-up gives way to the plateau. Only meaningful once the warm-up's own end
+  // is known, which for an iteration warm-up is not until it happens.
+  rampUpEndsMs(warmupEndedMs: number): number {
+    return warmupEndedMs + this.rampUpMs;
+  }
+
+  get rampDownStartsMs(): number | undefined {
+    return this.durationMs === undefined ? undefined : this.durationMs - this.rampDownMs;
+  }
+
+  /**
+   * How many virtual users should be running at this point. Never below one before the
+   * drain: a schedule that rounds to zero in the middle is a test that stops.
+   */
+  vusAt(elapsedMs: number, warmupEndedMs: number | undefined): number {
+    // Priming, not loading — one user, so the first call meets a cold server alone.
+    if (warmupEndedMs === undefined || elapsedMs < warmupEndedMs) return 1;
+
+    const drainStart = this.rampDownStartsMs;
+    if (drainStart !== undefined && elapsedMs >= drainStart) {
+      if (this.rampDownMs <= 0) return 0;
+      const left = 1 - (elapsedMs - drainStart) / this.rampDownMs;
+      return Math.max(0, Math.round(this.concurrency * left));
+    }
+
+    const rampEnd = this.rampUpEndsMs(warmupEndedMs);
+    if (this.rampUpMs > 0 && elapsedMs < rampEnd) {
+      const through = (elapsedMs - warmupEndedMs) / this.rampUpMs;
+      return Math.max(1, Math.round(this.concurrency * through));
+    }
+    return this.concurrency;
+  }
+}
+
+// A quick check with no options at all still has to be a test rather than one call.
+export const DEFAULT_ITERATIONS = 100;
+
+// How often the supervisor re-reads the schedule. Fine enough that a ten-second ramp
+// moves in ~400 steps, coarse enough to cost nothing beside the calls themselves.
+const TICK_MS = 25;
+
+export interface PerfRunnerOptions {
+  signal?: AbortSignal;
+  // Called whenever the schedule changes, so the bands grow as the test runs.
+  onSchedule: (schedule: PerfSchedule) => void;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface PerfOutcome {
+  schedule: PerfSchedule;
+  iterations: number;
+  // An iteration whose body threw. A failed call does not throw, so this is the
+  // script's own reckoning rather than the transport's.
+  failedIterations: number;
+}
+
+/**
+ * Which stretch of the test this moment is in. The runner watches this rather than
+ * computing boundaries in advance: an iteration warm-up has no end until it has one.
+ */
+export function phaseAt(plan: PerfPlan, elapsedMs: number, warmupEndedMs: number | undefined): PerfPhaseName {
+  if (warmupEndedMs === undefined || elapsedMs < warmupEndedMs) return "warm-up";
+  const drainStart = plan.rampDownStartsMs;
+  if (drainStart !== undefined && plan.rampDownMs > 0 && elapsedMs >= drainStart) return "ramp-down";
+  if (plan.rampUpMs > 0 && elapsedMs < plan.rampUpEndsMs(warmupEndedMs)) return "ramp-up";
+  return "steady";
+}
+
+export async function runPerfTest(body: PerfBody, plan: PerfPlan, options: PerfRunnerOptions): Promise<PerfOutcome> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const signal = options.signal;
+
+  const startedAt = now();
+  const elapsed = () => now() - startedAt;
+  const schedule: PerfSchedule = {
+    concurrency: plan.concurrency,
+    iterations: plan.iterations,
+    durationMs: plan.durationMs,
+    startedAt,
+    phases: [],
+  };
+
+  // A test with no warm-up is past it before it begins, which is what lets one rule
+  // cover both.
+  let warmupEndedMs: number | undefined = plan.warmupIterations !== undefined ? undefined : (plan.warmupMs ?? 0);
+  // A warm-up said in time knows its own end before the test starts, so the exclusion
+  // is in force from the first call rather than stamped once it is over.
+  if (plan.warmupMs !== undefined && plan.warmupMs > 0) schedule.warmupEndsAt = startedAt + plan.warmupMs;
+  let taken = 0;
+  let failedIterations = 0;
+  const workers = new Map<number, Promise<void>>();
+
+  const publish = () => options.onSchedule({ ...schedule, phases: schedule.phases.map((phase) => ({ ...phase })) });
+
+  const enterPhase = (name: PerfPhaseName, at: number) => {
+    const open = schedule.phases[schedule.phases.length - 1];
+    if (open?.name === name) return;
+    if (open !== undefined) open.endedAt = at;
+    schedule.phases.push({ name, startedAt: at });
+    publish();
+  };
+
+  const stampWarmupEnd = () => {
+    warmupEndedMs = elapsed();
+    schedule.warmupEndsAt = startedAt + warmupEndedMs;
+    schedule.warmupIterations = taken;
+    publish();
+  };
+
+  const budgetLeft = (): boolean => {
+    if (signal?.aborted) return false;
+    return plan.iterations !== undefined ? taken < plan.iterations : elapsed() < plan.durationMs!;
+  };
+
+  const target = () => plan.vusAt(elapsed(), warmupEndedMs);
+
+  const worker = async (slot: number): Promise<void> => {
+    for (;;) {
+      if (signal?.aborted) return;
+      // Stamped before the iteration that ends the warm-up is taken, and the warm-up
+      // runs at one virtual user, so no call issued after the boundary started before
+      // it.
+      if (plan.warmupIterations !== undefined && warmupEndedMs === undefined && taken >= plan.warmupIterations) stampWarmupEnd();
+      if (slot >= target() || !budgetLeft()) return;
+      const iteration = taken++;
+      try {
+        await body({ iteration, vu: slot });
+      } catch (error) {
+        if (signal?.aborted) return;
+        // A failed iteration is data, not a reason to stop: running to the end is half
+        // of what a perf test is for.
+        failedIterations++;
+      }
+    }
+  };
+
+  if (plan.warmupIterations !== undefined && plan.warmupIterations > 0) enterPhase("warm-up", startedAt);
+  else if (plan.warmupMs !== undefined && plan.warmupMs > 0) enterPhase("warm-up", startedAt);
+  else enterPhase(phaseAt(plan, 0, warmupEndedMs), startedAt);
+
+  for (;;) {
+    if (plan.warmupIterations !== undefined && warmupEndedMs === undefined && taken >= plan.warmupIterations) stampWarmupEnd();
+    enterPhase(phaseAt(plan, elapsed(), warmupEndedMs), now());
+
+    if (budgetLeft()) {
+      const want = target();
+      for (let slot = 0; slot < want; slot++) {
+        if (workers.has(slot)) continue;
+        const running = worker(slot).finally(() => workers.delete(slot));
+        workers.set(slot, running);
+      }
+    } else if (workers.size === 0) {
+      break;
+    }
+    if (signal?.aborted) break;
+    await sleep(TICK_MS);
+  }
+
+  await Promise.all([...workers.values()]);
+  const endedAt = now();
+  const open = schedule.phases[schedule.phases.length - 1];
+  if (open !== undefined) open.endedAt = endedAt;
+  schedule.endedAt = endedAt;
+  // A test stopped in its warm-up measured nothing, so nothing is excluded — the
+  // alternative is a page that reports a run of no calls at all.
+  if (warmupEndedMs === undefined || (schedule.warmupEndsAt !== undefined && endedAt <= schedule.warmupEndsAt)) {
+    schedule.warmupEndsAt = undefined;
+    schedule.warmupIterations = undefined;
+  }
+  publish();
+
+  return { schedule, iterations: taken, failedIterations };
+}
+
+/** What a perf test hands back, so a script can assert its own threshold. */
+export interface PerfReport {
+  iterations: number;
+  // An iteration whose body threw. Distinct from a failed call, which does not throw.
+  failedIterations: number;
+  requests: number;
+  failures: number;
+  errorRate: number;
+  durationMs: number;
+  rps: number;
+  // Of the calls that succeeded outside the warm-up — the same sample set the Stats
+  // page describes, so the two can never disagree.
+  latency: { min?: number; p50?: number; p90?: number; p95?: number; p99?: number; max?: number; mean?: number };
+  methods: { method: string; calls: number; failures: number; p50?: number; p95?: number; p99?: number; max?: number; rps: number }[];
+}
+
+/** The header note: what the schedule was, in the words it was written in. */
+export function describeSchedule(plan: PerfPlan): string {
+  const budget = plan.iterations !== undefined ? `${plan.iterations.toLocaleString()} iter` : formatSeconds(plan.durationMs ?? 0);
+  return `${budget} · ${plan.concurrency} vu`;
+}
+
+function formatSeconds(ms: number): string {
+  const seconds = ms / 1000;
+  return seconds < 100 ? `${Number(seconds.toFixed(1))}s` : `${Math.round(seconds)}s`;
+}
+
+export function perfReport(iterations: number, failedIterations: number, stats: RunStats): PerfReport {
+  return {
+    iterations,
+    failedIterations,
+    requests: stats.calls,
+    failures: stats.failures,
+    errorRate: stats.errorRate,
+    durationMs: stats.spanMs,
+    rps: stats.meanRps,
+    latency: { min: stats.min, p50: stats.p50, p90: stats.p90, p95: stats.p95, p99: stats.p99, max: stats.max, mean: stats.mean },
+    methods: stats.methods.map((row) => ({
+      method: row.method,
+      calls: row.calls,
+      failures: row.failures,
+      p50: row.p50,
+      p95: row.p95,
+      p99: row.p99,
+      max: row.max,
+      rps: row.rps,
+    })),
+  };
+}

--- a/ui/src/perfTestRun.test.ts
+++ b/ui/src/perfTestRun.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import { Block, PerfBlock } from "./blocks";
+import { Kaja } from "./kaja";
+import { PerfSchedule } from "./perfTest";
+
+// A Kaja whose canvas is a map and whose schedule reports are collected, so what a
+// perf test draws and what it tells the console can both be read back.
+function testing() {
+  const blocks = new Map<string, Block>();
+  const schedules: PerfSchedule[] = [];
+  const kaja = new Kaja({
+    onMethodCallUpdate: () => {},
+    onAsk: () => Promise.resolve("an answer"),
+    onApprove: () => Promise.resolve("approved" as const),
+    onBlockUpdate: (blockId, block) => void blocks.set(blockId, block),
+    onLog: () => {},
+    onPerfSchedule: (schedule) => schedules.push(schedule),
+  });
+  const perfBlocks = (): PerfBlock[] => [...blocks.values()].filter((block): block is PerfBlock => block.kind === "perf");
+  return { kaja, blocks, schedules, perfBlocks };
+}
+
+describe("kaja.perfTest", () => {
+  it("runs the body and reports what it did", async () => {
+    const { kaja } = testing();
+    let ran = 0;
+    const report = await kaja.perfTest(() => void ran++, { iterations: 20 });
+    expect(ran).toBe(20);
+    expect(report.iterations).toBe(20);
+    expect(report.failedIterations).toBe(0);
+    // No calls were made, so there is nothing to have percentiles of.
+    expect(report.requests).toBe(0);
+    expect(report.latency.p95).toBeUndefined();
+  });
+
+  it("draws one block, and it is the same one from start to finish", async () => {
+    const { kaja, perfBlocks, blocks } = testing();
+    await kaja.perfTest(() => {}, { iterations: 5 });
+    expect(perfBlocks()).toHaveLength(1);
+    expect(blocks.size).toBe(1);
+    expect(perfBlocks()[0].running).toBeUndefined();
+    expect(perfBlocks()[0].schedule).toBe("5 iter · 1 vu");
+  });
+
+  it("says what the schedule was in the words it was written in", async () => {
+    const { kaja, perfBlocks } = testing();
+    await kaja.perfTest(() => {}, { duration: "60ms", concurrency: 4 });
+    expect(perfBlocks()[0].schedule).toBe("0.1s · 4 vu");
+  });
+
+  it("reports its phases to the console as it goes", async () => {
+    const { kaja, schedules } = testing();
+    await kaja.perfTest(() => {}, { iterations: 6, warmup: 2 });
+    expect(schedules.length).toBeGreaterThan(0);
+    const last = schedules[schedules.length - 1];
+    expect(last.phases.map((phase) => phase.name)).toEqual(["warm-up", "steady"]);
+    expect(last.endedAt).toBeDefined();
+  });
+
+  it("counts a thrown iteration without stopping the test", async () => {
+    const { kaja } = testing();
+    let ran = 0;
+    const report = await kaja.perfTest(
+      () => {
+        if (++ran % 3 === 0) throw new Error("nope");
+      },
+      { iterations: 9 },
+    );
+    expect(report.iterations).toBe(9);
+    expect(report.failedIterations).toBe(3);
+  });
+
+  it("refuses a question inside the body rather than parking every user on it", async () => {
+    const { kaja } = testing();
+    let refused: unknown;
+    await kaja.perfTest(
+      async () => {
+        try {
+          await kaja.askStr("How many?");
+        } catch (error) {
+          refused = error;
+        }
+      },
+      { iterations: 1 },
+    );
+    expect(String(refused)).toMatch(/kaja\.ask\*/);
+    expect(String(refused)).toMatch(/kaja\.input/);
+  });
+
+  it("refuses a held call inside the body for the same reason", async () => {
+    const { kaja } = testing();
+    let refused: unknown;
+    await kaja.perfTest(
+      async () => {
+        try {
+          await kaja.approve({ label: "Shows.CreateShow", input: {}, started: false, claim: () => {}, start: () => Promise.resolve("sent") } as never);
+        } catch (error) {
+          refused = error;
+        }
+      },
+      { iterations: 1 },
+    );
+    expect(String(refused)).toMatch(/kaja\.approve/);
+  });
+
+  it("lets a question through once the test is over", async () => {
+    const { kaja } = testing();
+    await kaja.perfTest(() => {}, { iterations: 1 });
+    expect(await kaja.askStr("How many?")).toBe("an answer");
+  });
+
+  it("refuses a perf test inside a perf test", async () => {
+    const { kaja } = testing();
+    let refused: unknown;
+    await kaja.perfTest(
+      async () => {
+        try {
+          await kaja.perfTest(() => {}, { iterations: 1 });
+        } catch (error) {
+          refused = error;
+        }
+      },
+      { iterations: 1 },
+    );
+    expect(String(refused)).toMatch(/inside another one/);
+  });
+
+  it("lets the plan's own complaints reach the script", async () => {
+    const { kaja } = testing();
+    await expect(kaja.perfTest(() => {}, { iterations: 10, duration: "5s" })).rejects.toThrow(/not both/);
+  });
+});

--- a/ui/src/runStats.test.ts
+++ b/ui/src/runStats.test.ts
@@ -270,3 +270,62 @@ describe("slicing", () => {
     expect(metrics.view(80, 16, 1_000).slots.length).toBeGreaterThan(3);
   });
 });
+
+describe("what the percentiles are of", () => {
+  it("leaves a failed call out of the latency but counts it everywhere else", () => {
+    const metrics = new RunMetrics(START);
+    for (let index = 0; index < 9; index++) issueThenSettle(metrics, call(`ok-${index}`, { at: index * 10 }), 40);
+    // A call that failed fast would drag the median to 20 if it were a sample.
+    issueThenSettle(metrics, call("bad", { at: 90 }), 1, { status: 503 });
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.calls).toBe(10);
+    expect(stats.failures).toBe(1);
+    expect(stats.p50).toBe(40);
+    expect(stats.excludedFailures).toBe(1);
+    expect(stats.methods[0]).toMatchObject({ calls: 10, failures: 1, p50: 40 });
+  });
+
+  it("holds samples while a declared warm-up has no end, then splits them at it", () => {
+    const metrics = new RunMetrics(START);
+    metrics.declareWarmup();
+    for (let index = 0; index < 4; index++) issueThenSettle(metrics, call(`warm-${index}`, { at: index * 10 }), 500);
+    // Nothing is counted yet: which side of the boundary they fall on is unknown.
+    expect(metrics.view(20, 16, 1_000).p50).toBeUndefined();
+
+    metrics.resolveWarmup(START + 50);
+    for (let index = 0; index < 6; index++) issueThenSettle(metrics, call(`hot-${index}`, { at: 60 + index * 10 }), 40);
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.calls).toBe(10);
+    expect(stats.excludedWarmup).toBe(4);
+    expect(stats.p50).toBe(40);
+    expect(stats.methods[0].calls).toBe(10);
+  });
+
+  it("excludes nothing when the warm-up never ended", () => {
+    const metrics = new RunMetrics(START);
+    metrics.declareWarmup();
+    for (let index = 0; index < 4; index++) issueThenSettle(metrics, call(`warm-${index}`, { at: index * 10 }), 40);
+    metrics.resolveWarmup(undefined);
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.excludedWarmup).toBe(0);
+    expect(stats.p50).toBe(40);
+  });
+
+  it("keeps a warm-up call in the throughput and the concurrency it was part of", () => {
+    const metrics = new RunMetrics(START);
+    metrics.declareWarmup();
+    for (let index = 0; index < 4; index++) issueThenSettle(metrics, call(`warm-${index}`, { at: index * 10 }), 40);
+    metrics.resolveWarmup(START + 50);
+    const stats = metrics.view(20, 16, 1_000);
+    expect(stats.slots.reduce((total, slot) => total + slot.calls, 0)).toBe(4);
+    expect(stats.meanRps).toBeCloseTo(4);
+  });
+
+  it("names the slowest call the percentiles are actually of", () => {
+    const metrics = new RunMetrics(START);
+    issueThenSettle(metrics, call("ok", { at: 0, key: "page 1" }), 200);
+    // Slower, but it failed — so it is not what "slowest" is describing.
+    issueThenSettle(metrics, call("bad", { at: 10, key: "page 2" }), 9_000, { status: 503 });
+    expect(metrics.view(20, 16, 1_000).slowest).toMatchObject({ itemId: "ok", durationMs: 200 });
+  });
+});

--- a/ui/src/runStats.ts
+++ b/ui/src/runStats.ts
@@ -196,8 +196,12 @@ class Timeline {
     this.#at(timestamp).failures++;
   }
 
-  settled(startedAt: number, durationMs: number, reportedMs: number): void {
+  // Every call that settles leaves the air, whether or not its latency counts.
+  drained(startedAt: number, durationMs: number): void {
     this.#at(startedAt + durationMs).inFlightDelta--;
+  }
+
+  measured(startedAt: number, reportedMs: number): void {
     this.#at(startedAt).latencies.add(reportedMs);
   }
 
@@ -330,8 +334,17 @@ export interface RunStats {
   peakRps: number;
   maxInFlight: number;
   p50?: number;
+  p90?: number;
   p95?: number;
   p99?: number;
+  min?: number;
+  max?: number;
+  mean?: number;
+  // Calls left out of the percentiles and stated on the tile strip. A failed call is
+  // counted everywhere else — it is the latency of a call that failed fast that would
+  // poison the distribution, not its existence.
+  excludedFailures: number;
+  excludedWarmup: number;
   // The window the charts cover: the run's own wall clock where it has one, else how
   // far its calls reach.
   spanMs: number;
@@ -342,6 +355,16 @@ export interface RunStats {
   markers: { label: string; position: number; valueMs: number }[];
   methods: MethodRow[];
   slowest?: SlowestCall;
+}
+
+/** One settled call, before it is known whether it counts. */
+interface Sample {
+  itemId: string;
+  method: string;
+  key?: string;
+  startedAt: number;
+  reported: number;
+  failed: boolean;
 }
 
 class MethodTotals {
@@ -366,6 +389,11 @@ export class RunMetrics {
   readonly #of = new Map<string, Seen>();
   #calls = 0;
   #failures = 0;
+  #excludedFailures = 0;
+  #excludedWarmup = 0;
+  #warmupEndsAt: number | undefined;
+  // Non-null only while a declared warm-up has no end yet.
+  #held: Sample[] | null = null;
   #slowest: SlowestCall | undefined;
 
   constructor(startedAt: number) {
@@ -408,13 +436,56 @@ export class RunMetrics {
       // What the rows and bars are drawn against everywhere else: the upstream
       // exchange where Kaja measured it, the whole round trip where nothing did.
       const reported = callDurationMs(call) ?? call.durationMs;
-      this.#overall.add(reported);
-      this.#totals(method).latencies.add(reported);
-      this.#timeline.settled(seen.startedAt, call.durationMs, reported);
-      if (this.#slowest === undefined || reported > this.#slowest.durationMs) {
-        this.#slowest = { itemId: item.id, method, key: item.key, durationMs: reported };
-      }
+      this.#timeline.drained(seen.startedAt, call.durationMs);
+      this.#sample({ itemId: item.id, method, key: item.key, startedAt: seen.startedAt, reported, failed: seen.failed });
       this.version++;
+    }
+  }
+
+  /**
+   * A warm-up whose end is not known yet — an iteration warm-up has none until it
+   * happens. Samples are held rather than counted, because a sample counted under the
+   * wrong phase cannot be taken back out of a histogram.
+   */
+  declareWarmup(): void {
+    if (this.#held === null) this.#held = [];
+  }
+
+  /**
+   * Where the warm-up ended, or that it never did. Either way the held samples are
+   * released — a test stopped inside its own warm-up excludes nothing, since the
+   * alternative is a page reporting a run of no calls at all.
+   */
+  resolveWarmup(endsAt: number | undefined): void {
+    if (endsAt !== undefined && this.#warmupEndsAt === endsAt && this.#held === null) return;
+    this.#warmupEndsAt = endsAt;
+    const held = this.#held;
+    this.#held = null;
+    if (held !== null) for (const sample of held) this.#count(sample);
+    this.version++;
+  }
+
+  #sample(sample: Sample): void {
+    if (this.#held !== null) this.#held.push(sample);
+    else this.#count(sample);
+  }
+
+  // The one place the sample set is decided, so the tiles, the charts, the method
+  // table and the slowest row can never disagree about what they are describing.
+  #count(sample: Sample): void {
+    if (sample.failed) {
+      this.#excludedFailures++;
+      return;
+    }
+    if (this.#warmupEndsAt !== undefined && sample.startedAt < this.#warmupEndsAt) {
+      this.#excludedWarmup++;
+      return;
+    }
+    this.#overall.add(sample.reported);
+    this.#totals(sample.method).latencies.add(sample.reported);
+    this.#timeline.measured(sample.startedAt, sample.reported);
+    if (this.#slowest === undefined || sample.reported > this.#slowest.durationMs) {
+      this.#slowest = { itemId: sample.itemId, method: sample.method, key: sample.key, durationMs: sample.reported };
     }
   }
 
@@ -456,8 +527,14 @@ export class RunMetrics {
       peakRps: timeline.reduce((peak, slot) => Math.max(peak, slot.rps), 0),
       maxInFlight: this.#timeline.peakInFlight,
       p50: percentiles[0][1],
+      p90: this.#overall.percentile(0.9),
       p95: percentiles[1][1],
       p99: percentiles[2][1],
+      min: this.#overall.min,
+      max: this.#overall.max,
+      mean: this.#overall.mean,
+      excludedFailures: this.#excludedFailures,
+      excludedWarmup: this.#excludedWarmup,
       spanMs,
       slots: timeline,
       distribution,

--- a/ui/src/runs.ts
+++ b/ui/src/runs.ts
@@ -2,6 +2,7 @@ import { Block, blockLabel, isAwaitingUser } from "./blocks";
 import { callDurationMs, isCallInFlight, MethodCall } from "./kaja";
 // Type only: the strip is maintained in runStrip, which reads its items from here.
 // Importing the value would close the circle.
+import type { PerfSchedule } from "./perfTest";
 import type { RunMetrics } from "./runStats";
 import type { RunStrip } from "./runStrip";
 import { Log, LogLevel } from "./server/api";
@@ -31,6 +32,9 @@ export interface Run {
   stale?: boolean;
   // Set on a stale run whose payloads have aged out.
   payloadsExpired?: boolean;
+  // A run shaped by kaja.perfTest. The only thing the perf half tells the rest of the
+  // console about itself, and the only perf-test-specific ink on the Stats page.
+  perf?: PerfSchedule;
 }
 
 /**
@@ -358,6 +362,9 @@ export function printedCounts(group: RunGroup): { lines: number; errors: number 
  * outranks this and sticks per file.
  */
 export function defaultView(group: RunGroup | undefined): ConsoleView {
+  // A perf test is a run whose point is the numbers, and it draws a block on the way
+  // past — so it outranks the canvas it drew on.
+  if (group?.run.perf !== undefined) return "stats";
   return group?.drew ? "canvas" : "calls";
 }
 

--- a/workspace/scripts/how-fast.ts
+++ b/workspace/scripts/how-fast.ts
@@ -1,0 +1,58 @@
+// How fast is the catalog, and does it stay that way as the load comes on.
+//
+// Every run has a Stats tab. This is what it looks like when the run was
+// *shaped* for it: kaja.perfTest holds a body at a set number of virtual
+// users, and the phases it walks through — warm-up, ramp-up, steady,
+// ramp-down — are drawn as bands across all three charts.
+//
+// Three things are worth looking at while it runs:
+//
+//   in flight      the schedule itself. It climbs to the plateau over the
+//                  ramp-up and drains at the end, which is the one chart
+//                  that shows what the test was told to do.
+//   latency        the p50 line with the p50–p95 and p95–p99 bands behind
+//                  it. If the API bends under load, it bends here first.
+//   distribution   where the calls actually landed. A percentile table
+//                  cannot show you two humps; this can.
+//
+// The warm-up is measured and then left out of the percentiles — the tile
+// strip says so rather than quietly dropping it. Failed calls leave the
+// latency for the same reason and are counted everywhere else.
+//
+// The defaults are deliberately small: this points at a public demo service,
+// not at something of yours. Pass vus and seconds to change them, either from
+// Run with parameters or from a deeplink.
+
+import { kaja } from "kaja";
+import { Theatre } from "theatre/service";
+
+const vus = Math.round(number(kaja.input.vus, 6));
+const seconds = number(kaja.input.seconds, 12);
+// What the run is judged against, which is the whole reason perfTest hands a
+// report back rather than only drawing one.
+const budgetMs = number(kaja.input.budgetMs, 400);
+
+// Setup belongs before the test: asks and approvals throw inside the body,
+// because ten virtual users parked on one question is a deadlock wearing a
+// dialog. This call is also why the time axis has a stretch before the bands.
+const { movies } = await Theatre.ListMovies({ ids: [], genre: "", limit: 100, cursor: "" });
+const genres = [...new Set(movies.map((movie) => movie.genre))].filter(Boolean).sort();
+
+const report = await kaja.perfTest(
+  // One iteration is one read of the catalog. The genre rotates so the test
+  // is not asking for the same answer a thousand times over.
+  ({ iteration }) => Theatre.ListMovies({ ids: [], genre: genres[iteration % genres.length] ?? "", limit: 25, cursor: "" }),
+  { duration: `${seconds}s`, concurrency: vus, warmup: "2s", rampUp: "4s", rampDown: "2s" },
+);
+
+const p99 = Math.round(report.latency.p99 ?? 0);
+kaja.text(
+  p99 <= budgetMs
+    ? `p99 ${p99} ms, inside the ${budgetMs} ms budget — over ${report.requests.toLocaleString()} requests at ${vus} users.`
+    : `p99 ${p99} ms, over the ${budgetMs} ms budget — ${report.requests.toLocaleString()} requests at ${vus} users.`,
+);
+
+function number(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}


### PR DESCRIPTION
Added `kaja.perfTest`, which runs a body on a schedule — iterations or duration, virtual users, warm-up, ramp-up and ramp-down — and rides its phases to the Stats page as bands, with the warm-up as the one exclusion from the latency percentiles. On the canvas the test leaves the tile strip and a way to the page its charts are on, and `workspace/scripts/how-fast.ts` demos it against the movie catalog.