### PR TITLE
Said that a perf test reports itself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ The **log** is the flat audit log — one row per call, in wall order, always co
 - **The report is the same computation the page is** — `perfTest` feeds a `RunMetrics` from the same funnel every call already passes through (`KajaInternal.watchers`), so a script's own assertion and the Stats page can never disagree.
 - **Asks and approvals throw inside the body.** Ten virtual users parked on one question is a deadlock wearing a dialog, so the verb refuses and names where the value should have come from — before the test, or `kaja.input`.
 - **The plan is made once and never chases the run.** A schedule that adjusted to the observed rate would report the server's behaviour as if it were the test's.
-- **A perf run opens on its stats** (`defaultView`), outranking the canvas it drew on: the block it leaves there is a headline and a way to the page the charts are on, not a second copy of them.
+- **A perf run opens on its stats** (`defaultView`), outranking the canvas it drew on: the block it leaves there is a headline and a way to the page the charts are on, not a second copy of them. The script is held to the same rule, in the declaration's JSDoc and in the agent guide: the report is handed back to be *judged* — a budget, another schedule — and a script that redraws the percentiles as a table has retyped the page it is standing on.
 
 ### The console belongs to the file
 

--- a/server/pkg/mcp/guide.md
+++ b/server/pkg/mcp/guide.md
@@ -225,6 +225,36 @@ page and reports `more: true` — if you need the whole set, write the loop and
 read it yourself. Prefer this over `.row(...)` whenever the API pages: the person
 who opens the script gets the rest without running anything.
 
+## A perf test reports itself
+
+`kaja.perfTest(body, options)` runs a body on a schedule — `concurrency` virtual
+users each running it in a loop — and samples every call inside it. What comes
+out is a whole page: the run opens on its **Stats** tab, with requests,
+throughput, error rate, the percentiles, latency over time, the distribution,
+concurrency and a row per method, and the canvas gets a tile carrying the same
+headline and the way there.
+
+**So don't draw those numbers again.** A `kaja.table` of p50/p90/p99 is the Stats
+page retyped, and a narrower reading of it. The report handed back is there to be
+judged against something — a budget, another schedule, the method that got slow —
+which is the one thing Stats cannot say. Draw that sentence, or draw nothing:
+
+```ts
+const report = await kaja.perfTest(
+  ({ iteration }) => Shows.GetShow({ showId: ids[iteration % ids.length] }),
+  { duration: "30s", concurrency: 10, warmup: "2s", rampUp: "5s", rampDown: "2s" },
+);
+const p99 = Math.round(report.latency.p99 ?? 0);
+kaja.text(p99 <= 400 ? `p99 ${p99} ms, inside the budget.` : `p99 ${p99} ms, over the 400 ms budget.`);
+```
+
+The budget is `iterations` or `duration`, never both, and `duration` is the whole
+test with its ramps inside it. A numeric `warmup` is iterations and a string is
+time; either way those calls are measured and then left out of the percentiles. A
+failed call fails its iteration, not the test. `kaja.askStr` and `kaja.approve`
+throw inside the body — ten virtual users parked on one question is a deadlock
+wearing a dialog — so ask before the test, or take the value from `kaja.input`.
+
 ## The script runtime
 
 - **No interactive input.** `prompt`, `alert` and `confirm` do nothing and return
@@ -255,6 +285,9 @@ What each member is for:
   (an async generator) the table pulls a page at a time as it is paged through.
   A cell can be a promise or a function rather than a value, and draws as loading
   until it arrives.
+- `kaja.perfTest(body, options)` — run a body on a schedule and let the run's
+  Stats page report it. The numbers are drawn for you; the report it hands back
+  is for judging them. See above.
 - `kaja.askStr(question)`, `kaja.askInt(question)`,
   `kaja.askSelect(question, options)` — ask the user for text, a whole number,
   or one of a list; each blocks on a human and hands back the kind of thing it

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -307,7 +307,19 @@ export declare const kaja: {
    *     },
    *     { iterations: 1000, concurrency: 10, warmup: 50, rampUp: "10s" },
    *   );
-   *   kaja.text(\`p95 \${report.latency.p95} ms over \${report.requests} requests\`);
+   *   if ((report.latency.p99 ?? 0) > budgetMs) {
+   *     kaja.text(\`p99 \${report.latency.p99} ms, over the \${budgetMs} ms budget\`);
+   *   }
+   *
+   * The test reports itself. The run opens on its Stats page — requests,
+   * throughput, error rate, the percentiles, latency over time, the distribution,
+   * concurrency and a row per method — and leaves a tile block on the canvas
+   * carrying the same headline. So don't draw those numbers a second time: a
+   * table of p50/p90/p99 is the Stats page retyped, and a narrower reading of it.
+   *
+   * The report is handed back to be judged against something — a budget, another
+   * schedule, the method that got slow — which is the one thing Stats cannot say.
+   * Draw that sentence, or draw nothing.
    *
    * The budget is \`iterations\` or \`duration\` ("30s"), not both; \`duration\` is the
    * whole test, ramps included. A numeric \`warmup\` is iterations and a string is


### PR DESCRIPTION
A perf run already opens on its Stats page and leaves a tile on the canvas, so the agent guide and the `kaja.perfTest` declaration now say the returned report is there to be judged against a budget rather than redrawn as a table of percentiles.

---
_Generated by [Claude Code](https://claude.ai/code/session_011M4b6DkXv9neTkDo6siEsd)_