### PR TITLE
Read a REST app from its own document instead of through protobuf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,12 +420,40 @@ The experimental built-ins (mcp/openai/folder) appear in the sidebar's **New** d
 - **The editor is told the same rule by a barrel** (`barrel`), a `ts:/<app>.ts` model re-exporting each module. `export *` drops a name two modules declare, so the editor refuses exactly what `resolve` calls ambiguous.
 - **The app form shows the import the name produces** (`AppNameField`) rather than explaining that the name is a namespace. There is no longer a trailing `/…` to show, so the field states the whole line.
 
+### A REST app is addressed by its own paths
+
+An app built from a REST document has a second door beside its services, and it is the default:
+
+```ts
+import { api as theatre } from "theatre";
+await theatre.get("/shows/{showId}", { showId: "vera-lune" });
+```
+
+A verb and a path are what the document calls an operation, and they are unique by construction — which is the whole reason `protogen` has to work to make a generated method name unique (`sharedNamespace`, `trimServiceName`, per-service `seenRPC`). So the generated name was standing in front of one that was already there.
+
+- **Both doors reach the same methods.** `restDoor.ts` routes a verb and path to the bound `Methods` a service import gives, so the log row, the approvals, the rate limiter and the stats cannot tell which door a call came through, and both spellings compile in one file. It is bound per run for the same reason `Client.methodsFor` is.
+- **The declaration is one overload per operation**, written into the app's module by `restDoorDeclaration` (`appLoader.ts`). Not a map keyed on the path: **only an overload carries the API's description into the editor's hover and signature help** — a map's property documentation reaches neither, and that description is what a generated method name was already failing to say.
+- **A path parameter is the one field a request insists on** (`WithPath` in `kajaModule.ts`), because without it the path is not an address. It is read off the `kaja.http_in` marks rather than off the `{braces}`, since a path names the API's parameter and the request names the generated field. An operation that insists on nothing takes no request at all.
+- **The door is exported as `api`**, not under the app's name, which may be no identifier (`grpcb.in`) and which two REST apps in one script would collide on. Generated code aliases it back (`doorBinding`), so what is read is the app's own name.
+- **A method carrying an HTTP request is named by it everywhere one is named** (`httpMethod.ts`: `methodLabel`, `callLabel`; `MethodName.tsx`) — the tree, the finder, the draft title, the log row. The verb and each `{parameter}` are dimmed, the treatment a filename's extension gets. The finder still *matches* the generated name, which is now nowhere on screen to be read off.
+- **Only display moved.** `Service.Method` is still the identity: the approval scope, the sampled-method key, what a run stores and what `run_script` reports.
+- **The MCP catalog shows whichever door the method has** (`restSignature`, `restBinding`), so an agent is never shown a signature its example is not an instance of.
+
+### What an API says about an operation
+
+Hovering the path in a script shows the operation as its own document declares it (`restHover.ts` → `GetMethodDocumentation` → `apps.Documented`).
+
+- **It sits over the path string because the TypeScript worker has nothing to say there** — it reports no hover at all inside a string literal argument. Where the worker does speak, Monaco shows every provider's hover stacked, so nothing here is in front of anything.
+- **Fetched when hovered, never carried.** A document with nine hundred operations would otherwise ride along with every compile to answer for the one under the cursor — which is why the fragment is in neither the generated module nor the MCP catalog, both of which are read whole. An async provider is what buys that.
+- **The prose is stated once.** `summary` and `description` are the card's headline and body, so they are stripped from the fragment below it; what is left is what nothing else says — the parameters with their own descriptions and examples, the response codes that are never values, the vendor extensions.
+- **A miss is not an error.** An app type that documents nothing, an operation the document does not declare, an instance replaced by a recompile: all answer with nothing, because a hover with nothing to say says nothing.
+
 ### Architecture
 
 - **The map** — [docs/network-stack.md](docs/network-stack.md) draws every hop and how headers flow, per protocol, web and desktop, then traces one real call through each lane on both builds.
 - **Contract** — `server/pkg/apps` defines `App` (factory), `Instance` (live, invocable) and a `Manager` (type registry + live instances). `App.Open` returns an `*Opened` describing the proto surface (`ProtoDir`) and either an in-process `Instance` or a `Target`+`Protocol` the client invokes directly. `Manager.Open` registers an `Instance` under a `kaja-app://<id>` target; otherwise it passes the upstream URL and transport through.
 - **grpc/twirp** — `server/pkg/apps/rpc`. The proto surface is a workspace-relative `proto_dir` or, for gRPC, server reflection (the `reflection` field, reusing `server/pkg/grpc`). They have **no** in-process `Instance`: `Open` returns the upstream `url` and `"grpc"`/`"twirp"`, so the browser invokes them directly and gRPC-Web streaming is preserved.
-- **Open + compile** — the `OpenApp` RPC opens **every** app and returns the `proto_dir` to feed into `Compile`, the invocation `target`, and the `protocol`. `InspectOpenApi`, `InspectGrpc` and `InspectMcp` are the only app-type-specific RPCs, and none of them creates anything.
+- **Open + compile** — the `OpenApp` RPC opens **every** app and returns the `proto_dir` to feed into `Compile`, the invocation `target`, and the `protocol`. `InspectOpenApi`, `InspectGrpc` and `InspectMcp` are the only app-type-specific RPCs, and none of them creates anything. `GetMethodDocumentation` is not one of them: it takes a target and a method and asks whatever is behind it, through the optional `apps.Documented` interface, so an app type that documents nothing answers by not implementing it.
 - **Invoke** — in-process apps are invoked as gRPC via `kaja-app://` targets: the web `/target/{method}` handler calls `grpc.ServeAppGRPCWeb` (→ `Manager.Invoke`), the desktop Wails `Target` dispatches to `Manager.Invoke`. grpc/twirp keep their browser-direct transports.
 - **UI** — `ui/src/apps.ts` models an app as a `ConfigurationApp` plus a runtime `target`/`protocol` (`Transport`). `useCompilation` always calls `OpenApp`. `ui/src/appTypes.ts` is the single registry of app types and bridges the typed oneof to the generic form: `appType` is the set field, `appParameters`/`appHeaders` read the variant, `buildApp` constructs it, and its parameter keys are the generated camelCase field names (`protoDir`, `specUrl`). Each type's `icon` is how the app is shown everywhere it is named (`AppTypeIcon`, with the type label as a tooltip).
 - **App settings** is a document identified by the app: the view is titled with the app's name (a new one is `New <Type> app`), opened from the sidebar or by right-clicking an app → **Settings**. New apps come from the sidebar's **+**. Its `editMode` lives on the view, because the control that switches it (`</>` in the command row) sits in the row.

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -358,6 +358,49 @@ type TargetResult struct {
 	DurationMs int64             `json:"durationMs"`
 }
 
+// RestResult is one upstream HTTP answer, whole. A status is data here rather than
+// an outcome, so there is no flag saying whether it failed: a REST app's script
+// decides what a 404 means.
+type RestResult struct {
+	Status         int               `json:"status"`
+	Body           []byte            `json:"body"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	RequestHeaders map[string]string `json:"requestHeaders,omitempty"`
+	DurationMs     int64             `json:"durationMs"`
+}
+
+// Rest is the desktop's counterpart to POST /rest: one HTTP call an app's script
+// built for itself. The webview has read the document and knows the request; what
+// it does not have is where the API is and what credential opens it, and this is
+// the side that does.
+func (a *App) Rest(target string, method string, path string, headersJson string, body []byte) (*RestResult, error) {
+	headers := make(map[string]string)
+	if headersJson != "" && headersJson != "{}" {
+		if err := json.Unmarshal([]byte(headersJson), &headers); err != nil {
+			return nil, fmt.Errorf("failed to parse headers: %w", err)
+		}
+	}
+	apps.TakeAppName(headers)
+
+	result, err := a.api.ForwardApp(target, &apps.ForwardRequest{
+		Method:  method,
+		Path:    path,
+		Headers: headers,
+		Body:    body,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &RestResult{
+		Status:         result.Status,
+		Body:           result.Body,
+		Headers:        result.Headers,
+		RequestHeaders: result.RequestHeaders,
+		DurationMs:     result.DurationMs,
+	}, nil
+}
+
 // Target proxies external API calls to configured endpoints (the desktop's
 // counterpart to /target/{method...}). protocol is 1 for gRPC and 2 for Twirp;
 // headersJson is a JSON-encoded map of headers to forward.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"mime"
 	"net/http"
@@ -243,6 +245,44 @@ func main() {
 		}
 	})
 
+	// A REST app's calls come through here rather than through /target: the browser
+	// built the request itself from the document, so what crosses is an HTTP call
+	// rather than an encoded message. What this adds is the two things the browser
+	// is not given — where the API is, and the credential that opens it.
+	mux.HandleFunc("POST /rest", func(w http.ResponseWriter, r *http.Request) {
+		forwardHeaders := make(map[string]string)
+		for name, values := range r.Header {
+			if strings.HasPrefix(name, "X-Header-") && len(values) > 0 {
+				forwardHeaders[strings.TrimPrefix(name, "X-Header-")] = values[0]
+			}
+		}
+		apps.TakeAppName(forwardHeaders)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "could not read the request body", http.StatusBadRequest)
+			return
+		}
+
+		result, err := apiService.ForwardApp(r.Header.Get("X-Target"), &apps.ForwardRequest{
+			Method:  r.Header.Get("X-Kaja-Method"),
+			Path:    r.Header.Get("X-Kaja-Path"),
+			Headers: forwardHeaders,
+			Body:    body,
+		})
+		if err != nil {
+			// The call could not be made at all, which is not a status the API
+			// returned — so it is reported as kaja failing as the gateway it is here
+			// rather than dressed up as an answer.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		writeForwardResult(w, result)
+	})
+
 	root := http.NewServeMux()
 	root.Handle(configuration.PathPrefix+"/", logRequest(http.StripPrefix(configuration.PathPrefix, mux)))
 
@@ -280,4 +320,32 @@ func (rw *responseWriter) Flush() {
 	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+// writeForwardResult hands one upstream answer back to the browser: the status and
+// body as they came, and everything kaja knows about the exchange under the
+// reserved kaja-upstream-* namespace the other transports already use, so the
+// Headers view shows the API's own headers and nothing of the hop.
+func writeForwardResult(w http.ResponseWriter, result *apps.ForwardResult) {
+	headers, err := json.Marshal(result.Headers)
+	if err != nil {
+		headers = []byte("{}")
+	}
+	requestHeaders, err := json.Marshal(result.RequestHeaders)
+	if err != nil {
+		requestHeaders = []byte("{}")
+	}
+
+	w.Header().Set("Kaja-Upstream-Response-Headers", string(headers))
+	w.Header().Set("Kaja-Upstream-Request-Headers", string(requestHeaders))
+	w.Header().Set("Kaja-Upstream-Duration-Ms", strconv.FormatInt(result.DurationMs, 10))
+	w.Header().Set("Kaja-Upstream-Status", strconv.Itoa(result.Status))
+	if contentType := result.Headers["Content-Type"]; contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	// The browser is told 200 whatever the API said, and reads the real status off
+	// the reserved header: a 404 the API returned is an answer this hop delivered
+	// successfully, and letting fetch see it as a failure would lose the body.
+	w.WriteHeader(http.StatusOK)
+	w.Write(result.Body)
 }

--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -100,6 +100,24 @@ func (s *ApiService) InvokeApp(target string, method string, message []byte, hea
 	return result, nil
 }
 
+// ForwardApp makes one HTTP call on an app's behalf. The single door both builds
+// come through, the way InvokeApp is for the apps that are invoked as RPC: it
+// expands the headers the browser sent with their ${NAME} references intact, and
+// redacts the resolved values back out of what it reports having sent, so the
+// Headers view shows "Bearer ${TOKEN}" rather than the token.
+func (s *ApiService) ForwardApp(target string, request *apps.ForwardRequest) (*apps.ForwardResult, error) {
+	resolver := s.Variables()
+	sent := request.Headers
+	request.Headers = resolver.ExpandAll(request.Headers)
+
+	result, err := s.apps.Forward(target, request)
+	if err != nil {
+		return nil, err
+	}
+	result.RequestHeaders = resolver.Redact(result.RequestHeaders, sent)
+	return result, nil
+}
+
 func (s *ApiService) getOrCreateCompiler(id string) *Compiler {
 	compiler, _ := s.compilers.LoadOrStore(id, NewCompiler())
 	return compiler.(*Compiler)
@@ -179,6 +197,7 @@ func (s *ApiService) OpenApp(ctx context.Context, req *OpenAppRequest) (*OpenApp
 		ProtoDir: result.ProtoDir,
 		Target:   result.Target,
 		Protocol: result.Protocol,
+		Document: string(result.Document),
 	}, nil
 }
 

--- a/server/pkg/api/api.pb.go
+++ b/server/pkg/api/api.pb.go
@@ -767,7 +767,12 @@ type OpenAppResponse struct {
 	// for in-process apps (only set on success).
 	Target string `protobuf:"bytes,4,opt,name=target,proto3" json:"target,omitempty"`
 	// Transport the client uses to reach the target: "grpc" or "twirp".
-	Protocol      string `protobuf:"bytes,5,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	Protocol string `protobuf:"bytes,5,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	// The app's own description, as JSON, for an app the client drives as HTTP.
+	// A REST document is read in the browser — a schema becomes TypeScript there,
+	// and an operation becomes an HTTP request — so an app that has one compiles no
+	// proto and `proto_dir` is empty for it.
+	Document      string `protobuf:"bytes,6,opt,name=document,proto3" json:"document,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -833,6 +838,13 @@ func (x *OpenAppResponse) GetTarget() string {
 func (x *OpenAppResponse) GetProtocol() string {
 	if x != nil {
 		return x.Protocol
+	}
+	return ""
+}
+
+func (x *OpenAppResponse) GetDocument() string {
+	if x != nil {
+		return x.Document
 	}
 	return ""
 }
@@ -3857,13 +3869,14 @@ const file_proto_api_proto_rawDesc = "" +
 	"log_offset\x18\x02 \x01(\x05R\tlogOffset\x12\x1b\n" +
 	"\tproto_dir\x18\x03 \x01(\tR\bprotoDir\"5\n" +
 	"\x0eOpenAppRequest\x12#\n" +
-	"\x03app\x18\x01 \x01(\v2\x11.ConfigurationAppR\x03app\"\xa1\x01\n" +
+	"\x03app\x18\x01 \x01(\v2\x11.ConfigurationAppR\x03app\"\xbd\x01\n" +
 	"\x0fOpenAppResponse\x12#\n" +
 	"\x06status\x18\x01 \x01(\x0e2\v.OpenStatusR\x06status\x12\x18\n" +
 	"\x04logs\x18\x02 \x03(\v2\x04.LogR\x04logs\x12\x1b\n" +
 	"\tproto_dir\x18\x03 \x01(\tR\bprotoDir\x12\x16\n" +
 	"\x06target\x18\x04 \x01(\tR\x06target\x12\x1a\n" +
-	"\bprotocol\x18\x05 \x01(\tR\bprotocol\"2\n" +
+	"\bprotocol\x18\x05 \x01(\tR\bprotocol\x12\x1a\n" +
+	"\bdocument\x18\x06 \x01(\tR\bdocument\"2\n" +
 	"\x12InspectGrpcRequest\x12\x1c\n" +
 	"\x04grpc\x18\x01 \x01(\v2\b.GrpcAppR\x04grpc\"b\n" +
 	"\x13InspectGrpcResponse\x12#\n" +

--- a/server/pkg/api/api.pb.go
+++ b/server/pkg/api/api.pb.go
@@ -458,6 +458,192 @@ func (VariableSource) EnumDescriptor() ([]byte, []int) {
 	return file_proto_api_proto_rawDescGZIP(), []int{6}
 }
 
+// GetMethodDocumentation reads one of a live app's methods back out of the document
+// its surface was generated from. The generated proto carries what kaja could model;
+// this is the rest — the prose, the examples, the response codes — which is most of
+// what a person reads before writing the call.
+//
+// One operation at a time, because a document with nine hundred of them would
+// otherwise ride along with every compile to answer for the one under the cursor.
+type GetMethodDocumentationRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The opened app, as OpenApp reported it: "kaja-app://<id>".
+	Target string `protobuf:"bytes,1,opt,name=target,proto3" json:"target,omitempty"`
+	// The method, named the way the app's methods name theirs — "GET /shows/{showId}"
+	// for an app built from a REST document.
+	Method        string `protobuf:"bytes,2,opt,name=method,proto3" json:"method,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMethodDocumentationRequest) Reset() {
+	*x = GetMethodDocumentationRequest{}
+	mi := &file_proto_api_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMethodDocumentationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMethodDocumentationRequest) ProtoMessage() {}
+
+func (x *GetMethodDocumentationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_api_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMethodDocumentationRequest.ProtoReflect.Descriptor instead.
+func (*GetMethodDocumentationRequest) Descriptor() ([]byte, []int) {
+	return file_proto_api_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *GetMethodDocumentationRequest) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+func (x *GetMethodDocumentationRequest) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+type GetMethodDocumentationResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unset where the app documents nothing, or the method is one it does not declare.
+	// Not an error: the caller is a hover, and a hover with nothing to say says nothing.
+	Documentation *MethodDocumentation `protobuf:"bytes,1,opt,name=documentation,proto3" json:"documentation,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMethodDocumentationResponse) Reset() {
+	*x = GetMethodDocumentationResponse{}
+	mi := &file_proto_api_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMethodDocumentationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMethodDocumentationResponse) ProtoMessage() {}
+
+func (x *GetMethodDocumentationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_api_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMethodDocumentationResponse.ProtoReflect.Descriptor instead.
+func (*GetMethodDocumentationResponse) Descriptor() ([]byte, []int) {
+	return file_proto_api_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *GetMethodDocumentationResponse) GetDocumentation() *MethodDocumentation {
+	if x != nil {
+		return x.Documentation
+	}
+	return nil
+}
+
+type MethodDocumentation struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Summary     string                 `protobuf:"bytes,1,opt,name=summary,proto3" json:"summary,omitempty"`
+	Description string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Deprecated  bool                   `protobuf:"varint,3,opt,name=deprecated,proto3" json:"deprecated,omitempty"`
+	// The declaration as it was written, ready to show.
+	Document string `protobuf:"bytes,4,opt,name=document,proto3" json:"document,omitempty"`
+	// What `document` is written in, so an editor can colour it: "yaml", "json".
+	Language      string `protobuf:"bytes,5,opt,name=language,proto3" json:"language,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MethodDocumentation) Reset() {
+	*x = MethodDocumentation{}
+	mi := &file_proto_api_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MethodDocumentation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MethodDocumentation) ProtoMessage() {}
+
+func (x *MethodDocumentation) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_api_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MethodDocumentation.ProtoReflect.Descriptor instead.
+func (*MethodDocumentation) Descriptor() ([]byte, []int) {
+	return file_proto_api_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *MethodDocumentation) GetSummary() string {
+	if x != nil {
+		return x.Summary
+	}
+	return ""
+}
+
+func (x *MethodDocumentation) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *MethodDocumentation) GetDeprecated() bool {
+	if x != nil {
+		return x.Deprecated
+	}
+	return false
+}
+
+func (x *MethodDocumentation) GetDocument() string {
+	if x != nil {
+		return x.Document
+	}
+	return ""
+}
+
+func (x *MethodDocumentation) GetLanguage() string {
+	if x != nil {
+		return x.Language
+	}
+	return ""
+}
+
 type CompileRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -469,7 +655,7 @@ type CompileRequest struct {
 
 func (x *CompileRequest) Reset() {
 	*x = CompileRequest{}
-	mi := &file_proto_api_proto_msgTypes[0]
+	mi := &file_proto_api_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -481,7 +667,7 @@ func (x *CompileRequest) String() string {
 func (*CompileRequest) ProtoMessage() {}
 
 func (x *CompileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[0]
+	mi := &file_proto_api_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -494,7 +680,7 @@ func (x *CompileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompileRequest.ProtoReflect.Descriptor instead.
 func (*CompileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{0}
+	return file_proto_api_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CompileRequest) GetId() string {
@@ -534,7 +720,7 @@ type OpenAppRequest struct {
 
 func (x *OpenAppRequest) Reset() {
 	*x = OpenAppRequest{}
-	mi := &file_proto_api_proto_msgTypes[1]
+	mi := &file_proto_api_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +732,7 @@ func (x *OpenAppRequest) String() string {
 func (*OpenAppRequest) ProtoMessage() {}
 
 func (x *OpenAppRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[1]
+	mi := &file_proto_api_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +745,7 @@ func (x *OpenAppRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenAppRequest.ProtoReflect.Descriptor instead.
 func (*OpenAppRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{1}
+	return file_proto_api_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *OpenAppRequest) GetApp() *ConfigurationApp {
@@ -588,7 +774,7 @@ type OpenAppResponse struct {
 
 func (x *OpenAppResponse) Reset() {
 	*x = OpenAppResponse{}
-	mi := &file_proto_api_proto_msgTypes[2]
+	mi := &file_proto_api_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -600,7 +786,7 @@ func (x *OpenAppResponse) String() string {
 func (*OpenAppResponse) ProtoMessage() {}
 
 func (x *OpenAppResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[2]
+	mi := &file_proto_api_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -613,7 +799,7 @@ func (x *OpenAppResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenAppResponse.ProtoReflect.Descriptor instead.
 func (*OpenAppResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{2}
+	return file_proto_api_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *OpenAppResponse) GetStatus() OpenStatus {
@@ -665,7 +851,7 @@ type InspectGrpcRequest struct {
 
 func (x *InspectGrpcRequest) Reset() {
 	*x = InspectGrpcRequest{}
-	mi := &file_proto_api_proto_msgTypes[3]
+	mi := &file_proto_api_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -677,7 +863,7 @@ func (x *InspectGrpcRequest) String() string {
 func (*InspectGrpcRequest) ProtoMessage() {}
 
 func (x *InspectGrpcRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[3]
+	mi := &file_proto_api_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -690,7 +876,7 @@ func (x *InspectGrpcRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectGrpcRequest.ProtoReflect.Descriptor instead.
 func (*InspectGrpcRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{3}
+	return file_proto_api_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *InspectGrpcRequest) GetGrpc() *GrpcApp {
@@ -712,7 +898,7 @@ type InspectGrpcResponse struct {
 
 func (x *InspectGrpcResponse) Reset() {
 	*x = InspectGrpcResponse{}
-	mi := &file_proto_api_proto_msgTypes[4]
+	mi := &file_proto_api_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -724,7 +910,7 @@ func (x *InspectGrpcResponse) String() string {
 func (*InspectGrpcResponse) ProtoMessage() {}
 
 func (x *InspectGrpcResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[4]
+	mi := &file_proto_api_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -737,7 +923,7 @@ func (x *InspectGrpcResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectGrpcResponse.ProtoReflect.Descriptor instead.
 func (*InspectGrpcResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{4}
+	return file_proto_api_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *InspectGrpcResponse) GetServer() *GrpcServer {
@@ -785,7 +971,7 @@ type GrpcServer struct {
 
 func (x *GrpcServer) Reset() {
 	*x = GrpcServer{}
-	mi := &file_proto_api_proto_msgTypes[5]
+	mi := &file_proto_api_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -797,7 +983,7 @@ func (x *GrpcServer) String() string {
 func (*GrpcServer) ProtoMessage() {}
 
 func (x *GrpcServer) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[5]
+	mi := &file_proto_api_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -810,7 +996,7 @@ func (x *GrpcServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrpcServer.ProtoReflect.Descriptor instead.
 func (*GrpcServer) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{5}
+	return file_proto_api_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GrpcServer) GetSource() string {
@@ -891,7 +1077,7 @@ type GrpcService struct {
 
 func (x *GrpcService) Reset() {
 	*x = GrpcService{}
-	mi := &file_proto_api_proto_msgTypes[6]
+	mi := &file_proto_api_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -903,7 +1089,7 @@ func (x *GrpcService) String() string {
 func (*GrpcService) ProtoMessage() {}
 
 func (x *GrpcService) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[6]
+	mi := &file_proto_api_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -916,7 +1102,7 @@ func (x *GrpcService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrpcService.ProtoReflect.Descriptor instead.
 func (*GrpcService) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{6}
+	return file_proto_api_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GrpcService) GetName() string {
@@ -955,7 +1141,7 @@ type GrpcProblem struct {
 
 func (x *GrpcProblem) Reset() {
 	*x = GrpcProblem{}
-	mi := &file_proto_api_proto_msgTypes[7]
+	mi := &file_proto_api_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -967,7 +1153,7 @@ func (x *GrpcProblem) String() string {
 func (*GrpcProblem) ProtoMessage() {}
 
 func (x *GrpcProblem) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[7]
+	mi := &file_proto_api_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -980,7 +1166,7 @@ func (x *GrpcProblem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrpcProblem.ProtoReflect.Descriptor instead.
 func (*GrpcProblem) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{7}
+	return file_proto_api_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GrpcProblem) GetKind() GrpcProblemKind {
@@ -1018,7 +1204,7 @@ type InspectOpenApiRequest struct {
 
 func (x *InspectOpenApiRequest) Reset() {
 	*x = InspectOpenApiRequest{}
-	mi := &file_proto_api_proto_msgTypes[8]
+	mi := &file_proto_api_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1030,7 +1216,7 @@ func (x *InspectOpenApiRequest) String() string {
 func (*InspectOpenApiRequest) ProtoMessage() {}
 
 func (x *InspectOpenApiRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[8]
+	mi := &file_proto_api_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1043,7 +1229,7 @@ func (x *InspectOpenApiRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectOpenApiRequest.ProtoReflect.Descriptor instead.
 func (*InspectOpenApiRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{8}
+	return file_proto_api_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *InspectOpenApiRequest) GetOpenapi() *OpenApiApp {
@@ -1065,7 +1251,7 @@ type InspectOpenApiResponse struct {
 
 func (x *InspectOpenApiResponse) Reset() {
 	*x = InspectOpenApiResponse{}
-	mi := &file_proto_api_proto_msgTypes[9]
+	mi := &file_proto_api_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1077,7 +1263,7 @@ func (x *InspectOpenApiResponse) String() string {
 func (*InspectOpenApiResponse) ProtoMessage() {}
 
 func (x *InspectOpenApiResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[9]
+	mi := &file_proto_api_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1090,7 +1276,7 @@ func (x *InspectOpenApiResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectOpenApiResponse.ProtoReflect.Descriptor instead.
 func (*InspectOpenApiResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{9}
+	return file_proto_api_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *InspectOpenApiResponse) GetDocument() *OpenApiDocument {
@@ -1131,7 +1317,7 @@ type OpenApiDocument struct {
 
 func (x *OpenApiDocument) Reset() {
 	*x = OpenApiDocument{}
-	mi := &file_proto_api_proto_msgTypes[10]
+	mi := &file_proto_api_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1143,7 +1329,7 @@ func (x *OpenApiDocument) String() string {
 func (*OpenApiDocument) ProtoMessage() {}
 
 func (x *OpenApiDocument) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[10]
+	mi := &file_proto_api_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1156,7 +1342,7 @@ func (x *OpenApiDocument) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenApiDocument.ProtoReflect.Descriptor instead.
 func (*OpenApiDocument) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{10}
+	return file_proto_api_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *OpenApiDocument) GetTitle() string {
@@ -1233,7 +1419,7 @@ type OpenApiServer struct {
 
 func (x *OpenApiServer) Reset() {
 	*x = OpenApiServer{}
-	mi := &file_proto_api_proto_msgTypes[11]
+	mi := &file_proto_api_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1245,7 +1431,7 @@ func (x *OpenApiServer) String() string {
 func (*OpenApiServer) ProtoMessage() {}
 
 func (x *OpenApiServer) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[11]
+	mi := &file_proto_api_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1258,7 +1444,7 @@ func (x *OpenApiServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenApiServer.ProtoReflect.Descriptor instead.
 func (*OpenApiServer) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{11}
+	return file_proto_api_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *OpenApiServer) GetUrl() string {
@@ -1297,7 +1483,7 @@ type OpenApiServerVariable struct {
 
 func (x *OpenApiServerVariable) Reset() {
 	*x = OpenApiServerVariable{}
-	mi := &file_proto_api_proto_msgTypes[12]
+	mi := &file_proto_api_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1309,7 +1495,7 @@ func (x *OpenApiServerVariable) String() string {
 func (*OpenApiServerVariable) ProtoMessage() {}
 
 func (x *OpenApiServerVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[12]
+	mi := &file_proto_api_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1322,7 +1508,7 @@ func (x *OpenApiServerVariable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenApiServerVariable.ProtoReflect.Descriptor instead.
 func (*OpenApiServerVariable) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{12}
+	return file_proto_api_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *OpenApiServerVariable) GetName() string {
@@ -1380,7 +1566,7 @@ type OpenApiSecurityScheme struct {
 
 func (x *OpenApiSecurityScheme) Reset() {
 	*x = OpenApiSecurityScheme{}
-	mi := &file_proto_api_proto_msgTypes[13]
+	mi := &file_proto_api_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1392,7 +1578,7 @@ func (x *OpenApiSecurityScheme) String() string {
 func (*OpenApiSecurityScheme) ProtoMessage() {}
 
 func (x *OpenApiSecurityScheme) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[13]
+	mi := &file_proto_api_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1405,7 +1591,7 @@ func (x *OpenApiSecurityScheme) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenApiSecurityScheme.ProtoReflect.Descriptor instead.
 func (*OpenApiSecurityScheme) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{13}
+	return file_proto_api_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *OpenApiSecurityScheme) GetKey() string {
@@ -1493,7 +1679,7 @@ type OpenApiProblem struct {
 
 func (x *OpenApiProblem) Reset() {
 	*x = OpenApiProblem{}
-	mi := &file_proto_api_proto_msgTypes[14]
+	mi := &file_proto_api_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1505,7 +1691,7 @@ func (x *OpenApiProblem) String() string {
 func (*OpenApiProblem) ProtoMessage() {}
 
 func (x *OpenApiProblem) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[14]
+	mi := &file_proto_api_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1518,7 +1704,7 @@ func (x *OpenApiProblem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenApiProblem.ProtoReflect.Descriptor instead.
 func (*OpenApiProblem) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{14}
+	return file_proto_api_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *OpenApiProblem) GetKind() OpenApiProblemKind {
@@ -1557,7 +1743,7 @@ type InspectMcpRequest struct {
 
 func (x *InspectMcpRequest) Reset() {
 	*x = InspectMcpRequest{}
-	mi := &file_proto_api_proto_msgTypes[15]
+	mi := &file_proto_api_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1569,7 +1755,7 @@ func (x *InspectMcpRequest) String() string {
 func (*InspectMcpRequest) ProtoMessage() {}
 
 func (x *InspectMcpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[15]
+	mi := &file_proto_api_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1582,7 +1768,7 @@ func (x *InspectMcpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectMcpRequest.ProtoReflect.Descriptor instead.
 func (*InspectMcpRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{15}
+	return file_proto_api_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *InspectMcpRequest) GetMcp() *McpApp {
@@ -1604,7 +1790,7 @@ type InspectMcpResponse struct {
 
 func (x *InspectMcpResponse) Reset() {
 	*x = InspectMcpResponse{}
-	mi := &file_proto_api_proto_msgTypes[16]
+	mi := &file_proto_api_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1616,7 +1802,7 @@ func (x *InspectMcpResponse) String() string {
 func (*InspectMcpResponse) ProtoMessage() {}
 
 func (x *InspectMcpResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[16]
+	mi := &file_proto_api_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1629,7 +1815,7 @@ func (x *InspectMcpResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectMcpResponse.ProtoReflect.Descriptor instead.
 func (*InspectMcpResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{16}
+	return file_proto_api_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *InspectMcpResponse) GetServer() *McpServer {
@@ -1672,7 +1858,7 @@ type McpServer struct {
 
 func (x *McpServer) Reset() {
 	*x = McpServer{}
-	mi := &file_proto_api_proto_msgTypes[17]
+	mi := &file_proto_api_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1684,7 +1870,7 @@ func (x *McpServer) String() string {
 func (*McpServer) ProtoMessage() {}
 
 func (x *McpServer) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[17]
+	mi := &file_proto_api_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1697,7 +1883,7 @@ func (x *McpServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use McpServer.ProtoReflect.Descriptor instead.
 func (*McpServer) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{17}
+	return file_proto_api_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *McpServer) GetName() string {
@@ -1791,7 +1977,7 @@ type McpTool struct {
 
 func (x *McpTool) Reset() {
 	*x = McpTool{}
-	mi := &file_proto_api_proto_msgTypes[18]
+	mi := &file_proto_api_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1803,7 +1989,7 @@ func (x *McpTool) String() string {
 func (*McpTool) ProtoMessage() {}
 
 func (x *McpTool) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[18]
+	mi := &file_proto_api_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1816,7 +2002,7 @@ func (x *McpTool) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use McpTool.ProtoReflect.Descriptor instead.
 func (*McpTool) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{18}
+	return file_proto_api_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *McpTool) GetName() string {
@@ -1862,7 +2048,7 @@ type McpProblem struct {
 
 func (x *McpProblem) Reset() {
 	*x = McpProblem{}
-	mi := &file_proto_api_proto_msgTypes[19]
+	mi := &file_proto_api_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1874,7 +2060,7 @@ func (x *McpProblem) String() string {
 func (*McpProblem) ProtoMessage() {}
 
 func (x *McpProblem) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[19]
+	mi := &file_proto_api_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1887,7 +2073,7 @@ func (x *McpProblem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use McpProblem.ProtoReflect.Descriptor instead.
 func (*McpProblem) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{19}
+	return file_proto_api_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *McpProblem) GetKind() McpProblemKind {
@@ -1923,7 +2109,7 @@ type CompileResponse struct {
 
 func (x *CompileResponse) Reset() {
 	*x = CompileResponse{}
-	mi := &file_proto_api_proto_msgTypes[20]
+	mi := &file_proto_api_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1935,7 +2121,7 @@ func (x *CompileResponse) String() string {
 func (*CompileResponse) ProtoMessage() {}
 
 func (x *CompileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[20]
+	mi := &file_proto_api_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1948,7 +2134,7 @@ func (x *CompileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompileResponse.ProtoReflect.Descriptor instead.
 func (*CompileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{20}
+	return file_proto_api_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CompileResponse) GetStatus() CompileStatus {
@@ -1989,7 +2175,7 @@ type Log struct {
 
 func (x *Log) Reset() {
 	*x = Log{}
-	mi := &file_proto_api_proto_msgTypes[21]
+	mi := &file_proto_api_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2001,7 +2187,7 @@ func (x *Log) String() string {
 func (*Log) ProtoMessage() {}
 
 func (x *Log) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[21]
+	mi := &file_proto_api_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2014,7 +2200,7 @@ func (x *Log) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Log.ProtoReflect.Descriptor instead.
 func (*Log) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{21}
+	return file_proto_api_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Log) GetLevel() LogLevel {
@@ -2041,7 +2227,7 @@ type Source struct {
 
 func (x *Source) Reset() {
 	*x = Source{}
-	mi := &file_proto_api_proto_msgTypes[22]
+	mi := &file_proto_api_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2053,7 +2239,7 @@ func (x *Source) String() string {
 func (*Source) ProtoMessage() {}
 
 func (x *Source) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[22]
+	mi := &file_proto_api_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2066,7 +2252,7 @@ func (x *Source) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Source.ProtoReflect.Descriptor instead.
 func (*Source) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{22}
+	return file_proto_api_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Source) GetPath() string {
@@ -2091,7 +2277,7 @@ type GetConfigurationRequest struct {
 
 func (x *GetConfigurationRequest) Reset() {
 	*x = GetConfigurationRequest{}
-	mi := &file_proto_api_proto_msgTypes[23]
+	mi := &file_proto_api_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2103,7 +2289,7 @@ func (x *GetConfigurationRequest) String() string {
 func (*GetConfigurationRequest) ProtoMessage() {}
 
 func (x *GetConfigurationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[23]
+	mi := &file_proto_api_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2116,7 +2302,7 @@ func (x *GetConfigurationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigurationRequest.ProtoReflect.Descriptor instead.
 func (*GetConfigurationRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{23}
+	return file_proto_api_proto_rawDescGZIP(), []int{26}
 }
 
 type GetConfigurationResponse struct {
@@ -2134,7 +2320,7 @@ type GetConfigurationResponse struct {
 
 func (x *GetConfigurationResponse) Reset() {
 	*x = GetConfigurationResponse{}
-	mi := &file_proto_api_proto_msgTypes[24]
+	mi := &file_proto_api_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2146,7 +2332,7 @@ func (x *GetConfigurationResponse) String() string {
 func (*GetConfigurationResponse) ProtoMessage() {}
 
 func (x *GetConfigurationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[24]
+	mi := &file_proto_api_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2159,7 +2345,7 @@ func (x *GetConfigurationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigurationResponse.ProtoReflect.Descriptor instead.
 func (*GetConfigurationResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{24}
+	return file_proto_api_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetConfigurationResponse) GetConfiguration() *Configuration {
@@ -2215,7 +2401,7 @@ type Runtime struct {
 
 func (x *Runtime) Reset() {
 	*x = Runtime{}
-	mi := &file_proto_api_proto_msgTypes[25]
+	mi := &file_proto_api_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2227,7 +2413,7 @@ func (x *Runtime) String() string {
 func (*Runtime) ProtoMessage() {}
 
 func (x *Runtime) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[25]
+	mi := &file_proto_api_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2240,7 +2426,7 @@ func (x *Runtime) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Runtime.ProtoReflect.Descriptor instead.
 func (*Runtime) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{25}
+	return file_proto_api_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *Runtime) GetCanUpdateConfiguration() bool {
@@ -2288,7 +2474,7 @@ type VariableStatus struct {
 
 func (x *VariableStatus) Reset() {
 	*x = VariableStatus{}
-	mi := &file_proto_api_proto_msgTypes[26]
+	mi := &file_proto_api_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2300,7 +2486,7 @@ func (x *VariableStatus) String() string {
 func (*VariableStatus) ProtoMessage() {}
 
 func (x *VariableStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[26]
+	mi := &file_proto_api_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2313,7 +2499,7 @@ func (x *VariableStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VariableStatus.ProtoReflect.Descriptor instead.
 func (*VariableStatus) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{26}
+	return file_proto_api_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *VariableStatus) GetName() string {
@@ -2349,7 +2535,7 @@ type SetStoredValueRequest struct {
 
 func (x *SetStoredValueRequest) Reset() {
 	*x = SetStoredValueRequest{}
-	mi := &file_proto_api_proto_msgTypes[27]
+	mi := &file_proto_api_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2361,7 +2547,7 @@ func (x *SetStoredValueRequest) String() string {
 func (*SetStoredValueRequest) ProtoMessage() {}
 
 func (x *SetStoredValueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[27]
+	mi := &file_proto_api_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2374,7 +2560,7 @@ func (x *SetStoredValueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetStoredValueRequest.ProtoReflect.Descriptor instead.
 func (*SetStoredValueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{27}
+	return file_proto_api_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SetStoredValueRequest) GetName() string {
@@ -2400,7 +2586,7 @@ type ClearStoredValueRequest struct {
 
 func (x *ClearStoredValueRequest) Reset() {
 	*x = ClearStoredValueRequest{}
-	mi := &file_proto_api_proto_msgTypes[28]
+	mi := &file_proto_api_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2412,7 +2598,7 @@ func (x *ClearStoredValueRequest) String() string {
 func (*ClearStoredValueRequest) ProtoMessage() {}
 
 func (x *ClearStoredValueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[28]
+	mi := &file_proto_api_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2425,7 +2611,7 @@ func (x *ClearStoredValueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearStoredValueRequest.ProtoReflect.Descriptor instead.
 func (*ClearStoredValueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{28}
+	return file_proto_api_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ClearStoredValueRequest) GetName() string {
@@ -2444,7 +2630,7 @@ type StoredValueResponse struct {
 
 func (x *StoredValueResponse) Reset() {
 	*x = StoredValueResponse{}
-	mi := &file_proto_api_proto_msgTypes[29]
+	mi := &file_proto_api_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2456,7 +2642,7 @@ func (x *StoredValueResponse) String() string {
 func (*StoredValueResponse) ProtoMessage() {}
 
 func (x *StoredValueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[29]
+	mi := &file_proto_api_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2469,7 +2655,7 @@ func (x *StoredValueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoredValueResponse.ProtoReflect.Descriptor instead.
 func (*StoredValueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{29}
+	return file_proto_api_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *StoredValueResponse) GetVariableStatus() []*VariableStatus {
@@ -2504,7 +2690,7 @@ type Script struct {
 
 func (x *Script) Reset() {
 	*x = Script{}
-	mi := &file_proto_api_proto_msgTypes[30]
+	mi := &file_proto_api_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2516,7 +2702,7 @@ func (x *Script) String() string {
 func (*Script) ProtoMessage() {}
 
 func (x *Script) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[30]
+	mi := &file_proto_api_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2529,7 +2715,7 @@ func (x *Script) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Script.ProtoReflect.Descriptor instead.
 func (*Script) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{30}
+	return file_proto_api_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Script) GetPath() string {
@@ -2568,7 +2754,7 @@ type ListScriptsRequest struct {
 
 func (x *ListScriptsRequest) Reset() {
 	*x = ListScriptsRequest{}
-	mi := &file_proto_api_proto_msgTypes[31]
+	mi := &file_proto_api_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2580,7 +2766,7 @@ func (x *ListScriptsRequest) String() string {
 func (*ListScriptsRequest) ProtoMessage() {}
 
 func (x *ListScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[31]
+	mi := &file_proto_api_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2593,7 +2779,7 @@ func (x *ListScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListScriptsRequest.ProtoReflect.Descriptor instead.
 func (*ListScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{31}
+	return file_proto_api_proto_rawDescGZIP(), []int{34}
 }
 
 type ListScriptsResponse struct {
@@ -2605,7 +2791,7 @@ type ListScriptsResponse struct {
 
 func (x *ListScriptsResponse) Reset() {
 	*x = ListScriptsResponse{}
-	mi := &file_proto_api_proto_msgTypes[32]
+	mi := &file_proto_api_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2617,7 +2803,7 @@ func (x *ListScriptsResponse) String() string {
 func (*ListScriptsResponse) ProtoMessage() {}
 
 func (x *ListScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[32]
+	mi := &file_proto_api_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2630,7 +2816,7 @@ func (x *ListScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListScriptsResponse.ProtoReflect.Descriptor instead.
 func (*ListScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{32}
+	return file_proto_api_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListScriptsResponse) GetScripts() []*Script {
@@ -2652,7 +2838,7 @@ type ReadScriptRequest struct {
 
 func (x *ReadScriptRequest) Reset() {
 	*x = ReadScriptRequest{}
-	mi := &file_proto_api_proto_msgTypes[33]
+	mi := &file_proto_api_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2664,7 +2850,7 @@ func (x *ReadScriptRequest) String() string {
 func (*ReadScriptRequest) ProtoMessage() {}
 
 func (x *ReadScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[33]
+	mi := &file_proto_api_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2677,7 +2863,7 @@ func (x *ReadScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadScriptRequest.ProtoReflect.Descriptor instead.
 func (*ReadScriptRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{33}
+	return file_proto_api_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ReadScriptRequest) GetName() string {
@@ -2696,7 +2882,7 @@ type ReadScriptResponse struct {
 
 func (x *ReadScriptResponse) Reset() {
 	*x = ReadScriptResponse{}
-	mi := &file_proto_api_proto_msgTypes[34]
+	mi := &file_proto_api_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2708,7 +2894,7 @@ func (x *ReadScriptResponse) String() string {
 func (*ReadScriptResponse) ProtoMessage() {}
 
 func (x *ReadScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[34]
+	mi := &file_proto_api_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2721,7 +2907,7 @@ func (x *ReadScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadScriptResponse.ProtoReflect.Descriptor instead.
 func (*ReadScriptResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{34}
+	return file_proto_api_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ReadScriptResponse) GetScript() *Script {
@@ -2755,7 +2941,7 @@ type Configuration struct {
 
 func (x *Configuration) Reset() {
 	*x = Configuration{}
-	mi := &file_proto_api_proto_msgTypes[35]
+	mi := &file_proto_api_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2767,7 +2953,7 @@ func (x *Configuration) String() string {
 func (*Configuration) ProtoMessage() {}
 
 func (x *Configuration) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[35]
+	mi := &file_proto_api_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2780,7 +2966,7 @@ func (x *Configuration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Configuration.ProtoReflect.Descriptor instead.
 func (*Configuration) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{35}
+	return file_proto_api_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *Configuration) GetPathPrefix() string {
@@ -2826,7 +3012,7 @@ type ConfigurationApp struct {
 
 func (x *ConfigurationApp) Reset() {
 	*x = ConfigurationApp{}
-	mi := &file_proto_api_proto_msgTypes[36]
+	mi := &file_proto_api_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2838,7 +3024,7 @@ func (x *ConfigurationApp) String() string {
 func (*ConfigurationApp) ProtoMessage() {}
 
 func (x *ConfigurationApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[36]
+	mi := &file_proto_api_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2851,7 +3037,7 @@ func (x *ConfigurationApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigurationApp.ProtoReflect.Descriptor instead.
 func (*ConfigurationApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{36}
+	return file_proto_api_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ConfigurationApp) GetName() string {
@@ -3005,7 +3191,7 @@ type GrpcApp struct {
 
 func (x *GrpcApp) Reset() {
 	*x = GrpcApp{}
-	mi := &file_proto_api_proto_msgTypes[37]
+	mi := &file_proto_api_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3017,7 +3203,7 @@ func (x *GrpcApp) String() string {
 func (*GrpcApp) ProtoMessage() {}
 
 func (x *GrpcApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[37]
+	mi := &file_proto_api_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3030,7 +3216,7 @@ func (x *GrpcApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrpcApp.ProtoReflect.Descriptor instead.
 func (*GrpcApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{37}
+	return file_proto_api_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GrpcApp) GetUrl() string {
@@ -3143,7 +3329,7 @@ type TwirpApp struct {
 
 func (x *TwirpApp) Reset() {
 	*x = TwirpApp{}
-	mi := &file_proto_api_proto_msgTypes[38]
+	mi := &file_proto_api_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3155,7 +3341,7 @@ func (x *TwirpApp) String() string {
 func (*TwirpApp) ProtoMessage() {}
 
 func (x *TwirpApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[38]
+	mi := &file_proto_api_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3168,7 +3354,7 @@ func (x *TwirpApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TwirpApp.ProtoReflect.Descriptor instead.
 func (*TwirpApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{38}
+	return file_proto_api_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *TwirpApp) GetUrl() string {
@@ -3220,7 +3406,7 @@ type OpenApiApp struct {
 
 func (x *OpenApiApp) Reset() {
 	*x = OpenApiApp{}
-	mi := &file_proto_api_proto_msgTypes[39]
+	mi := &file_proto_api_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3232,7 +3418,7 @@ func (x *OpenApiApp) String() string {
 func (*OpenApiApp) ProtoMessage() {}
 
 func (x *OpenApiApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[39]
+	mi := &file_proto_api_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3245,7 +3431,7 @@ func (x *OpenApiApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenApiApp.ProtoReflect.Descriptor instead.
 func (*OpenApiApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{39}
+	return file_proto_api_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *OpenApiApp) GetSpecUrl() string {
@@ -3345,7 +3531,7 @@ type OpenAiApp struct {
 
 func (x *OpenAiApp) Reset() {
 	*x = OpenAiApp{}
-	mi := &file_proto_api_proto_msgTypes[40]
+	mi := &file_proto_api_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3357,7 +3543,7 @@ func (x *OpenAiApp) String() string {
 func (*OpenAiApp) ProtoMessage() {}
 
 func (x *OpenAiApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[40]
+	mi := &file_proto_api_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3370,7 +3556,7 @@ func (x *OpenAiApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenAiApp.ProtoReflect.Descriptor instead.
 func (*OpenAiApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{40}
+	return file_proto_api_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *OpenAiApp) GetEndpoint() string {
@@ -3426,7 +3612,7 @@ type FolderApp struct {
 
 func (x *FolderApp) Reset() {
 	*x = FolderApp{}
-	mi := &file_proto_api_proto_msgTypes[41]
+	mi := &file_proto_api_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3438,7 +3624,7 @@ func (x *FolderApp) String() string {
 func (*FolderApp) ProtoMessage() {}
 
 func (x *FolderApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[41]
+	mi := &file_proto_api_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3451,7 +3637,7 @@ func (x *FolderApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FolderApp.ProtoReflect.Descriptor instead.
 func (*FolderApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{41}
+	return file_proto_api_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *FolderApp) GetPath() string {
@@ -3487,7 +3673,7 @@ type McpApp struct {
 
 func (x *McpApp) Reset() {
 	*x = McpApp{}
-	mi := &file_proto_api_proto_msgTypes[42]
+	mi := &file_proto_api_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3499,7 +3685,7 @@ func (x *McpApp) String() string {
 func (*McpApp) ProtoMessage() {}
 
 func (x *McpApp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[42]
+	mi := &file_proto_api_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3512,7 +3698,7 @@ func (x *McpApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use McpApp.ProtoReflect.Descriptor instead.
 func (*McpApp) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{42}
+	return file_proto_api_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *McpApp) GetUrl() string {
@@ -3559,7 +3745,7 @@ type UpdateConfigurationRequest struct {
 
 func (x *UpdateConfigurationRequest) Reset() {
 	*x = UpdateConfigurationRequest{}
-	mi := &file_proto_api_proto_msgTypes[43]
+	mi := &file_proto_api_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3571,7 +3757,7 @@ func (x *UpdateConfigurationRequest) String() string {
 func (*UpdateConfigurationRequest) ProtoMessage() {}
 
 func (x *UpdateConfigurationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[43]
+	mi := &file_proto_api_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3584,7 +3770,7 @@ func (x *UpdateConfigurationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigurationRequest.ProtoReflect.Descriptor instead.
 func (*UpdateConfigurationRequest) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{43}
+	return file_proto_api_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *UpdateConfigurationRequest) GetConfiguration() *Configuration {
@@ -3605,7 +3791,7 @@ type UpdateConfigurationResponse struct {
 
 func (x *UpdateConfigurationResponse) Reset() {
 	*x = UpdateConfigurationResponse{}
-	mi := &file_proto_api_proto_msgTypes[44]
+	mi := &file_proto_api_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3617,7 +3803,7 @@ func (x *UpdateConfigurationResponse) String() string {
 func (*UpdateConfigurationResponse) ProtoMessage() {}
 
 func (x *UpdateConfigurationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_api_proto_msgTypes[44]
+	mi := &file_proto_api_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3630,7 +3816,7 @@ func (x *UpdateConfigurationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigurationResponse.ProtoReflect.Descriptor instead.
 func (*UpdateConfigurationResponse) Descriptor() ([]byte, []int) {
-	return file_proto_api_proto_rawDescGZIP(), []int{44}
+	return file_proto_api_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *UpdateConfigurationResponse) GetConfiguration() *Configuration {
@@ -3651,7 +3837,20 @@ var File_proto_api_proto protoreflect.FileDescriptor
 
 const file_proto_api_proto_rawDesc = "" +
 	"\n" +
-	"\x0fproto/api.proto\"\\\n" +
+	"\x0fproto/api.proto\"O\n" +
+	"\x1dGetMethodDocumentationRequest\x12\x16\n" +
+	"\x06target\x18\x01 \x01(\tR\x06target\x12\x16\n" +
+	"\x06method\x18\x02 \x01(\tR\x06method\"\\\n" +
+	"\x1eGetMethodDocumentationResponse\x12:\n" +
+	"\rdocumentation\x18\x01 \x01(\v2\x14.MethodDocumentationR\rdocumentation\"\xa9\x01\n" +
+	"\x13MethodDocumentation\x12\x18\n" +
+	"\asummary\x18\x01 \x01(\tR\asummary\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x1e\n" +
+	"\n" +
+	"deprecated\x18\x03 \x01(\bR\n" +
+	"deprecated\x12\x1a\n" +
+	"\bdocument\x18\x04 \x01(\tR\bdocument\x12\x1a\n" +
+	"\blanguage\x18\x05 \x01(\tR\blanguage\"\\\n" +
 	"\x0eCompileRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -3951,7 +4150,7 @@ const file_proto_api_proto_rawDesc = "" +
 	"\x15VARIABLE_SOURCE_UNSET\x10\x00\x12\x18\n" +
 	"\x14VARIABLE_SOURCE_FILE\x10\x01\x12\x1c\n" +
 	"\x18VARIABLE_SOURCE_KEYCHAIN\x10\x02\x12\x1f\n" +
-	"\x1bVARIABLE_SOURCE_ENVIRONMENT\x10\x032\xa5\x05\n" +
+	"\x1bVARIABLE_SOURCE_ENVIRONMENT\x10\x032\x80\x06\n" +
 	"\x03Api\x12,\n" +
 	"\aCompile\x12\x0f.CompileRequest\x1a\x10.CompileResponse\x12,\n" +
 	"\aOpenApp\x12\x0f.OpenAppRequest\x1a\x10.OpenAppResponse\x12A\n" +
@@ -3965,7 +4164,8 @@ const file_proto_api_proto_rawDesc = "" +
 	"\x10ClearStoredValue\x12\x18.ClearStoredValueRequest\x1a\x14.StoredValueResponse\x128\n" +
 	"\vListScripts\x12\x13.ListScriptsRequest\x1a\x14.ListScriptsResponse\x125\n" +
 	"\n" +
-	"ReadScript\x12\x12.ReadScriptRequest\x1a\x13.ReadScriptResponseB\tZ\apkg/apib\x06proto3"
+	"ReadScript\x12\x12.ReadScriptRequest\x1a\x13.ReadScriptResponse\x12Y\n" +
+	"\x16GetMethodDocumentation\x12\x1e.GetMethodDocumentationRequest\x1a\x1f.GetMethodDocumentationResponseB\tZ\apkg/apib\x06proto3"
 
 var (
 	file_proto_api_proto_rawDescOnce sync.Once
@@ -3980,143 +4180,149 @@ func file_proto_api_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_api_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_proto_api_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_proto_api_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
 var file_proto_api_proto_goTypes = []any{
-	(OpenStatus)(0),                     // 0: OpenStatus
-	(GrpcProblemKind)(0),                // 1: GrpcProblemKind
-	(OpenApiProblemKind)(0),             // 2: OpenApiProblemKind
-	(McpProblemKind)(0),                 // 3: McpProblemKind
-	(CompileStatus)(0),                  // 4: CompileStatus
-	(LogLevel)(0),                       // 5: LogLevel
-	(VariableSource)(0),                 // 6: VariableSource
-	(*CompileRequest)(nil),              // 7: CompileRequest
-	(*OpenAppRequest)(nil),              // 8: OpenAppRequest
-	(*OpenAppResponse)(nil),             // 9: OpenAppResponse
-	(*InspectGrpcRequest)(nil),          // 10: InspectGrpcRequest
-	(*InspectGrpcResponse)(nil),         // 11: InspectGrpcResponse
-	(*GrpcServer)(nil),                  // 12: GrpcServer
-	(*GrpcService)(nil),                 // 13: GrpcService
-	(*GrpcProblem)(nil),                 // 14: GrpcProblem
-	(*InspectOpenApiRequest)(nil),       // 15: InspectOpenApiRequest
-	(*InspectOpenApiResponse)(nil),      // 16: InspectOpenApiResponse
-	(*OpenApiDocument)(nil),             // 17: OpenApiDocument
-	(*OpenApiServer)(nil),               // 18: OpenApiServer
-	(*OpenApiServerVariable)(nil),       // 19: OpenApiServerVariable
-	(*OpenApiSecurityScheme)(nil),       // 20: OpenApiSecurityScheme
-	(*OpenApiProblem)(nil),              // 21: OpenApiProblem
-	(*InspectMcpRequest)(nil),           // 22: InspectMcpRequest
-	(*InspectMcpResponse)(nil),          // 23: InspectMcpResponse
-	(*McpServer)(nil),                   // 24: McpServer
-	(*McpTool)(nil),                     // 25: McpTool
-	(*McpProblem)(nil),                  // 26: McpProblem
-	(*CompileResponse)(nil),             // 27: CompileResponse
-	(*Log)(nil),                         // 28: Log
-	(*Source)(nil),                      // 29: Source
-	(*GetConfigurationRequest)(nil),     // 30: GetConfigurationRequest
-	(*GetConfigurationResponse)(nil),    // 31: GetConfigurationResponse
-	(*Runtime)(nil),                     // 32: Runtime
-	(*VariableStatus)(nil),              // 33: VariableStatus
-	(*SetStoredValueRequest)(nil),       // 34: SetStoredValueRequest
-	(*ClearStoredValueRequest)(nil),     // 35: ClearStoredValueRequest
-	(*StoredValueResponse)(nil),         // 36: StoredValueResponse
-	(*Script)(nil),                      // 37: Script
-	(*ListScriptsRequest)(nil),          // 38: ListScriptsRequest
-	(*ListScriptsResponse)(nil),         // 39: ListScriptsResponse
-	(*ReadScriptRequest)(nil),           // 40: ReadScriptRequest
-	(*ReadScriptResponse)(nil),          // 41: ReadScriptResponse
-	(*Configuration)(nil),               // 42: Configuration
-	(*ConfigurationApp)(nil),            // 43: ConfigurationApp
-	(*GrpcApp)(nil),                     // 44: GrpcApp
-	(*TwirpApp)(nil),                    // 45: TwirpApp
-	(*OpenApiApp)(nil),                  // 46: OpenApiApp
-	(*OpenAiApp)(nil),                   // 47: OpenAiApp
-	(*FolderApp)(nil),                   // 48: FolderApp
-	(*McpApp)(nil),                      // 49: McpApp
-	(*UpdateConfigurationRequest)(nil),  // 50: UpdateConfigurationRequest
-	(*UpdateConfigurationResponse)(nil), // 51: UpdateConfigurationResponse
-	nil,                                 // 52: Configuration.VariablesEntry
-	nil,                                 // 53: GrpcApp.HeadersEntry
-	nil,                                 // 54: TwirpApp.HeadersEntry
-	nil,                                 // 55: OpenApiApp.HeadersEntry
-	nil,                                 // 56: OpenAiApp.HeadersEntry
-	nil,                                 // 57: McpApp.HeadersEntry
+	(OpenStatus)(0),                        // 0: OpenStatus
+	(GrpcProblemKind)(0),                   // 1: GrpcProblemKind
+	(OpenApiProblemKind)(0),                // 2: OpenApiProblemKind
+	(McpProblemKind)(0),                    // 3: McpProblemKind
+	(CompileStatus)(0),                     // 4: CompileStatus
+	(LogLevel)(0),                          // 5: LogLevel
+	(VariableSource)(0),                    // 6: VariableSource
+	(*GetMethodDocumentationRequest)(nil),  // 7: GetMethodDocumentationRequest
+	(*GetMethodDocumentationResponse)(nil), // 8: GetMethodDocumentationResponse
+	(*MethodDocumentation)(nil),            // 9: MethodDocumentation
+	(*CompileRequest)(nil),                 // 10: CompileRequest
+	(*OpenAppRequest)(nil),                 // 11: OpenAppRequest
+	(*OpenAppResponse)(nil),                // 12: OpenAppResponse
+	(*InspectGrpcRequest)(nil),             // 13: InspectGrpcRequest
+	(*InspectGrpcResponse)(nil),            // 14: InspectGrpcResponse
+	(*GrpcServer)(nil),                     // 15: GrpcServer
+	(*GrpcService)(nil),                    // 16: GrpcService
+	(*GrpcProblem)(nil),                    // 17: GrpcProblem
+	(*InspectOpenApiRequest)(nil),          // 18: InspectOpenApiRequest
+	(*InspectOpenApiResponse)(nil),         // 19: InspectOpenApiResponse
+	(*OpenApiDocument)(nil),                // 20: OpenApiDocument
+	(*OpenApiServer)(nil),                  // 21: OpenApiServer
+	(*OpenApiServerVariable)(nil),          // 22: OpenApiServerVariable
+	(*OpenApiSecurityScheme)(nil),          // 23: OpenApiSecurityScheme
+	(*OpenApiProblem)(nil),                 // 24: OpenApiProblem
+	(*InspectMcpRequest)(nil),              // 25: InspectMcpRequest
+	(*InspectMcpResponse)(nil),             // 26: InspectMcpResponse
+	(*McpServer)(nil),                      // 27: McpServer
+	(*McpTool)(nil),                        // 28: McpTool
+	(*McpProblem)(nil),                     // 29: McpProblem
+	(*CompileResponse)(nil),                // 30: CompileResponse
+	(*Log)(nil),                            // 31: Log
+	(*Source)(nil),                         // 32: Source
+	(*GetConfigurationRequest)(nil),        // 33: GetConfigurationRequest
+	(*GetConfigurationResponse)(nil),       // 34: GetConfigurationResponse
+	(*Runtime)(nil),                        // 35: Runtime
+	(*VariableStatus)(nil),                 // 36: VariableStatus
+	(*SetStoredValueRequest)(nil),          // 37: SetStoredValueRequest
+	(*ClearStoredValueRequest)(nil),        // 38: ClearStoredValueRequest
+	(*StoredValueResponse)(nil),            // 39: StoredValueResponse
+	(*Script)(nil),                         // 40: Script
+	(*ListScriptsRequest)(nil),             // 41: ListScriptsRequest
+	(*ListScriptsResponse)(nil),            // 42: ListScriptsResponse
+	(*ReadScriptRequest)(nil),              // 43: ReadScriptRequest
+	(*ReadScriptResponse)(nil),             // 44: ReadScriptResponse
+	(*Configuration)(nil),                  // 45: Configuration
+	(*ConfigurationApp)(nil),               // 46: ConfigurationApp
+	(*GrpcApp)(nil),                        // 47: GrpcApp
+	(*TwirpApp)(nil),                       // 48: TwirpApp
+	(*OpenApiApp)(nil),                     // 49: OpenApiApp
+	(*OpenAiApp)(nil),                      // 50: OpenAiApp
+	(*FolderApp)(nil),                      // 51: FolderApp
+	(*McpApp)(nil),                         // 52: McpApp
+	(*UpdateConfigurationRequest)(nil),     // 53: UpdateConfigurationRequest
+	(*UpdateConfigurationResponse)(nil),    // 54: UpdateConfigurationResponse
+	nil,                                    // 55: Configuration.VariablesEntry
+	nil,                                    // 56: GrpcApp.HeadersEntry
+	nil,                                    // 57: TwirpApp.HeadersEntry
+	nil,                                    // 58: OpenApiApp.HeadersEntry
+	nil,                                    // 59: OpenAiApp.HeadersEntry
+	nil,                                    // 60: McpApp.HeadersEntry
 }
 var file_proto_api_proto_depIdxs = []int32{
-	43, // 0: OpenAppRequest.app:type_name -> ConfigurationApp
-	0,  // 1: OpenAppResponse.status:type_name -> OpenStatus
-	28, // 2: OpenAppResponse.logs:type_name -> Log
-	44, // 3: InspectGrpcRequest.grpc:type_name -> GrpcApp
-	12, // 4: InspectGrpcResponse.server:type_name -> GrpcServer
-	14, // 5: InspectGrpcResponse.problem:type_name -> GrpcProblem
-	13, // 6: GrpcServer.services:type_name -> GrpcService
-	1,  // 7: GrpcProblem.kind:type_name -> GrpcProblemKind
-	46, // 8: InspectOpenApiRequest.openapi:type_name -> OpenApiApp
-	17, // 9: InspectOpenApiResponse.document:type_name -> OpenApiDocument
-	21, // 10: InspectOpenApiResponse.problem:type_name -> OpenApiProblem
-	18, // 11: OpenApiDocument.servers:type_name -> OpenApiServer
-	20, // 12: OpenApiDocument.security_schemes:type_name -> OpenApiSecurityScheme
-	19, // 13: OpenApiServer.variables:type_name -> OpenApiServerVariable
-	2,  // 14: OpenApiProblem.kind:type_name -> OpenApiProblemKind
-	49, // 15: InspectMcpRequest.mcp:type_name -> McpApp
-	24, // 16: InspectMcpResponse.server:type_name -> McpServer
-	26, // 17: InspectMcpResponse.problem:type_name -> McpProblem
-	25, // 18: McpServer.tools:type_name -> McpTool
-	3,  // 19: McpProblem.kind:type_name -> McpProblemKind
-	4,  // 20: CompileResponse.status:type_name -> CompileStatus
-	28, // 21: CompileResponse.logs:type_name -> Log
-	29, // 22: CompileResponse.sources:type_name -> Source
-	5,  // 23: Log.level:type_name -> LogLevel
-	42, // 24: GetConfigurationResponse.configuration:type_name -> Configuration
-	28, // 25: GetConfigurationResponse.logs:type_name -> Log
-	33, // 26: GetConfigurationResponse.variable_status:type_name -> VariableStatus
-	32, // 27: GetConfigurationResponse.runtime:type_name -> Runtime
-	6,  // 28: VariableStatus.source:type_name -> VariableSource
-	33, // 29: StoredValueResponse.variable_status:type_name -> VariableStatus
-	37, // 30: ListScriptsResponse.scripts:type_name -> Script
-	37, // 31: ReadScriptResponse.script:type_name -> Script
-	43, // 32: Configuration.apps:type_name -> ConfigurationApp
-	52, // 33: Configuration.variables:type_name -> Configuration.VariablesEntry
-	44, // 34: ConfigurationApp.grpc:type_name -> GrpcApp
-	45, // 35: ConfigurationApp.twirp:type_name -> TwirpApp
-	46, // 36: ConfigurationApp.openapi:type_name -> OpenApiApp
-	47, // 37: ConfigurationApp.openai:type_name -> OpenAiApp
-	48, // 38: ConfigurationApp.folder:type_name -> FolderApp
-	49, // 39: ConfigurationApp.mcp:type_name -> McpApp
-	53, // 40: GrpcApp.headers:type_name -> GrpcApp.HeadersEntry
-	54, // 41: TwirpApp.headers:type_name -> TwirpApp.HeadersEntry
-	55, // 42: OpenApiApp.headers:type_name -> OpenApiApp.HeadersEntry
-	56, // 43: OpenAiApp.headers:type_name -> OpenAiApp.HeadersEntry
-	57, // 44: McpApp.headers:type_name -> McpApp.HeadersEntry
-	42, // 45: UpdateConfigurationRequest.configuration:type_name -> Configuration
-	42, // 46: UpdateConfigurationResponse.configuration:type_name -> Configuration
-	33, // 47: UpdateConfigurationResponse.variable_status:type_name -> VariableStatus
-	7,  // 48: Api.Compile:input_type -> CompileRequest
-	8,  // 49: Api.OpenApp:input_type -> OpenAppRequest
-	15, // 50: Api.InspectOpenApi:input_type -> InspectOpenApiRequest
-	10, // 51: Api.InspectGrpc:input_type -> InspectGrpcRequest
-	22, // 52: Api.InspectMcp:input_type -> InspectMcpRequest
-	30, // 53: Api.GetConfiguration:input_type -> GetConfigurationRequest
-	50, // 54: Api.UpdateConfiguration:input_type -> UpdateConfigurationRequest
-	34, // 55: Api.SetStoredValue:input_type -> SetStoredValueRequest
-	35, // 56: Api.ClearStoredValue:input_type -> ClearStoredValueRequest
-	38, // 57: Api.ListScripts:input_type -> ListScriptsRequest
-	40, // 58: Api.ReadScript:input_type -> ReadScriptRequest
-	27, // 59: Api.Compile:output_type -> CompileResponse
-	9,  // 60: Api.OpenApp:output_type -> OpenAppResponse
-	16, // 61: Api.InspectOpenApi:output_type -> InspectOpenApiResponse
-	11, // 62: Api.InspectGrpc:output_type -> InspectGrpcResponse
-	23, // 63: Api.InspectMcp:output_type -> InspectMcpResponse
-	31, // 64: Api.GetConfiguration:output_type -> GetConfigurationResponse
-	51, // 65: Api.UpdateConfiguration:output_type -> UpdateConfigurationResponse
-	36, // 66: Api.SetStoredValue:output_type -> StoredValueResponse
-	36, // 67: Api.ClearStoredValue:output_type -> StoredValueResponse
-	39, // 68: Api.ListScripts:output_type -> ListScriptsResponse
-	41, // 69: Api.ReadScript:output_type -> ReadScriptResponse
-	59, // [59:70] is the sub-list for method output_type
-	48, // [48:59] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	9,  // 0: GetMethodDocumentationResponse.documentation:type_name -> MethodDocumentation
+	46, // 1: OpenAppRequest.app:type_name -> ConfigurationApp
+	0,  // 2: OpenAppResponse.status:type_name -> OpenStatus
+	31, // 3: OpenAppResponse.logs:type_name -> Log
+	47, // 4: InspectGrpcRequest.grpc:type_name -> GrpcApp
+	15, // 5: InspectGrpcResponse.server:type_name -> GrpcServer
+	17, // 6: InspectGrpcResponse.problem:type_name -> GrpcProblem
+	16, // 7: GrpcServer.services:type_name -> GrpcService
+	1,  // 8: GrpcProblem.kind:type_name -> GrpcProblemKind
+	49, // 9: InspectOpenApiRequest.openapi:type_name -> OpenApiApp
+	20, // 10: InspectOpenApiResponse.document:type_name -> OpenApiDocument
+	24, // 11: InspectOpenApiResponse.problem:type_name -> OpenApiProblem
+	21, // 12: OpenApiDocument.servers:type_name -> OpenApiServer
+	23, // 13: OpenApiDocument.security_schemes:type_name -> OpenApiSecurityScheme
+	22, // 14: OpenApiServer.variables:type_name -> OpenApiServerVariable
+	2,  // 15: OpenApiProblem.kind:type_name -> OpenApiProblemKind
+	52, // 16: InspectMcpRequest.mcp:type_name -> McpApp
+	27, // 17: InspectMcpResponse.server:type_name -> McpServer
+	29, // 18: InspectMcpResponse.problem:type_name -> McpProblem
+	28, // 19: McpServer.tools:type_name -> McpTool
+	3,  // 20: McpProblem.kind:type_name -> McpProblemKind
+	4,  // 21: CompileResponse.status:type_name -> CompileStatus
+	31, // 22: CompileResponse.logs:type_name -> Log
+	32, // 23: CompileResponse.sources:type_name -> Source
+	5,  // 24: Log.level:type_name -> LogLevel
+	45, // 25: GetConfigurationResponse.configuration:type_name -> Configuration
+	31, // 26: GetConfigurationResponse.logs:type_name -> Log
+	36, // 27: GetConfigurationResponse.variable_status:type_name -> VariableStatus
+	35, // 28: GetConfigurationResponse.runtime:type_name -> Runtime
+	6,  // 29: VariableStatus.source:type_name -> VariableSource
+	36, // 30: StoredValueResponse.variable_status:type_name -> VariableStatus
+	40, // 31: ListScriptsResponse.scripts:type_name -> Script
+	40, // 32: ReadScriptResponse.script:type_name -> Script
+	46, // 33: Configuration.apps:type_name -> ConfigurationApp
+	55, // 34: Configuration.variables:type_name -> Configuration.VariablesEntry
+	47, // 35: ConfigurationApp.grpc:type_name -> GrpcApp
+	48, // 36: ConfigurationApp.twirp:type_name -> TwirpApp
+	49, // 37: ConfigurationApp.openapi:type_name -> OpenApiApp
+	50, // 38: ConfigurationApp.openai:type_name -> OpenAiApp
+	51, // 39: ConfigurationApp.folder:type_name -> FolderApp
+	52, // 40: ConfigurationApp.mcp:type_name -> McpApp
+	56, // 41: GrpcApp.headers:type_name -> GrpcApp.HeadersEntry
+	57, // 42: TwirpApp.headers:type_name -> TwirpApp.HeadersEntry
+	58, // 43: OpenApiApp.headers:type_name -> OpenApiApp.HeadersEntry
+	59, // 44: OpenAiApp.headers:type_name -> OpenAiApp.HeadersEntry
+	60, // 45: McpApp.headers:type_name -> McpApp.HeadersEntry
+	45, // 46: UpdateConfigurationRequest.configuration:type_name -> Configuration
+	45, // 47: UpdateConfigurationResponse.configuration:type_name -> Configuration
+	36, // 48: UpdateConfigurationResponse.variable_status:type_name -> VariableStatus
+	10, // 49: Api.Compile:input_type -> CompileRequest
+	11, // 50: Api.OpenApp:input_type -> OpenAppRequest
+	18, // 51: Api.InspectOpenApi:input_type -> InspectOpenApiRequest
+	13, // 52: Api.InspectGrpc:input_type -> InspectGrpcRequest
+	25, // 53: Api.InspectMcp:input_type -> InspectMcpRequest
+	33, // 54: Api.GetConfiguration:input_type -> GetConfigurationRequest
+	53, // 55: Api.UpdateConfiguration:input_type -> UpdateConfigurationRequest
+	37, // 56: Api.SetStoredValue:input_type -> SetStoredValueRequest
+	38, // 57: Api.ClearStoredValue:input_type -> ClearStoredValueRequest
+	41, // 58: Api.ListScripts:input_type -> ListScriptsRequest
+	43, // 59: Api.ReadScript:input_type -> ReadScriptRequest
+	7,  // 60: Api.GetMethodDocumentation:input_type -> GetMethodDocumentationRequest
+	30, // 61: Api.Compile:output_type -> CompileResponse
+	12, // 62: Api.OpenApp:output_type -> OpenAppResponse
+	19, // 63: Api.InspectOpenApi:output_type -> InspectOpenApiResponse
+	14, // 64: Api.InspectGrpc:output_type -> InspectGrpcResponse
+	26, // 65: Api.InspectMcp:output_type -> InspectMcpResponse
+	34, // 66: Api.GetConfiguration:output_type -> GetConfigurationResponse
+	54, // 67: Api.UpdateConfiguration:output_type -> UpdateConfigurationResponse
+	39, // 68: Api.SetStoredValue:output_type -> StoredValueResponse
+	39, // 69: Api.ClearStoredValue:output_type -> StoredValueResponse
+	42, // 70: Api.ListScripts:output_type -> ListScriptsResponse
+	44, // 71: Api.ReadScript:output_type -> ReadScriptResponse
+	8,  // 72: Api.GetMethodDocumentation:output_type -> GetMethodDocumentationResponse
+	61, // [61:73] is the sub-list for method output_type
+	49, // [49:61] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_proto_api_proto_init() }
@@ -4124,7 +4330,7 @@ func file_proto_api_proto_init() {
 	if File_proto_api_proto != nil {
 		return
 	}
-	file_proto_api_proto_msgTypes[36].OneofWrappers = []any{
+	file_proto_api_proto_msgTypes[39].OneofWrappers = []any{
 		(*ConfigurationApp_Grpc)(nil),
 		(*ConfigurationApp_Twirp)(nil),
 		(*ConfigurationApp_Openapi)(nil),
@@ -4138,7 +4344,7 @@ func file_proto_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_api_proto_rawDesc), len(file_proto_api_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   51,
+			NumMessages:   54,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/server/pkg/api/api_grpc.pb.go
+++ b/server/pkg/api/api_grpc.pb.go
@@ -19,17 +19,18 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Api_Compile_FullMethodName             = "/Api/Compile"
-	Api_OpenApp_FullMethodName             = "/Api/OpenApp"
-	Api_InspectOpenApi_FullMethodName      = "/Api/InspectOpenApi"
-	Api_InspectGrpc_FullMethodName         = "/Api/InspectGrpc"
-	Api_InspectMcp_FullMethodName          = "/Api/InspectMcp"
-	Api_GetConfiguration_FullMethodName    = "/Api/GetConfiguration"
-	Api_UpdateConfiguration_FullMethodName = "/Api/UpdateConfiguration"
-	Api_SetStoredValue_FullMethodName      = "/Api/SetStoredValue"
-	Api_ClearStoredValue_FullMethodName    = "/Api/ClearStoredValue"
-	Api_ListScripts_FullMethodName         = "/Api/ListScripts"
-	Api_ReadScript_FullMethodName          = "/Api/ReadScript"
+	Api_Compile_FullMethodName                = "/Api/Compile"
+	Api_OpenApp_FullMethodName                = "/Api/OpenApp"
+	Api_InspectOpenApi_FullMethodName         = "/Api/InspectOpenApi"
+	Api_InspectGrpc_FullMethodName            = "/Api/InspectGrpc"
+	Api_InspectMcp_FullMethodName             = "/Api/InspectMcp"
+	Api_GetConfiguration_FullMethodName       = "/Api/GetConfiguration"
+	Api_UpdateConfiguration_FullMethodName    = "/Api/UpdateConfiguration"
+	Api_SetStoredValue_FullMethodName         = "/Api/SetStoredValue"
+	Api_ClearStoredValue_FullMethodName       = "/Api/ClearStoredValue"
+	Api_ListScripts_FullMethodName            = "/Api/ListScripts"
+	Api_ReadScript_FullMethodName             = "/Api/ReadScript"
+	Api_GetMethodDocumentation_FullMethodName = "/Api/GetMethodDocumentation"
 )
 
 // ApiClient is the client API for Api service.
@@ -47,6 +48,7 @@ type ApiClient interface {
 	ClearStoredValue(ctx context.Context, in *ClearStoredValueRequest, opts ...grpc.CallOption) (*StoredValueResponse, error)
 	ListScripts(ctx context.Context, in *ListScriptsRequest, opts ...grpc.CallOption) (*ListScriptsResponse, error)
 	ReadScript(ctx context.Context, in *ReadScriptRequest, opts ...grpc.CallOption) (*ReadScriptResponse, error)
+	GetMethodDocumentation(ctx context.Context, in *GetMethodDocumentationRequest, opts ...grpc.CallOption) (*GetMethodDocumentationResponse, error)
 }
 
 type apiClient struct {
@@ -167,6 +169,16 @@ func (c *apiClient) ReadScript(ctx context.Context, in *ReadScriptRequest, opts 
 	return out, nil
 }
 
+func (c *apiClient) GetMethodDocumentation(ctx context.Context, in *GetMethodDocumentationRequest, opts ...grpc.CallOption) (*GetMethodDocumentationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMethodDocumentationResponse)
+	err := c.cc.Invoke(ctx, Api_GetMethodDocumentation_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ApiServer is the server API for Api service.
 // All implementations should embed UnimplementedApiServer
 // for forward compatibility.
@@ -182,6 +194,7 @@ type ApiServer interface {
 	ClearStoredValue(context.Context, *ClearStoredValueRequest) (*StoredValueResponse, error)
 	ListScripts(context.Context, *ListScriptsRequest) (*ListScriptsResponse, error)
 	ReadScript(context.Context, *ReadScriptRequest) (*ReadScriptResponse, error)
+	GetMethodDocumentation(context.Context, *GetMethodDocumentationRequest) (*GetMethodDocumentationResponse, error)
 }
 
 // UnimplementedApiServer should be embedded to have
@@ -223,6 +236,9 @@ func (UnimplementedApiServer) ListScripts(context.Context, *ListScriptsRequest) 
 }
 func (UnimplementedApiServer) ReadScript(context.Context, *ReadScriptRequest) (*ReadScriptResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReadScript not implemented")
+}
+func (UnimplementedApiServer) GetMethodDocumentation(context.Context, *GetMethodDocumentationRequest) (*GetMethodDocumentationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetMethodDocumentation not implemented")
 }
 func (UnimplementedApiServer) testEmbeddedByValue() {}
 
@@ -442,6 +458,24 @@ func _Api_ReadScript_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Api_GetMethodDocumentation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMethodDocumentationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ApiServer).GetMethodDocumentation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Api_GetMethodDocumentation_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ApiServer).GetMethodDocumentation(ctx, req.(*GetMethodDocumentationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Api_ServiceDesc is the grpc.ServiceDesc for Api service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -492,6 +526,10 @@ var Api_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReadScript",
 			Handler:    _Api_ReadScript_Handler,
+		},
+		{
+			MethodName: "GetMethodDocumentation",
+			Handler:    _Api_GetMethodDocumentation_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/server/pkg/api/documentation.go
+++ b/server/pkg/api/documentation.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+	"strings"
+)
+
+// GetMethodDocumentation reads one of a live app's methods back out of the document
+// its surface was generated from — what the generated proto could not carry: the
+// prose under each parameter, the examples, the response codes a method never
+// returns as values, the vendor extensions.
+//
+// It reaches the opened app by its target, the same key an invocation uses, so it
+// answers about the app as it is running rather than re-reading a document that may
+// since have moved. An app type that documents nothing, a method it does not
+// declare, or an instance replaced by a recompile all answer the same way: with
+// nothing, and not with an error. The caller is a hover.
+func (s *ApiService) GetMethodDocumentation(ctx context.Context, req *GetMethodDocumentationRequest) (*GetMethodDocumentationResponse, error) {
+	target := strings.TrimSpace(req.Target)
+	method := strings.TrimSpace(req.Method)
+	if target == "" || method == "" {
+		return &GetMethodDocumentationResponse{}, nil
+	}
+
+	documentation, ok := s.apps.Documentation(target, method)
+	if !ok {
+		return &GetMethodDocumentationResponse{}, nil
+	}
+
+	return &GetMethodDocumentationResponse{Documentation: &MethodDocumentation{
+		Summary:     documentation.Summary,
+		Description: documentation.Description,
+		Deprecated:  documentation.Deprecated,
+		Document:    documentation.Document,
+		Language:    documentation.Language,
+	}}, nil
+}

--- a/server/pkg/apps/apps.go
+++ b/server/pkg/apps/apps.go
@@ -104,6 +104,28 @@ type Instance interface {
 	Invoke(methodPath string, request []byte, headers map[string]string) (*InvokeResult, error)
 }
 
+// Documented is an app that can show where one of its methods came from. Optional:
+// an app whose surface it generated out of a document has one to show, and an app
+// that reflects a live server has nothing but what it already reported.
+type Documented interface {
+	// Documentation answers for one operation, named the way the app's methods name
+	// theirs — "GET /shows/{showId}" for an app built from a REST document.
+	Documentation(operation string) (*Documentation, bool)
+}
+
+// Documentation is one method as the document that generated it states it. The
+// generated proto carries what could be modelled; this is the rest, which is most of
+// what a person reads before writing the call.
+type Documentation struct {
+	Summary     string
+	Description string
+	Deprecated  bool
+	// The declaration as written, ready to show.
+	Document string
+	// What Document is written in, so an editor can colour it: "yaml", "json".
+	Language string
+}
+
 // InvokeResult is the outcome of a single Invoke. Body is the proto3-JSON response.
 // RequestHeaders/ResponseHeaders are what the app actually exchanged with its
 // upstream, which the transports surface to the Headers view; an in-process app with
@@ -192,6 +214,30 @@ func (m *Manager) Invoke(target string, methodPath string, request []byte, heade
 	}
 
 	return instance.Invoke(methodPath, request, headers)
+}
+
+// Documentation answers for one of a live app's operations, or reports that the app
+// has nothing to show for it — an app type that documents nothing, an operation the
+// document does not declare, or an instance that has since been replaced. A miss is
+// not an error: the caller is a hover, and a hover with nothing to say says nothing.
+func (m *Manager) Documentation(target string, operation string) (*Documentation, bool) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, false
+	}
+
+	m.mu.Lock()
+	instance, ok := m.instances[u.Host]
+	m.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+
+	documented, ok := instance.(Documented)
+	if !ok {
+		return nil, false
+	}
+	return documented.Documentation(operation)
 }
 
 func newID() (string, error) {

--- a/server/pkg/apps/apps.go
+++ b/server/pkg/apps/apps.go
@@ -87,6 +87,10 @@ type Opened struct {
 	// or "twirp"). Ignored when Instance is non-nil.
 	Target   string
 	Protocol string
+	// Document is the app's own description, as JSON, for an app the client drives
+	// as HTTP. The client reads it into the surface a script writes against, which
+	// is why nothing here compiles a proto for one.
+	Document []byte
 }
 
 // OpenResult tells the caller how a freshly opened app is compiled and invoked.
@@ -94,6 +98,7 @@ type OpenResult struct {
 	ProtoDir string
 	Target   string
 	Protocol string
+	Document []byte
 }
 
 // Instance is a live, opened app that can invoke its generated methods.
@@ -102,6 +107,39 @@ type Instance interface {
 	// "openapi.petstore.PetstoreApi/GetPet". request is the proto3-JSON request body;
 	// headers are forwarded upstream.
 	Invoke(methodPath string, request []byte, headers map[string]string) (*InvokeResult, error)
+}
+
+// Forwarder is an app the client drives as HTTP rather than as RPC. The client has
+// read the document and knows the shape of every call; what it does not have, and
+// must not, is where the API is and what credential reaches it. So it sends a path
+// and this fills in the rest — which is the whole of what the server does for a
+// REST app.
+type Forwarder interface {
+	// Forward makes one upstream call. path is relative to the app's base URL and
+	// is never a URL: a script that could name the destination could aim this
+	// process at anything the machine can reach.
+	Forward(request *ForwardRequest) (*ForwardResult, error)
+}
+
+// ForwardRequest is one HTTP call, as the browser asked for it.
+type ForwardRequest struct {
+	Method string
+	// Relative to the app's base URL, query string included.
+	Path    string
+	Headers map[string]string
+	Body    []byte
+}
+
+// ForwardResult is what the API answered, whole. A status is data here rather than
+// a failure: an API that answers 404 has answered, and the script decides.
+type ForwardResult struct {
+	Status  int
+	Headers map[string]string
+	Body    []byte
+	// What was actually sent upstream, with the resolved secrets masked back out,
+	// for the Headers view.
+	RequestHeaders map[string]string
+	DurationMs     int64
 }
 
 // Documented is an app that can show where one of its methods came from. Optional:
@@ -172,7 +210,7 @@ func (m *Manager) Open(appType string, parameters map[string]string, protoDir st
 		return nil, err
 	}
 
-	result := &OpenResult{ProtoDir: protoDir, Target: opened.Target, Protocol: opened.Protocol}
+	result := &OpenResult{ProtoDir: protoDir, Target: opened.Target, Protocol: opened.Protocol, Document: opened.Document}
 	if opened.ProtoDir != "" {
 		result.ProtoDir = opened.ProtoDir
 	}
@@ -214,6 +252,29 @@ func (m *Manager) Invoke(target string, methodPath string, request []byte, heade
 	}
 
 	return instance.Invoke(methodPath, request, headers)
+}
+
+// Forward routes one HTTP call to the app behind a target. An app type that is not
+// driven as HTTP has no Forward, which is an error rather than a miss: a call has
+// to go somewhere.
+func (m *Manager) Forward(target string, request *ForwardRequest) (*ForwardResult, error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("invalid app target %q: %w", target, err)
+	}
+
+	m.mu.Lock()
+	instance, ok := m.instances[u.Host]
+	m.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("app instance %q not found (the app may need to be recompiled)", u.Host)
+	}
+
+	forwarder, ok := instance.(Forwarder)
+	if !ok {
+		return nil, fmt.Errorf("app instance %q is not driven as HTTP", u.Host)
+	}
+	return forwarder.Forward(request)
 }
 
 // Documentation answers for one of a live app's operations, or reports that the app

--- a/server/pkg/apps/openapi/documentation.go
+++ b/server/pkg/apps/openapi/documentation.go
@@ -1,0 +1,115 @@
+package openapi
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/wham/kaja/v2/pkg/apps"
+	"sigs.k8s.io/yaml"
+)
+
+// Documentation answers with the operation as its own document states it.
+//
+// The generated proto carries what kaja could model — the request, the response,
+// which fields travel in the path — and drops the rest: the examples, the response
+// codes the method never returns as values, the vendor extensions, the prose under
+// each parameter. That is the half a person reads before writing a call, so it is
+// served from the document rather than reconstructed from what was kept.
+//
+// Lazily, one operation at a time: a document with nine hundred operations would
+// otherwise ride along with every compile, and only the one under the cursor is ever
+// read.
+func (in *instance) Documentation(operation string) (*apps.Documentation, bool) {
+	verb, path, ok := splitOperation(operation)
+	if !ok || in.raw == nil {
+		return nil, false
+	}
+
+	body, ok := operationJSON(in.raw, verb, path)
+	if !ok {
+		return nil, false
+	}
+
+	// Read twice: once for the fields worth stating on their own, once as the
+	// document to show. Only the second can carry what kaja has no field for.
+	var described struct {
+		Summary     string `json:"summary"`
+		Description string `json:"description"`
+		Deprecated  bool   `json:"deprecated"`
+	}
+	_ = json.Unmarshal(body, &described)
+
+	// The summary and the description are stated above the fragment, so leaving them in
+	// it prints the API's own prose twice — and, because JSON objects render in key
+	// order, a long description would be the first thing under a heading that has just
+	// said it. What is left is what nothing else says: the parameters, the examples,
+	// the response codes, and whatever the document declares that kaja has no field for.
+	var declared map[string]json.RawMessage
+	if err := json.Unmarshal(body, &declared); err != nil {
+		return nil, false
+	}
+	delete(declared, "summary")
+	delete(declared, "description")
+
+	remaining, err := json.Marshal(declared)
+	if err != nil {
+		return nil, false
+	}
+	document, err := yaml.JSONToYAML(remaining)
+	if err != nil {
+		return nil, false
+	}
+	// An operation that declared nothing but prose has an empty document, not "{}".
+	if strings.TrimSpace(string(document)) == "{}" {
+		document = nil
+	}
+
+	return &apps.Documentation{
+		Summary:     strings.TrimSpace(described.Summary),
+		Description: strings.TrimSpace(described.Description),
+		Deprecated:  described.Deprecated,
+		Document:    strings.TrimRight(string(document), "\n"),
+		Language:    "yaml",
+	}, true
+}
+
+// splitOperation reads "GET /shows/{showId}" back into the two halves that address
+// an operation in a document.
+func splitOperation(operation string) (verb string, path string, ok bool) {
+	verb, path, found := strings.Cut(strings.TrimSpace(operation), " ")
+	if !found {
+		return "", "", false
+	}
+	path = strings.TrimSpace(path)
+	if verb == "" || !strings.HasPrefix(path, "/") {
+		return "", "", false
+	}
+	return strings.ToLower(verb), path, true
+}
+
+// operationJSON walks paths → <path> → <verb> without decoding the rest of the
+// document, which for a large API is most of it.
+func operationJSON(raw []byte, verb string, path string) ([]byte, bool) {
+	var document struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return nil, false
+	}
+	item, ok := document.Paths[path]
+	if !ok {
+		return nil, false
+	}
+	var operations map[string]json.RawMessage
+	if err := json.Unmarshal(item, &operations); err != nil {
+		return nil, false
+	}
+	// A document's verbs are lowercase by the specification, but it costs nothing to
+	// read one that shouts.
+	for name, body := range operations {
+		if strings.EqualFold(name, verb) {
+			return body, true
+		}
+	}
+	return nil, false
+}

--- a/server/pkg/apps/openapi/documentation_test.go
+++ b/server/pkg/apps/openapi/documentation_test.go
@@ -1,0 +1,177 @@
+package openapi
+
+import (
+	"strings"
+	"testing"
+)
+
+const documentedSpec = `
+openapi: 3.1.0
+info: { title: Theatre, version: "1.0" }
+paths:
+  /shows:
+    get:
+      summary: What is playing where
+      description: |
+        The schedule, soonest first.
+      operationId: listShows
+      parameters:
+        - name: city
+          in: query
+          description: Only screenings in this city.
+          example: Chicago
+          schema: { type: string }
+      responses:
+        "200": { description: One page of the schedule. }
+        "400": { description: The limit is out of range. }
+  /shows/{showId}:
+    get:
+      summary: One show
+      deprecated: true
+      parameters:
+        - name: showId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200": { description: The show. }
+    delete:
+      summary: Cancel a show
+      responses:
+        "204": { description: Gone. }
+`
+
+func documented(t *testing.T) *instance {
+	t.Helper()
+	s, err := parseSpec([]byte(documentedSpec))
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	if s.raw == nil {
+		t.Fatal("the document was parsed but not kept")
+	}
+	return &instance{raw: s.raw}
+}
+
+// The point of the fragment is what the generated proto could not carry: the prose
+// under a parameter, its example, and the response codes that are never values.
+func TestDocumentationShowsWhatTheProtoDropped(t *testing.T) {
+	documentation, ok := documented(t).Documentation("GET /shows")
+	if !ok {
+		t.Fatal("expected GET /shows to be documented")
+	}
+
+	if documentation.Summary != "What is playing where" {
+		t.Errorf("Summary = %q", documentation.Summary)
+	}
+	if !strings.Contains(documentation.Description, "The schedule, soonest first.") {
+		t.Errorf("Description = %q", documentation.Description)
+	}
+	if documentation.Language != "yaml" {
+		t.Errorf("Language = %q, want yaml", documentation.Language)
+	}
+	for _, want := range []string{"operationId: listShows", "Only screenings in this city.", "example: Chicago", `"400"`} {
+		if !strings.Contains(documentation.Document, want) {
+			t.Errorf("document is missing %q:\n%s", want, documentation.Document)
+		}
+	}
+	// It is one operation, not the path item: the sibling verb is not in it.
+	if strings.Contains(documentation.Document, "Cancel a show") {
+		t.Errorf("document carried a sibling operation:\n%s", documentation.Document)
+	}
+	// The prose is stated above the fragment, so it is not restated inside it.
+	for _, unwanted := range []string{"summary:", "description: |", "What is playing where"} {
+		if strings.Contains(documentation.Document, unwanted) {
+			t.Errorf("document restated the prose (%q):\n%s", unwanted, documentation.Document)
+		}
+	}
+}
+
+// A templated path is the one a script most needs the document for, and the path is
+// carried verbatim from the document into the method's mark, so it is looked up whole.
+func TestDocumentationFindsATemplatedPath(t *testing.T) {
+	in := documented(t)
+
+	documentation, ok := in.Documentation("GET /shows/{showId}")
+	if !ok {
+		t.Fatal("expected GET /shows/{showId} to be documented")
+	}
+	if documentation.Summary != "One show" || !documentation.Deprecated {
+		t.Errorf("Summary = %q, Deprecated = %v", documentation.Summary, documentation.Deprecated)
+	}
+
+	// Two operations under one path are two answers.
+	cancel, ok := in.Documentation("DELETE /shows/{showId}")
+	if !ok || cancel.Summary != "Cancel a show" {
+		t.Errorf("DELETE /shows/{showId} = %+v, ok = %v", cancel, ok)
+	}
+}
+
+// A hover with nothing to say says nothing, so every miss is a miss rather than an
+// error: a path the document does not declare, a verb it does not declare under a
+// path it does, and anything that is not an operation at all.
+func TestDocumentationMissesWithoutFailing(t *testing.T) {
+	in := documented(t)
+
+	for _, operation := range []string{"GET /nope", "POST /shows", "", "GET", "nonsense", "GET shows", "  "} {
+		if documentation, ok := in.Documentation(operation); ok {
+			t.Errorf("Documentation(%q) answered %+v, want a miss", operation, documentation)
+		}
+	}
+}
+
+// An operation whose whole declaration is prose has nothing left to show below it,
+// and an empty fragment is better than a "{}".
+func TestDocumentationLeavesNoEmptyFragment(t *testing.T) {
+	s, err := parseSpec([]byte(`
+openapi: 3.1.0
+info: { title: T, version: "1" }
+paths:
+  /ping:
+    get:
+      summary: Ping
+      description: Says hello.
+`))
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+
+	documentation, ok := (&instance{raw: s.raw}).Documentation("GET /ping")
+	if !ok {
+		t.Fatal("expected the operation to be documented")
+	}
+	if documentation.Document != "" {
+		t.Errorf("Document = %q, want empty", documentation.Document)
+	}
+	if documentation.Summary != "Ping" {
+		t.Errorf("Summary = %q", documentation.Summary)
+	}
+}
+
+func TestDocumentationMissesWhereNoDocumentWasKept(t *testing.T) {
+	if _, ok := (&instance{}).Documentation("GET /shows"); ok {
+		t.Error("an instance with no document answered for one")
+	}
+}
+
+// A YAML document and a JSON one are shown the same way, because both have already
+// been reduced to JSON by the time they are kept.
+func TestDocumentationReadsAJsonDocument(t *testing.T) {
+	s, err := parseSpec([]byte(`{"openapi":"3.1.0","info":{"title":"T","version":"1"},"paths":{"/shows":{"get":{"summary":"Shows","responses":{"200":{"description":"ok"}}}}}}`))
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+
+	documentation, ok := (&instance{raw: s.raw}).Documentation("GET /shows")
+	if !ok {
+		t.Fatal("expected the operation to be documented")
+	}
+	if documentation.Summary != "Shows" {
+		t.Errorf("Summary = %q", documentation.Summary)
+	}
+	// Rendered as YAML whatever the document was written in — the summary having moved
+	// out of the fragment and into its own field.
+	if !strings.Contains(documentation.Document, "description: ok") {
+		t.Errorf("expected YAML, got:\n%s", documentation.Document)
+	}
+}

--- a/server/pkg/apps/openapi/forward.go
+++ b/server/pkg/apps/openapi/forward.go
@@ -1,0 +1,89 @@
+package openapi
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wham/kaja/v2/pkg/apps"
+)
+
+// maxBody bounds what one response may bring back. A REST API is free to answer
+// with a gigabyte, and the browser this is carried to has to hold it.
+const maxBody = 64 << 20
+
+// Forward makes one upstream call on behalf of a script that built the request
+// itself.
+//
+// It is the whole of what this process does for a REST app now. The client read
+// the document, so it knows the verb, the path, the query and the body; what it
+// does not have is where the API lives and what credential opens it, and it must
+// not — a kaja serving a browser over the network would otherwise be handing out
+// the workspace's secrets.
+//
+// A status is data, not an outcome: an API that answers 404 has answered, and what
+// to make of it is the script's business. Only a call that could not be made at all
+// is an error here.
+func (in *instance) Forward(request *apps.ForwardRequest) (*apps.ForwardResult, error) {
+	if strings.Contains(request.Path, "://") || strings.HasPrefix(request.Path, "//") {
+		return nil, fmt.Errorf("path %q is a URL; a forwarded call is addressed relative to the app", request.Path)
+	}
+	path := request.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	target := strings.TrimSuffix(in.baseURL, "/") + path
+	var body io.Reader
+	if len(request.Body) > 0 {
+		body = bytes.NewReader(request.Body)
+	}
+
+	outgoing, err := http.NewRequest(strings.ToUpper(request.Method), target, body)
+	if err != nil {
+		return nil, fmt.Errorf("building the upstream request: %w", err)
+	}
+	for name, value := range request.Headers {
+		outgoing.Header.Set(name, value)
+	}
+
+	// The app's own credential goes on after the call's headers, the way it always
+	// has: it is the app's, and a header the script wrote does not carry it.
+	query := outgoing.URL.Query()
+	in.auth.applyQuery(query)
+	outgoing.URL.RawQuery = query.Encode()
+	in.auth.applyRequest(outgoing)
+
+	started := time.Now()
+	response, err := in.client.Do(outgoing)
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", target, err)
+	}
+	defer response.Body.Close()
+
+	answered, err := io.ReadAll(io.LimitReader(response.Body, maxBody))
+	if err != nil {
+		return nil, fmt.Errorf("reading the response from %s: %w", target, err)
+	}
+
+	return &apps.ForwardResult{
+		Status:         response.StatusCode,
+		Headers:        flatten(response.Header),
+		Body:           answered,
+		RequestHeaders: flatten(outgoing.Header),
+		DurationMs:     time.Since(started).Milliseconds(),
+	}, nil
+}
+
+// One value per name, which is what the Headers view shows and what a script reads
+// back. A repeated header is joined the way HTTP itself allows.
+func flatten(header http.Header) map[string]string {
+	flat := make(map[string]string, len(header))
+	for name, values := range header {
+		flat[name] = strings.Join(values, ", ")
+	}
+	return flat
+}

--- a/server/pkg/apps/openapi/forward.go
+++ b/server/pkg/apps/openapi/forward.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -28,21 +29,17 @@ const maxBody = 64 << 20
 // to make of it is the script's business. Only a call that could not be made at all
 // is an error here.
 func (in *instance) Forward(request *apps.ForwardRequest) (*apps.ForwardResult, error) {
-	if strings.Contains(request.Path, "://") || strings.HasPrefix(request.Path, "//") {
-		return nil, fmt.Errorf("path %q is a URL; a forwarded call is addressed relative to the app", request.Path)
-	}
-	path := request.Path
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+	target, err := in.resolve(request.Path)
+	if err != nil {
+		return nil, err
 	}
 
-	target := strings.TrimSuffix(in.baseURL, "/") + path
 	var body io.Reader
 	if len(request.Body) > 0 {
 		body = bytes.NewReader(request.Body)
 	}
 
-	outgoing, err := http.NewRequest(strings.ToUpper(request.Method), target, body)
+	outgoing, err := http.NewRequest(strings.ToUpper(request.Method), target.String(), body)
 	if err != nil {
 		return nil, fmt.Errorf("building the upstream request: %w", err)
 	}
@@ -76,6 +73,68 @@ func (in *instance) Forward(request *apps.ForwardRequest) (*apps.ForwardResult, 
 		RequestHeaders: flatten(outgoing.Header),
 		DurationMs:     time.Since(started).Milliseconds(),
 	}, nil
+}
+
+// resolve turns the path a script asked for into the URL this process will call.
+//
+// The address is the security boundary of this whole lane: anything that reaches
+// here has crossed from a browser, and on a deployed kaja that browser is not
+// necessarily the workspace's owner. So the destination is not assembled from
+// text — every part of the authority is taken from the app's own base URL, and
+// the request supplies a path and a query and nothing else. Even a reference that
+// parses as absolute contributes only its path, because there is no branch here
+// that can read a host out of the input.
+//
+// Confining the result under the base path is the second half: a document mounted
+// at /v1 is an API that begins at /v1, and `../..` climbing out of it reaches
+// endpoints on that host the app was never opened for.
+func (in *instance) resolve(path string) (*url.URL, error) {
+	base, err := url.Parse(in.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("the app's base URL %q is not a URL: %w", in.baseURL, err)
+	}
+
+	reference, err := url.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("path %q is not a path: %w", path, err)
+	}
+	if reference.IsAbs() || reference.Host != "" || reference.User != nil {
+		return nil, fmt.Errorf("path %q names a destination; a forwarded call is addressed relative to the app", path)
+	}
+
+	// An operation's path hangs off the server URL, which is what an OpenAPI
+	// document means by the two: /v1 and /shows are /v1/shows. So they are joined
+	// rather than resolved against one another, where an absolute /shows would
+	// replace the mount point instead of extending it.
+	basePath := base.EscapedPath()
+	if basePath == "" {
+		basePath = "/"
+	}
+	joined := strings.TrimSuffix(basePath, "/") + "/" + strings.TrimPrefix(reference.EscapedPath(), "/")
+
+	candidate, err := url.Parse(joined)
+	if err != nil {
+		return nil, fmt.Errorf("path %q is not a path: %w", path, err)
+	}
+	// Resolving the joined path against the base is what removes the dot segments,
+	// so `..` is settled here rather than left for the upstream to interpret.
+	candidate.RawQuery = reference.RawQuery
+	resolved := base.ResolveReference(candidate)
+
+	confined := strings.TrimSuffix(basePath, "/")
+	if resolved.EscapedPath() != confined && !strings.HasPrefix(resolved.EscapedPath(), confined+"/") {
+		return nil, fmt.Errorf("path %q reaches outside the app", path)
+	}
+
+	// Built from the base rather than from the reference, so the scheme, the host
+	// and any credentials in the base URL are the only ones that can be used.
+	target := *base
+	target.Path = resolved.Path
+	target.RawPath = resolved.RawPath
+	target.RawQuery = resolved.RawQuery
+	target.Fragment = ""
+	target.RawFragment = ""
+	return &target, nil
 }
 
 // One value per name, which is what the Headers view shows and what a script reads

--- a/server/pkg/apps/openapi/forward_test.go
+++ b/server/pkg/apps/openapi/forward_test.go
@@ -1,0 +1,93 @@
+package openapi
+
+import "testing"
+
+// The address is the security boundary of the forwarding lane. What reaches it has
+// crossed from a browser, and on a deployed kaja that browser is not necessarily
+// the workspace's owner — so the host is the app's and only the path is the
+// caller's, whatever the caller writes.
+func TestResolveKeepsTheCallOnTheAppsOwnHost(t *testing.T) {
+	in := &instance{baseURL: "https://api.example.com/v1"}
+
+	for _, path := range []string{
+		"https://evil.example.net/x",
+		"//evil.example.net/x",
+		"http://evil.example.net",
+		"https://user:pass@evil.example.net/x",
+		"//evil.example.net",
+	} {
+		if target, err := in.resolve(path); err == nil {
+			t.Errorf("resolve(%q) = %s, want a refusal", path, target)
+		}
+	}
+}
+
+// A document mounted at /v1 is an API that begins at /v1: climbing out of it
+// reaches endpoints on that host the app was never opened for.
+func TestResolveStaysUnderTheBasePath(t *testing.T) {
+	in := &instance{baseURL: "https://api.example.com/v1"}
+
+	for _, path := range []string{"/../admin", "/../../admin", "/shows/../../admin", "/..%2fadmin"} {
+		if target, err := in.resolve(path); err == nil && target.Path != "/v1" && !hasPrefix(target.Path, "/v1/") {
+			t.Errorf("resolve(%q) = %s, want it kept under /v1", path, target)
+		}
+	}
+}
+
+func TestResolveBuildsTheOrdinaryCall(t *testing.T) {
+	in := &instance{baseURL: "https://api.example.com/v1"}
+
+	cases := []struct{ path, want string }{
+		{"/shows", "https://api.example.com/v1/shows"},
+		{"/shows?limit=2", "https://api.example.com/v1/shows?limit=2"},
+		{"/shows/vera-lune", "https://api.example.com/v1/shows/vera-lune"},
+		// A dot segment inside the path is settled here rather than left for the
+		// upstream to interpret.
+		{"/shows/./vera-lune", "https://api.example.com/v1/shows/vera-lune"},
+		{"/shows/a/../b", "https://api.example.com/v1/shows/b"},
+	}
+	for _, one := range cases {
+		target, err := in.resolve(one.path)
+		if err != nil {
+			t.Errorf("resolve(%q): %v", one.path, err)
+			continue
+		}
+		if target.String() != one.want {
+			t.Errorf("resolve(%q) = %s, want %s", one.path, target, one.want)
+		}
+	}
+}
+
+// A base URL with no path of its own confines nothing but the host, which is the
+// common case and must keep working.
+func TestResolveWithABareBaseURL(t *testing.T) {
+	in := &instance{baseURL: "https://api.example.com"}
+
+	target, err := in.resolve("/shows")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if target.String() != "https://api.example.com/shows" {
+		t.Errorf("resolve = %s", target)
+	}
+	if _, err := in.resolve("https://evil.example.net/x"); err == nil {
+		t.Error("an absolute URL was accepted against a bare base URL")
+	}
+}
+
+// The fragment is never sent, so a path carrying one loses it rather than
+// smuggling it upstream.
+func TestResolveDropsAFragment(t *testing.T) {
+	in := &instance{baseURL: "https://api.example.com"}
+	target, err := in.resolve("/shows#anchor")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if target.String() != "https://api.example.com/shows" {
+		t.Errorf("resolve = %s", target)
+	}
+}
+
+func hasPrefix(text, prefix string) bool {
+	return len(text) >= len(prefix) && text[:len(prefix)] == prefix
+}

--- a/server/pkg/apps/openapi/invoke.go
+++ b/server/pkg/apps/openapi/invoke.go
@@ -34,6 +34,9 @@ type instance struct {
 	methods map[string]*boundMethod
 	client  *http.Client
 	auth    *auth
+	// The document this app was generated from, kept so one operation can be shown
+	// the way it was written. See documentation.go.
+	raw []byte
 }
 
 func (in *instance) Invoke(methodPath string, request []byte, headers map[string]string) (*apps.InvokeResult, error) {

--- a/server/pkg/apps/openapi/openapi.go
+++ b/server/pkg/apps/openapi/openapi.go
@@ -118,6 +118,7 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 		methods: methods,
 		client:  &http.Client{Timeout: 30 * time.Second},
 		auth:    authentication,
+		raw:     s.raw,
 	}}, nil
 }
 

--- a/server/pkg/apps/openapi/openapi.go
+++ b/server/pkg/apps/openapi/openapi.go
@@ -113,7 +113,7 @@ func (a *App) Open(parameters map[string]string, protoDir string, log func(strin
 		log("Authentication: " + summary)
 	}
 
-	return &apps.Opened{Instance: &instance{
+	return &apps.Opened{Document: s.raw, Instance: &instance{
 		baseURL: baseURL,
 		methods: methods,
 		client:  &http.Client{Timeout: 30 * time.Second},

--- a/server/pkg/apps/openapi/spec.go
+++ b/server/pkg/apps/openapi/spec.go
@@ -19,6 +19,10 @@ import (
 // understands. sigs.k8s.io/yaml honours the json tags and parses both JSON and
 // YAML documents.
 type spec struct {
+	// The whole document as JSON, for showing an operation the way it was written.
+	// Unexported, so it is never a field of the parsed shape anything else reads.
+	raw []byte
+
 	OpenAPI string `json:"openapi"`
 	// Swagger is the version field of the predecessor format. It is only read to
 	// tell a Swagger 2.0 document apart from a document that is not an API
@@ -369,6 +373,14 @@ func readSpec(body []byte, contentType string) (*spec, *problem) {
 	var s spec
 	if err := yaml.Unmarshal(body, &s); err != nil {
 		return nil, &problem{Kind: problemMalformed, Message: "Couldn't parse the document", Detail: err.Error()}
+	}
+	// The document as it was written, kept beside what was read out of it. An
+	// operation is shown as the API states it — every keyword, including the ones
+	// kaja has no field for — and a typed struct can only give back what it models.
+	// JSON rather than the original bytes because a YAML document and a JSON one have
+	// to be shown the same way, and this is the form both have already been reduced to.
+	if raw, err := yaml.YAMLToJSON(body); err == nil {
+		s.raw = raw
 	}
 
 	if s.OpenAPI == "" {

--- a/server/pkg/mcp/catalog.go
+++ b/server/pkg/mcp/catalog.go
@@ -40,9 +40,13 @@ func isRuntimeName(name string) bool {
 }
 
 type CatalogApp struct {
-	Name     string           `json:"name"`
-	Type     string           `json:"type,omitempty"`
-	Services []CatalogService `json:"services"`
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+	// What the app's REST door is read under, where it has one — "theatre" for
+	// `import { api as theatre }`. Empty for an app whose methods stand for no HTTP
+	// request.
+	RestBinding string           `json:"restBinding,omitempty"`
+	Services    []CatalogService `json:"services"`
 	// Every type the app's services name, by its TypeScript name.
 	Declarations map[string]Declaration `json:"declarations,omitempty"`
 }
@@ -64,8 +68,12 @@ type CatalogMethod struct {
 	Doc       string `json:"doc,omitempty"`
 	// The HTTP request the method stands for, e.g. "GET /shows", when the app said so.
 	// The only thing that states whether calling it reads or writes.
-	HTTP      string `json:"http,omitempty"`
-	Streaming string `json:"streaming,omitempty"`
+	HTTP string `json:"http,omitempty"`
+	// The method as the REST door declares it, where the app has one:
+	// `get(path: "/shows/{showId}", request: WithPath<GetShowRequest, "showId">, options?: CallOptions): Call<Show>`.
+	// It is what Example is an instance of, so the two cannot be two spellings.
+	RestSignature string `json:"restSignature,omitempty"`
+	Streaming     string `json:"streaming,omitempty"`
 	// The call Kaja writes for this method — the same code clicking it in the tree puts
 	// in a draft.
 	Example string `json:"example"`

--- a/server/pkg/mcp/describe.go
+++ b/server/pkg/mcp/describe.go
@@ -48,8 +48,16 @@ func (c Catalog) describeMethod(resolved resolvedMethod) string {
 		fmt.Fprintf(&b, "streaming: %s\n", note)
 	}
 
-	fmt.Fprintf(&b, "\nimport { %s } from %q;\n", resolved.service.Name, resolved.service.ImportPath)
-	fmt.Fprintf(&b, "%s.%s\n", resolved.service.Name, method.Signature)
+	// A method that stands for an HTTP request is written the way its own API writes
+	// it, through the app's REST door. The service door still answers, and is what an
+	// app with no path has, so which one is shown is which one the method has.
+	if method.RestSignature != "" && resolved.app.RestBinding != "" {
+		fmt.Fprintf(&b, "\nimport { api as %s } from %q;\n", resolved.app.RestBinding, resolved.service.ImportPath)
+		fmt.Fprintf(&b, "%s.%s\n", resolved.app.RestBinding, method.RestSignature)
+	} else {
+		fmt.Fprintf(&b, "\nimport { %s } from %q;\n", resolved.service.Name, resolved.service.ImportPath)
+		fmt.Fprintf(&b, "%s.%s\n", resolved.service.Name, method.Signature)
+	}
 
 	b.WriteString("\n" + strings.TrimRight(resolved.app.renderDeclarations(method.Input, method.Output), "\n") + "\n")
 

--- a/server/pkg/mcp/list.go
+++ b/server/pkg/mcp/list.go
@@ -65,9 +65,15 @@ func (c Catalog) listServices(appFilter, serviceFilter, search string) string {
 
 func methodLine(resolved resolvedMethod) string {
 	method := resolved.method
-	line := fmt.Sprintf("%-6s %s", resolved.effect(), method.Signature)
+	// The index reads as the API's own list where the API has one: the path is in the
+	// signature, so repeating it as a mark beside it says the same thing twice.
+	signature, rest := method.Signature, method.RestSignature != ""
+	if rest {
+		signature = method.RestSignature
+	}
+	line := fmt.Sprintf("%-6s %s", resolved.effect(), signature)
 	var marks []string
-	if method.HTTP != "" {
+	if method.HTTP != "" && !rest {
 		marks = append(marks, method.HTTP)
 	}
 	// Which way it streams is only worth a mark for what it costs the caller: one

--- a/server/pkg/mcp/rest_door_test.go
+++ b/server/pkg/mcp/rest_door_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// An app built from a REST document addresses its methods the way the document does.
+// The catalog carries both doors, and what is shown is whichever the method has — so
+// the signature an agent reads is the one its example is an instance of.
+func restCatalog() Catalog {
+	return Catalog{Apps: []CatalogApp{{
+		Name:        "theatre",
+		Type:        "openapi",
+		RestBinding: "theatre",
+		Services: []CatalogService{{
+			Name:       "Shows",
+			ImportPath: "theatre",
+			Methods: []CatalogMethod{
+				{
+					Name:          "GetShow",
+					Signature:     "GetShow(input: Input<GetShowRequest>): Call<Show>",
+					RestSignature: `get(path: "/shows/{showId}", request: WithPath<GetShowRequest, "showId">, options?: CallOptions): Call<Show>`,
+					Input:         "GetShowRequest",
+					Output:        "Show",
+					HTTP:          "GET /shows/{showId}",
+					Doc:           "Fetch one show by its id.",
+					Example:       "import { api as theatre } from \"theatre\";\n\ntheatre.get(\"/shows/{showId}\", { showId: \"\" });",
+				},
+				{
+					Name:      "Ping",
+					Signature: "Ping(input: Input<PingRequest>): Call<PingResponse>",
+					Input:     "PingRequest",
+					Output:    "PingResponse",
+					Example:   "import { Shows } from \"theatre\";\n\nShows.Ping({});",
+				},
+			},
+		}},
+	}}}
+}
+
+func TestDescribeMethodShowsTheRestDoor(t *testing.T) {
+	catalog := restCatalog()
+	resolved, _, ok := catalog.findMethod("Shows.GetShow")
+	if !ok {
+		t.Fatal("findMethod did not resolve Shows.GetShow")
+	}
+
+	out := catalog.describeMethod(resolved)
+	if !strings.Contains(out, `import { api as theatre } from "theatre";`) {
+		t.Errorf("expected the door's import line, got:\n%s", out)
+	}
+	if !strings.Contains(out, `theatre.get(path: "/shows/{showId}"`) {
+		t.Errorf("expected the door's signature, got:\n%s", out)
+	}
+	// The service door is a second address, not a second thing to read here.
+	if strings.Contains(out, "Shows.GetShow(input:") {
+		t.Errorf("expected the service signature to be left out, got:\n%s", out)
+	}
+}
+
+func TestDescribeMethodKeepsTheServiceDoorWhereThereIsNoPath(t *testing.T) {
+	catalog := restCatalog()
+	resolved, _, ok := catalog.findMethod("Shows.Ping")
+	if !ok {
+		t.Fatal("findMethod did not resolve Shows.Ping")
+	}
+
+	out := catalog.describeMethod(resolved)
+	if !strings.Contains(out, `import { Shows } from "theatre";`) {
+		t.Errorf("expected the service import line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Shows.Ping(input:") {
+		t.Errorf("expected the service signature, got:\n%s", out)
+	}
+}
+
+// The path is in the signature, so repeating it beside the line says it twice.
+func TestListServicesNamesThePathOnceAndKeepsTheEffect(t *testing.T) {
+	catalog := restCatalog()
+	out := catalog.listServices("", "", "")
+
+	if !strings.Contains(out, `get(path: "/shows/{showId}"`) {
+		t.Errorf("expected the door's signature in the index, got:\n%s", out)
+	}
+	if strings.Count(out, "GET /shows/{showId}") != 0 {
+		t.Errorf("expected the HTTP mark to be left out beside it, got:\n%s", out)
+	}
+	if !strings.Contains(out, "read") {
+		t.Errorf("expected the read/write effect to survive, got:\n%s", out)
+	}
+}

--- a/server/proto/api.proto
+++ b/server/proto/api.proto
@@ -14,6 +14,38 @@ service Api {
   rpc ClearStoredValue(ClearStoredValueRequest) returns (StoredValueResponse);
   rpc ListScripts(ListScriptsRequest) returns (ListScriptsResponse);
   rpc ReadScript(ReadScriptRequest) returns (ReadScriptResponse);
+  rpc GetMethodDocumentation(GetMethodDocumentationRequest) returns (GetMethodDocumentationResponse);
+}
+
+// GetMethodDocumentation reads one of a live app's methods back out of the document
+// its surface was generated from. The generated proto carries what kaja could model;
+// this is the rest — the prose, the examples, the response codes — which is most of
+// what a person reads before writing the call.
+//
+// One operation at a time, because a document with nine hundred of them would
+// otherwise ride along with every compile to answer for the one under the cursor.
+message GetMethodDocumentationRequest {
+  // The opened app, as OpenApp reported it: "kaja-app://<id>".
+  string target = 1;
+  // The method, named the way the app's methods name theirs — "GET /shows/{showId}"
+  // for an app built from a REST document.
+  string method = 2;
+}
+
+message GetMethodDocumentationResponse {
+  // Unset where the app documents nothing, or the method is one it does not declare.
+  // Not an error: the caller is a hover, and a hover with nothing to say says nothing.
+  MethodDocumentation documentation = 1;
+}
+
+message MethodDocumentation {
+  string summary = 1;
+  string description = 2;
+  bool deprecated = 3;
+  // The declaration as it was written, ready to show.
+  string document = 4;
+  // What `document` is written in, so an editor can colour it: "yaml", "json".
+  string language = 5;
 }
 
 message CompileRequest {

--- a/server/proto/api.proto
+++ b/server/proto/api.proto
@@ -83,6 +83,11 @@ message OpenAppResponse {
   string target = 4;
   // Transport the client uses to reach the target: "grpc" or "twirp".
   string protocol = 5;
+  // The app's own description, as JSON, for an app the client drives as HTTP.
+  // A REST document is read in the browser — a schema becomes TypeScript there,
+  // and an operation becomes an HTTP request — so an app that has one compiles no
+  // proto and `proto_dir` is empty for it.
+  string document = 6;
 }
 
 // InspectGrpc reads the service surface a grpc app *would* be opened with -

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -46,6 +46,7 @@ import { deriveDraftTitle, proposeFileName, proposeFileNames } from "./draftTitl
 import { hasMultiplePackages, methodUse, recordUse } from "./treeExpansion";
 import { isWithinFolder, scriptsWithin } from "./scriptTree";
 import { generateMethodEditorCode } from "./appLoader";
+import { methodLabel } from "./httpMethod";
 import { barrel } from "./appImports";
 import { agentSession } from "./agentSession";
 import { buildMcpCatalog } from "./mcpCatalog";
@@ -2118,7 +2119,8 @@ export function App() {
             // The package is part of the key: without it two same-named services in one app
             // share one, and React renders whichever it already had wherever the other belongs.
             key: `call:${app.configuration.name}/${service.packageName}.${service.name}/${method.name}`,
-            name: method.name,
+            name: methodLabel(method),
+            search: method.name,
             path: `${app.configuration.name} / ${qualified}`,
             origin: app.configuration.name,
             icon: FileCode,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -47,6 +47,7 @@ import { hasMultiplePackages, methodUse, recordUse } from "./treeExpansion";
 import { isWithinFolder, scriptsWithin } from "./scriptTree";
 import { generateMethodEditorCode } from "./appLoader";
 import { methodLabel } from "./httpMethod";
+import { setHoverApps } from "./restHover";
 import { barrel } from "./appImports";
 import { agentSession } from "./agentSession";
 import { buildMcpCatalog } from "./mcpCatalog";
@@ -810,6 +811,7 @@ export function App() {
 
   useEffect(() => {
     setValueCompletionApps(apps);
+    setHoverApps(apps);
   }, [apps]);
 
   useEffect(() => {

--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -5,6 +5,7 @@ import { formatTypeScript, formatTypeScriptWithCursor } from "./formatter";
 import { findTimestamps, timestampToDate, formatDateForDisplay } from "./timestampPicker";
 import { TimestampPickerContentWidget } from "./TimestampPickerWidget";
 import { kajaModuleDeclaration } from "./kajaModule";
+import { registerRestHover } from "./restHover";
 import { codeFontSize } from "./monacoTheme";
 import { suggestValues } from "./valueCompletions";
 
@@ -195,6 +196,11 @@ monaco.languages.registerCompletionItemProvider("typescript", {
     };
   },
 });
+
+// What an API says about the operation under the cursor. The TypeScript worker
+// reports no hover inside a string literal argument, so the path is an empty slot
+// rather than a second opinion — and where it does speak, hovers are shown stacked.
+registerRestHover();
 
 const TIMESTAMP_PICKER_COMMAND = "kaja.pickTimestamp";
 let timestampCommandRegistered = false;

--- a/ui/src/Finder.tsx
+++ b/ui/src/Finder.tsx
@@ -31,6 +31,10 @@ export interface Destination {
   // A call Kaja won't make. Dimmed and marked with the glyph the tree row carries,
   // since the finder is the other list every method is in.
   uncallable?: boolean;
+  // Matched but never shown. A REST method is named by its path everywhere, so the
+  // generated name is nowhere on screen to be read off — and it is still what someone
+  // who has been reading the declarations will type.
+  search?: string;
   go: () => void;
 }
 
@@ -61,7 +65,7 @@ export function Finder({ recent, elsewhere, errorCount, open, onOpenChange, high
 
   const { recentRows, otherRows } = useMemo(() => {
     const term = query.trim().toLowerCase();
-    const matches = (destination: Destination) => `${destination.name} ${destination.path}`.toLowerCase().includes(term);
+    const matches = (destination: Destination) => `${destination.name} ${destination.path} ${destination.search ?? ""}`.toLowerCase().includes(term);
     const been = recent.filter(matches);
     const rest = elsewhere.filter(matches);
     return { recentRows: been, otherRows: term ? rest : rest.slice(0, RESTING_OTHERS) };

--- a/ui/src/MethodName.tsx
+++ b/ui/src/MethodName.tsx
@@ -1,0 +1,40 @@
+import { Method } from "./apps";
+import { cn } from "./cn";
+import { httpRequestOf, pathParts } from "./httpMethod";
+
+/**
+ * A method, wherever one is named: the path its own API gives it, or the name the
+ * proto surface gave it where there is no path.
+ *
+ * A REST operation is addressed by its verb and path — that is what its documentation
+ * says, what a person pastes from it, and what a script now writes — so a generated
+ * `GetShow` standing in for `GET /shows/{showId}` is Kaja's name for something that
+ * already had one.
+ *
+ * Two things are dimmed and the rest is the name: the **verb**, which qualifies the
+ * path rather than naming it, and each `{parameter}`, which is a blank to fill rather
+ * than part of the address. It is the treatment a filename's extension gets and the
+ * one the deeplink sheet gives a URL's scheme and keys — the same restraint, so the
+ * tree stays one list of names in one font.
+ *
+ * A fragment rather than an element, so the caller owns truncation, font and weight.
+ */
+export function MethodName({ method, className }: { method: Method; className?: string }) {
+  const request = httpRequestOf(method);
+  if (!request) return <>{method.name}</>;
+
+  return (
+    <>
+      <span className={cn("text-muted-foreground", className)}>{request.verb}</span>{" "}
+      {pathParts(request.path).map((part, index) =>
+        part.parameter ? (
+          <span key={index} className={cn("text-muted-foreground", className)}>
+            {part.text}
+          </span>
+        ) : (
+          <span key={index}>{part.text}</span>
+        ),
+      )}
+    </>
+  );
+}

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -23,6 +23,8 @@ import { usePersistedState } from "./usePersistedState";
 import { appType } from "./appTypes";
 import { AppTypeIcon } from "./AppTypeIcon";
 import { Method, App, Service, methodId } from "./apps";
+import { methodLabel } from "./httpMethod";
+import { MethodName } from "./MethodName";
 import { appWarnings, firstErrorMessage } from "./compileSummary";
 import { unsupportedReason } from "./streaming";
 import { KajaTrace } from "./KajaTrace";
@@ -348,7 +350,9 @@ export function Sidebar({
                                       }}
                                       onSelect={(event) => onSelect(method, service, app, !unsupported && event?.altKey ? "append" : "go")}
                                     >
-                                      <span className={cn(unsupported && "text-muted-foreground")}>{method.name}</span>
+<span className={cn(unsupported && "text-muted-foreground")}>
+                                        <MethodName method={method} />
+                                      </span>
                                       <TreeView.TrailingVisual>
                                         {/* Adding a call to the draft you already have open is
                                           deliberate, so it gets its own target rather than
@@ -361,7 +365,7 @@ export function Sidebar({
                                           (touch || hoveredMethod === mId) && (
                                             <RowAction
                                               icon={PlusIcon}
-                                              label={`Add ${method.name} to the open draft`}
+                                              label={`Add ${methodLabel(method)} to the open draft`}
                                               onClick={() => onSelect(method, service, app, "append")}
                                             />
                                           )

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -350,7 +350,7 @@ export function Sidebar({
                                       }}
                                       onSelect={(event) => onSelect(method, service, app, !unsupported && event?.altKey ? "append" : "go")}
                                     >
-<span className={cn(unsupported && "text-muted-foreground")}>
+                                      <span className={cn(unsupported && "text-muted-foreground")}>
                                         <MethodName method={method} />
                                       </span>
                                       <TreeView.TrailingVisual>

--- a/ui/src/appImports.ts
+++ b/ui/src/appImports.ts
@@ -1,5 +1,6 @@
 import { App } from "./apps";
 import { Source } from "./sources";
+import { REST_DOOR } from "./restDoor";
 
 // An import names an app. A path follows it only where the app declares one name
 // in two modules and the app alone cannot say which is meant — which is the whole
@@ -17,9 +18,14 @@ export function importable(app: App): Source[] {
   return app.sources.filter((source) => !source.importPath.endsWith(".client"));
 }
 
-// declaring returns the app's modules that export `name` under it.
+// declaring returns the app's modules that export `name` under it. The REST door is
+// one of those names: a module that declares it exports it exactly as it exports a
+// service, so it is ambiguous under the same rule and reached by a path under the same
+// one.
 export function declaring(app: App, name: string): Source[] {
-  return importable(app).filter((source) => source.serviceNames.includes(name) || source.enums[name] !== undefined);
+  return importable(app).filter(
+    (source) => source.serviceNames.includes(name) || source.enums[name] !== undefined || (name === REST_DOOR && source.restDoor === true),
+  );
 }
 
 // moduleSpecifier is what a script writes to reach `name` in `source`.

--- a/ui/src/appLoader.rest.test.ts
+++ b/ui/src/appLoader.rest.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "bun:test";
+import { generateMethodEditorCode, loadApp } from "./appLoader";
+import type { Source as ApiSource } from "./server/api";
+
+(globalThis as any).window = { location: { href: "http://localhost/" } };
+
+// An app whose methods carry the HTTP request they transcode to — what
+// server/pkg/apps/openapi writes onto every method it generates.
+const serviceTs = `
+import { ServiceType } from "@protobuf-ts/runtime-rpc";
+export interface ListShowsRequest { pageSize: number; }
+export interface ListShowsResponse { items: string[]; }
+export interface GetShowRequest { showId: string; expand: string; }
+export interface CreateShowRequest { title: string; }
+export interface Show { id: string; }
+export const Shows = new ServiceType("Shows", []);
+`;
+
+const clientTs = `
+import type { RpcOptions, UnaryCall } from "@protobuf-ts/runtime-rpc";
+import type { ListShowsRequest, ListShowsResponse, GetShowRequest, CreateShowRequest, Show } from "./service";
+export interface IShowsClient {
+    /**
+     * List every show in the season.
+     */
+    listShows(input: ListShowsRequest, options?: RpcOptions): UnaryCall<ListShowsRequest, ListShowsResponse>;
+    /**
+     * Fetch one show by its id.
+     */
+    getShow(input: GetShowRequest, options?: RpcOptions): UnaryCall<GetShowRequest, Show>;
+    /**
+     * Create a show.
+     */
+    createShow(input: CreateShowRequest, options?: RpcOptions): UnaryCall<CreateShowRequest, Show>;
+}
+`;
+
+// The field options are what the app writes where protobuf has no shape for what it
+// needs to say: which fields travel in the path, and which the API insists on.
+const stubCode = `
+export const proto$service = {
+  Shows: {
+    typeName: "theatre.Shows",
+    methods: [
+      { name: "ListShows", options: { "kaja.http_request": "GET /shows" },
+        I: { fields: [{ localName: "pageSize", options: { "kaja.http_in": "query" } }] } },
+      { name: "GetShow", options: { "kaja.http_request": "GET /shows/{showId}" },
+        I: { fields: [{ localName: "showId", options: { "kaja.http_in": "path", "kaja.http_required": true } },
+                      { localName: "expand", options: { "kaja.http_in": "query" } }] } },
+      { name: "CreateShow", options: { "kaja.http_request": "POST /shows" },
+        I: { fields: [{ localName: "title", options: { "kaja.http_required": true } }] } },
+    ],
+  },
+};
+export const proto$service$client = { ShowsClient: class { listShows() {} getShow() {} createShow() {} } };
+`;
+
+async function restApp() {
+  const apiSources: ApiSource[] = [
+    { path: "proto/service.ts", content: serviceTs },
+    { path: "proto/service.client.ts", content: clientTs },
+  ] as ApiSource[];
+  return loadApp(apiSources, stubCode, { name: "theatre" } as any, "kaja-app://x", "grpc" as any);
+}
+
+describe("the REST door", () => {
+  it("writes one overload per operation, addressed by the API's own path", async () => {
+    const app = await restApp();
+    const text = app.sources.find((s) => s.serviceNames.includes("Shows"))!.file.text;
+
+    expect(text).toContain("export const api: {");
+    expect(text).toContain(`get(path: "/shows", request?: Input<ListShowsRequest>, options?: CallOptions): Call<ListShowsResponse>;`);
+    expect(text).toContain(`get(path: "/shows/{showId}", request: WithPath<GetShowRequest, "showId">, options?: CallOptions): Call<Show>;`);
+    expect(text).toContain(`post(path: "/shows", request: Input<CreateShowRequest>, options?: CallOptions): Call<Show>;`);
+  });
+
+  // An overload is the only encoding that carries the API's description into the
+  // editor's hover and signature help, which is the whole reason the door is written
+  // as one rather than as a map keyed on the path.
+  it("carries the API's own description onto each overload", async () => {
+    const text = (await restApp()).sources.find((s) => s.serviceNames.includes("Shows"))!.file.text;
+    expect(text).toContain("/** Fetch one show by its id. */");
+    expect(text).toContain("/** List every show in the season. */");
+  });
+
+  it("insists on a path parameter and offers the request where nothing is insisted on", async () => {
+    const text = (await restApp()).sources.find((s) => s.serviceNames.includes("Shows"))!.file.text;
+    // Nothing required, so the request is optional and `api.get("/shows")` is the call.
+    expect(text).toContain(`get(path: "/shows", request?:`);
+    // A path parameter and a required body field each make it required.
+    expect(text).toContain(`get(path: "/shows/{showId}", request:`);
+    expect(text).toContain(`post(path: "/shows", request:`);
+  });
+
+  it("declares the door beside the services, so the module is one import", async () => {
+    const app = await restApp();
+    const source = app.sources.find((s) => s.serviceNames.includes("Shows"))!;
+    expect(source.restDoor).toBe(true);
+    // The door spells WithPath, so the module's type import carries it.
+    expect(source.file.text).toContain('import type { Call, CallOptions, Input, WithPath } from "kaja";');
+    // The service door is untouched: both address the same methods.
+    expect(source.file.text).toContain("export const Shows = {");
+  });
+
+  it("writes no door for an app whose methods stand for no HTTP request", async () => {
+    const plainStub = stubCode.replace(/"kaja.http_request": "[^"]*"/g, '"x": ""');
+    const apiSources: ApiSource[] = [
+      { path: "proto/service.ts", content: serviceTs },
+      { path: "proto/service.client.ts", content: clientTs },
+    ] as ApiSource[];
+    const app = await loadApp(apiSources, plainStub, { name: "theatre" } as any, "kaja-app://x", "grpc" as any);
+    const source = app.sources.find((s) => s.serviceNames.includes("Shows"))!;
+    expect(source.restDoor).toBeFalsy();
+    expect(source.file.text).not.toContain("export const api");
+    expect(source.file.text).toContain('import type { Call, CallOptions, Input } from "kaja";');
+  });
+});
+
+describe("the code a REST method generates", () => {
+  it("writes the call the way the API addresses it, under the app's own name", async () => {
+    const app = await restApp();
+    const service = app.services.find((s) => s.name === "Shows")!;
+    const code = generateMethodEditorCode(
+      app,
+      service,
+      service.methods.find((m) => m.name === "GetShow")!,
+    );
+
+    expect(code).toContain('import { api as theatre } from "theatre";');
+    expect(code).toContain('theatre.get("/shows/{showId}", {');
+    expect(code).toContain("showId:");
+    // The generated name is nowhere in it — the path is the name.
+    expect(code).not.toContain("GetShow");
+  });
+
+  it("writes the verb the operation is, not the one it reads like", async () => {
+    const app = await restApp();
+    const service = app.services.find((s) => s.name === "Shows")!;
+    const code = generateMethodEditorCode(
+      app,
+      service,
+      service.methods.find((m) => m.name === "CreateShow")!,
+    );
+    expect(code).toContain('theatre.post("/shows", {');
+  });
+
+  it("leaves a method that stands for no HTTP request on the service door", async () => {
+    const plainStub = stubCode.replace(/"kaja.http_request": "[^"]*"/g, '"x": ""');
+    const app = await loadApp(
+      [
+        { path: "proto/service.ts", content: serviceTs },
+        { path: "proto/service.client.ts", content: clientTs },
+      ] as ApiSource[],
+      plainStub,
+      { name: "theatre" } as any,
+      "kaja-app://x",
+      "grpc" as any,
+    );
+    const service = app.services.find((s) => s.name === "Shows")!;
+    const code = generateMethodEditorCode(
+      app,
+      service,
+      service.methods.find((m) => m.name === "GetShow")!,
+    );
+    expect(code).toContain('import { Shows } from "theatre";');
+    expect(code).toContain("Shows.GetShow({");
+  });
+
+  // The alias is what keeps two REST apps in one script readable, so an app whose name
+  // could not be one falls back to the export's own name rather than to broken code.
+  it("keeps the plain name where the app's name is no identifier", async () => {
+    const app = await loadApp(
+      [
+        { path: "proto/service.ts", content: serviceTs },
+        { path: "proto/service.client.ts", content: clientTs },
+      ] as ApiSource[],
+      stubCode,
+      { name: "grpcb.in" } as any,
+      "kaja-app://x",
+      "grpc" as any,
+    );
+    const service = app.services.find((s) => s.name === "Shows")!;
+    const code = generateMethodEditorCode(
+      app,
+      service,
+      service.methods.find((m) => m.name === "ListShows")!,
+    );
+    expect(code).toContain('import { api } from "grpcb.in";');
+    expect(code).toContain('api.get("/shows", {');
+  });
+});

--- a/ui/src/appLoader.ts
+++ b/ui/src/appLoader.ts
@@ -11,11 +11,23 @@ import { moduleSpecifier } from "./appImports";
 import { unsupportedReason } from "./streaming";
 import { HttpRequest, httpRequestOf, parseHttpRequest, verbMember } from "./httpMethod";
 import { doorBinding, REST_DOOR } from "./restDoor";
+import { restEditorCode } from "./openapi/module";
 
 // Generate editor code for a method on demand. `fields` is how much of the request is
 // written out: the whole shape for a person clicking the method in the tree, the
 // required fields alone for a reader who has the declarations already (see FieldSet).
 export function generateMethodEditorCode(app: App, service: Service, method: Method, fields: FieldSet = "all"): string {
+  // An app read from its own document has no stub to look a method up in: the
+  // call is written from the operation, which is the only place it was ever
+  // described.
+  if (app.rest) {
+    const binding = doorBinding(app.configuration.name);
+    const call = restEditorCode(app.rest, method.name, binding);
+    if (!call) return `// Error: Could not find operation ${method.name}`;
+    const alias = binding === REST_DOOR ? REST_DOOR : `${REST_DOOR} as ${binding}`;
+    return `import { ${alias} } from ${JSON.stringify(app.configuration.name)};\n\n${call}`;
+  }
+
   const source = app.sources.find((s) => s.importPath === service.sourcePath);
   if (!source) {
     return `// Error: Could not find source for service ${service.name}`;

--- a/ui/src/appLoader.ts
+++ b/ui/src/appLoader.ts
@@ -1,3 +1,4 @@
+import type { IMessageType } from "@protobuf-ts/runtime";
 import { MethodInfo, ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import ts from "typescript";
 import { createClient } from "./client";
@@ -8,6 +9,8 @@ import { docText } from "./declarations";
 import { findInStub, loadSources, parseStub, Source, Sources, Stub } from "./sources";
 import { moduleSpecifier } from "./appImports";
 import { unsupportedReason } from "./streaming";
+import { HttpRequest, httpRequestOf, parseHttpRequest, verbMember } from "./httpMethod";
+import { doorBinding, REST_DOOR } from "./restDoor";
 
 // Generate editor code for a method on demand. `fields` is how much of the request is
 // written out: the whole shape for a person clicking the method in the tree, the
@@ -39,6 +42,7 @@ export async function loadApp(apiSources: ApiSource[], stubCode: string, configu
 
   sources.forEach((source) => {
     const serviceInterfaceDefinitions: ts.VariableStatement[] = [];
+    const restOperations: RestOperation[] = [];
 
     source.serviceNames.forEach((serviceName) => {
       const serviceInfo: ServiceInfo | undefined = findInStub(stub, source, serviceName);
@@ -80,6 +84,17 @@ export async function loadApp(apiSources: ApiSource[], stubCode: string, configu
       if (interfaceDeclaration && clientSource) {
         serviceInterfaceDefinitions.push(createServiceInterfaceDefinition(serviceName, interfaceDeclaration, clientSource.file, signatures));
       }
+
+      // Collected here because this is where the signature and the message type are both
+      // in hand: the door is written from the TypeScript names a script sees, not from
+      // the proto the app generated them out of.
+      serviceInfo.methods.forEach((methodInfo, index) => {
+        const request = httpRequestOf(methods[index]);
+        const signature = signatures[methodInfo.name];
+        if (request && signature) {
+          restOperations.push({ request, signature, requestType: methodInfo.I as IMessageType<object> | undefined });
+        }
+      });
     });
 
     const kajaStatements = source.file.statements.filter((statement) => {
@@ -89,6 +104,11 @@ export async function loadApp(apiSources: ApiSource[], stubCode: string, configu
         (ts.isImportDeclaration(statement) && isAnotherSourceImport(statement, source.file))
       );
     });
+
+    // The door is written per module, over the services that module declares. An app
+    // whose proto surface kaja generated has exactly one, so for a REST app that is the
+    // whole app — which is what makes one `api` the address of every path it serves.
+    const door = restDoorDeclaration(restOperations);
 
     kajaSources.push({
       path: source.path,
@@ -100,10 +120,12 @@ export async function loadApp(apiSources: ApiSource[], stubCode: string, configu
         // A method hands back a Call rather than a Promise and takes an Input rather than the
         // request type itself, so the source that declares one says where those types come
         // from — the same module a script imports `kaja` from.
-        printStatements([...(serviceInterfaceDefinitions.length > 0 ? [kajaTypeImport()] : []), ...kajaStatements, ...serviceInterfaceDefinitions]),
+        printStatements([...(serviceInterfaceDefinitions.length > 0 ? [kajaTypeImport(door !== "")] : []), ...kajaStatements, ...serviceInterfaceDefinitions]) +
+          door,
         ts.ScriptTarget.Latest,
       ),
       serviceNames: source.serviceNames,
+      restDoor: door !== "",
       interfaces: source.interfaces,
       enums: source.enums,
       declarations: source.declarations,
@@ -189,7 +211,14 @@ function getOutputType(method: ts.MethodSignature, sourceFile: ts.SourceFile): t
 }
 
 function methodEditorCode(methodInfo: MethodInfo, serviceName: string, source: Source, app: App, fields: FieldSet): string {
-  const imports = addImport({}, serviceName, source);
+  // A REST method is written the way its own API writes it. The door is the default
+  // because the path is the name the API gave the operation — a generated `GetShow` is
+  // Kaja's name for something already named — and it is a second address rather than a
+  // replacement, so the service form still compiles beside it.
+  const request = source.restDoor ? parseHttpRequest(httpRequest(methodInfo)) : undefined;
+  const binding = request ? doorBinding(app.configuration.name) : undefined;
+
+  const imports = addImport({}, request ? REST_DOOR : serviceName, source);
   const input = defaultMessage(methodInfo.I, app.sources, imports, new Set(), fields);
 
   let statements: ts.Statement[] = [];
@@ -214,11 +243,13 @@ function methodEditorCode(methodInfo: MethodInfo, serviceName: string, source: S
           false, // isTypeOnly
           undefined, // name
           ts.factory.createNamedImports(
-            [...bySpecifier[path]].map((enumName) => {
+            [...bySpecifier[path]].map((importedName) => {
+              // `api as theatre`: one export name, read under the app's own.
+              const aliased = importedName === REST_DOOR && binding !== undefined && binding !== REST_DOOR;
               return ts.factory.createImportSpecifier(
                 false, // propertyName
-                undefined,
-                ts.factory.createIdentifier(enumName),
+                aliased ? ts.factory.createIdentifier(REST_DOOR) : undefined,
+                ts.factory.createIdentifier(aliased ? binding! : importedName),
               );
             }),
           ), // elements
@@ -229,11 +260,17 @@ function methodEditorCode(methodInfo: MethodInfo, serviceName: string, source: S
   }
 
   let call: ts.Statement = ts.factory.createExpressionStatement(
-    ts.factory.createCallExpression(
-      ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(serviceName), ts.factory.createIdentifier(methodInfo.name)),
-      undefined,
-      [input],
-    ),
+    request
+      ? ts.factory.createCallExpression(
+          ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(binding!), ts.factory.createIdentifier(verbMember(request))),
+          undefined,
+          [ts.factory.createStringLiteral(request.path), input],
+        )
+      : ts.factory.createCallExpression(
+          ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(serviceName), ts.factory.createIdentifier(methodInfo.name)),
+          undefined,
+          [input],
+        ),
   );
 
   // The call is written out even where Kaja won't make it, because the request is
@@ -305,15 +342,18 @@ function readSignatures(
 
 // `import type { Call, CallOptions, Input } from "kaja";` — what a generated service's
 // methods return, and what they take. Type-only, so nothing about it survives into
-// what a script runs.
-function kajaTypeImport(): ts.ImportDeclaration {
+// what a script runs. WithPath rides along only where the module writes a REST door,
+// which is the only thing that spells it.
+function kajaTypeImport(withPath: boolean): ts.ImportDeclaration {
   return ts.factory.createImportDeclaration(
     undefined,
     ts.factory.createImportClause(
       true,
       undefined,
       ts.factory.createNamedImports(
-        ["Call", "CallOptions", "Input"].map((name) => ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(name))),
+        [...["Call", "CallOptions", "Input"], ...(withPath ? ["WithPath"] : [])].map((name) =>
+          ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(name)),
+        ),
       ),
     ),
     ts.factory.createStringLiteral("kaja"),
@@ -402,6 +442,80 @@ function createServiceInterfaceDefinition(
       ts.NodeFlags.Const,
     ),
   );
+}
+
+// RestOperation is one path the door answers, with the TypeScript a script writes
+// against it.
+interface RestOperation {
+  request: HttpRequest;
+  signature: MethodSignature;
+  requestType?: IMessageType<object>;
+}
+
+// The field option marking a field the API carries in the path. Read rather than the
+// `{braces}` in the path template, because a path names the API's parameter and the
+// request names the generated field — `{show_id}` against `showId` — and a required
+// key nobody can spell is worse than no requirement at all.
+const HTTP_IN_OPTION = "kaja.http_in";
+const HTTP_REQUIRED_OPTION = "kaja.http_required";
+
+function fieldsWhere(messageType: IMessageType<object> | undefined, predicate: (options: { [key: string]: unknown }) => boolean): string[] {
+  return (messageType?.fields ?? []).filter((field) => predicate((field.options ?? {}) as { [key: string]: unknown })).map((field) => field.localName);
+}
+
+// restDoorDeclaration writes the door a script addresses a REST app through:
+//
+//   export const api: {
+//     /** Fetch one show. */
+//     get(path: "/shows/{showId}", request: WithPath<GetShowRequest, "showId">, options?: CallOptions): Call<Show>;
+//   } = {} as never;
+//
+// One overload per operation rather than a map keyed on the path, because only an
+// overload carries the API's own description into the editor's hover and signature
+// help — a map's property documentation reaches neither, and the description is the
+// thing a generated method name was already failing to say.
+//
+// The stub is `{} as never` because nothing in the editor's copy runs: the value a
+// script gets is bound at run time from the app's clients (restDoor.ts).
+function restDoorDeclaration(operations: RestOperation[]): string {
+  if (operations.length === 0) return "";
+
+  const byVerb = new Map<string, RestOperation[]>();
+  for (const operation of operations) {
+    const verb = verbMember(operation.request);
+    (byVerb.get(verb) ?? byVerb.set(verb, []).get(verb)!).push(operation);
+  }
+
+  const lines: string[] = ["", `export const ${REST_DOOR}: {`];
+  for (const [verb, verbOperations] of byVerb) {
+    // Sorted by path so the list reads as the API's own index rather than as whatever
+    // order the document happened to declare its operations in.
+    for (const operation of [...verbOperations].sort((a, b) => a.request.path.localeCompare(b.request.path))) {
+      if (operation.signature.doc) {
+        lines.push(`    /** ${operation.signature.doc} */`);
+      }
+      lines.push(`    ${verb}(${overloadParameters(operation)}): Call<${operation.signature.output}>;`);
+    }
+  }
+  lines.push(`} = {} as never;`, "");
+  return lines.join("\n");
+}
+
+function overloadParameters(operation: RestOperation): string {
+  const path = JSON.stringify(operation.request.path);
+  const inPath = fieldsWhere(operation.requestType, (options) => options[HTTP_IN_OPTION] === "path");
+
+  // A path parameter is the one field a call cannot leave out, because without it the
+  // path is not an address. Everything else stays as Input leaves it.
+  const request = inPath.length
+    ? `WithPath<${operation.signature.input}, ${inPath.map((name) => JSON.stringify(name)).join(" | ")}>`
+    : `Input<${operation.signature.input}>`;
+
+  // The request is offered rather than demanded exactly when the operation insists on
+  // nothing: `api.get("/shows")` is the whole call for a listing that takes no
+  // parameters, and spelling out `{}` there would be a rule with no reason behind it.
+  const required = inPath.length > 0 || fieldsWhere(operation.requestType, (options) => options[HTTP_REQUIRED_OPTION] === true).length > 0;
+  return `path: ${path}, request${required ? "" : "?"}: ${request}, options?: CallOptions`;
 }
 
 // httpRequest reads the HTTP request a method transcodes to, when the app wrote one

--- a/ui/src/apps.ts
+++ b/ui/src/apps.ts
@@ -1,4 +1,5 @@
 import { Call, CallOptions, Kaja } from "./kaja";
+import type { RestModule } from "./openapi/module";
 import { APP_OF } from "./rateLimit";
 import { Sources, Stub } from "./sources";
 import { ConfigurationApp, Log } from "./server/api";
@@ -59,6 +60,10 @@ export function scriptName(script: { name: string; folder: string }): string {
 
 export interface App {
   configuration: ConfigurationApp;
+  // What the app's own document said, for an app read in the browser rather than
+  // compiled. It is how the generated call is written and what the hover reads,
+  // and its absence is what says an app came through the compiler.
+  rest?: RestModule;
   appRef: AppRef;
   compilation: Compilation;
   services: Service[];

--- a/ui/src/callLabel.test.ts
+++ b/ui/src/callLabel.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { Method, Service } from "./apps";
+import { callLabel, MethodCall } from "./kaja";
+
+function call(method: Method, http?: { method: string; url: string }): MethodCall {
+  const service: Service = { name: "Shows", packageName: "", sourcePath: "", clientStubModuleId: "", methods: [method] };
+  return { id: "1", appName: "theatre", service, method, input: {}, requestHeaders: {}, timestamp: 0, http } as MethodCall;
+}
+
+// Three kinds of call, each named the way its own world names it. The fetch case is
+// covered where fetch is; these two are the rest of the rule.
+describe("callLabel", () => {
+  it("names a method the API gives a path by that path", () => {
+    expect(callLabel(call({ name: "GetShow", http: "GET /shows/{showId}" }))).toBe("GET /shows/{showId}");
+  });
+
+  it("names a method with no path by its service and its name", () => {
+    expect(callLabel(call({ name: "GetShow" }))).toBe("Shows.GetShow");
+  });
+
+  // A fetch has neither a service nor an operation, and it wins: the method beside
+  // it on a fetch call is a placeholder, not something to read.
+  it("names a fetch by its verb and host, whatever the method says", () => {
+    expect(callLabel(call({ name: "fetch", http: "GET /shows" }, { method: "POST", url: "https://api.example.com/orders" }))).toBe("POST api.example.com");
+  });
+});

--- a/ui/src/draftTitle.test.ts
+++ b/ui/src/draftTitle.test.ts
@@ -174,3 +174,34 @@ describe("scripts that draw", () => {
     expect(deriveDraftTitle(code)).toBeUndefined();
   });
 });
+
+// A draft made by clicking a path is named by that path, the way the tree named it.
+// Every call through the door shares its verb, so a title read off the receiver and
+// the member alone would call them all `get`.
+describe("a call through the REST door", () => {
+  it("is named by the path it addresses", () => {
+    expect(deriveDraftTitle(`import { api as theatre } from "theatre";\n\ntheatre.get("/shows", {});\n`)).toBe("GET /shows");
+  });
+
+  it("takes its subject from the request, which is the second argument", () => {
+    expect(deriveDraftTitle(`import { api as theatre } from "theatre";\n\ntheatre.get("/shows/{showId}", { showId: "vera-lune" });\n`)).toBe(
+      "GET /shows/{showId} · vera-lune",
+    );
+  });
+
+  it("reads two paths as the sequence they are", () => {
+    const code = `import { api as theatre } from "theatre";\n\nawait theatre.get("/shows", {});\nawait theatre.post("/shows", { title: "x" });\n`;
+    expect(deriveDraftTitle(code)).toBe("GET /shows → POST /shows");
+  });
+
+  it("is unmoved by a receiver that only looks like a door", () => {
+    expect(deriveDraftTitle(`const theatre = { get: (p: string) => p };\ntheatre.get("/shows");\n`)).toBeUndefined();
+  });
+
+  it("proposes a filename from the path rather than from the verb every call shares", () => {
+    expect(proposeFileName("GET /shows")).toBe("shows");
+    expect(proposeFileName("GET /shows/{showId} · vera-lune")).toBe("shows");
+    // A title that is not a path is untouched.
+    expect(proposeFileName("ListShows")).toBe("listShows");
+  });
+});

--- a/ui/src/draftTitle.ts
+++ b/ui/src/draftTitle.ts
@@ -1,6 +1,6 @@
 import { fetchHost, fetchKey } from "./fetchCall";
 import { SUBJECT_FIELDS } from "./loopKey";
-import { importedNames, runtimeNames } from "./scriptBindings";
+import { doorNames, importedNames, runtimeNames } from "./scriptBindings";
 import ts from "typescript";
 
 // A request small enough to read at a glance is described by its values, which is
@@ -8,6 +8,8 @@ import ts from "typescript";
 // rather than picking an arbitrary field out of a crowd.
 const SMALL_REQUEST_FIELDS = 3;
 const MAX_SUBJECT = 24;
+
+const HTTP_VERBS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
 
 // A call a draft makes, in source order.
 export interface DraftCall {
@@ -23,6 +25,7 @@ export function readCalls(code: string): DraftCall[] {
   const file = ts.createSourceFile("draft.ts", code, ts.ScriptTarget.Latest, /*setParentNodes*/ false, ts.ScriptKind.TS);
   const imported = importedNames(file);
   const runtime = runtimeNames(file);
+  const doors = doorNames(file);
   const calls: DraftCall[] = [];
 
   const visit = (node: ts.Node) => {
@@ -40,6 +43,21 @@ export function readCalls(code: string): DraftCall[] {
       // `kaja.table(...)` is the script drawing rather than a call it made — a script that
       // only draws would otherwise be titled `text +3`.
       if (runtime.has(service)) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      // A call through the REST door is named by the path it addresses, the way the
+      // tree names it — `theatre.get(...)` would otherwise title every such draft `get`.
+      // The request is the second argument there, the first being the path itself.
+      if (doors.has(service)) {
+        const path = node.arguments[0];
+        if (path && ts.isStringLiteral(path)) {
+          calls.push({
+            service,
+            method: `${node.expression.name.text.toUpperCase()} ${path.text}`,
+            subject: subjectOf(node.arguments[1]),
+          });
+        }
         ts.forEachChild(node, visit);
         return;
       }
@@ -184,11 +202,15 @@ export function titleParts(title: string): { name: string; qualifier?: string } 
  * whole pile at once produces even where saving one at a time wouldn't.
  */
 export function proposeFileName(title: string, taken: Iterable<string> = []): string {
-  const word =
-    title
-      .replace(/[^A-Za-z0-9]+/g, " ")
-      .trim()
-      .split(" ")[0] || "draft";
+  // A REST title opens with the verb, which every call through that door shares — so
+  // the word that names this one is the next.
+  const words = title
+    .replace(/[^A-Za-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+  if (words.length > 1 && HTTP_VERBS.has(words[0].toUpperCase())) words.shift();
+  const word = words[0] || "draft";
   const base = word.charAt(0).toLowerCase() + word.slice(1);
   const used = new Set([...taken].map((name) => name.replace(/\.ts$/, "").toLowerCase()));
   if (!used.has(base.toLowerCase())) return base;

--- a/ui/src/drafts.test.ts
+++ b/ui/src/drafts.test.ts
@@ -197,6 +197,30 @@ describe("appendCall", () => {
     expect(merged.indexOf("Seating.GetSeatMap")).toBeGreaterThan(merged.indexOf("TheKajaTheatre.ListShows"));
   });
 
+  // The REST door is exported as `api` and read under the app's name, so a name folded
+  // into an existing line has to arrive as it was written: `api` alone binds nothing.
+  it("folds an aliased binding in as it was written", () => {
+    const merged = appendCall(
+      `import { TheKajaTheatre } from "theatre/service";\n\nTheKajaTheatre.ListShows({});\n`,
+      `import { api as theatre } from "theatre/service";\n\ntheatre.get("/shows");\n`,
+    );
+
+    expect(merged.match(/^import/gm)).toHaveLength(1);
+    expect(merged).toContain("{ TheKajaTheatre, api as theatre }");
+    expect(merged).toContain('theatre.get("/shows");');
+  });
+
+  it("does not fold in a binding the line already has under its alias", () => {
+    const merged = appendCall(
+      `import { api as theatre } from "theatre/service";\n\ntheatre.get("/shows");\n`,
+      `import { api as theatre } from "theatre/service";\n\ntheatre.get("/venues");\n`,
+    );
+
+    expect(merged.match(/^import/gm)).toHaveLength(1);
+    expect(merged).toContain("{ api as theatre }");
+    expect(merged).not.toContain("api as theatre, api as theatre");
+  });
+
   it("keeps whatever the author wrote in between", () => {
     const authored = `import { TheKajaTheatre } from "theatre/service";\n\n// my note\nconst shows = TheKajaTheatre.ListShows({});\n`;
     expect(appendCall(authored, getShow)).toContain("// my note");

--- a/ui/src/drafts.ts
+++ b/ui/src/drafts.ts
@@ -161,7 +161,7 @@ export function appendCall(existingCode: string, generatedCode: string): string 
       continue;
     }
 
-    const missing = imported.names.filter((name) => !target.names.includes(name));
+    const missing = imported.specifiers.filter((_, index) => !target.names.includes(imported.names[index]));
     if (missing.length === 0) continue;
     // Insert after the last name in the existing named imports, keeping whatever spacing
     // sits before the closing brace.
@@ -183,7 +183,11 @@ export function appendCall(existingCode: string, generatedCode: string): string 
 
 interface ImportLine {
   module: string;
+  // The local names the line binds — what a name is matched against.
   names: string[];
+  // The specifiers as written, which is what a missing one is inserted as: `api as
+  // theatre` binds `theatre`, and re-inserting the local name alone would bind nothing.
+  specifiers: string[];
   text: string;
   end: number;
 }
@@ -193,8 +197,14 @@ function importsOf(file: ts.SourceFile, code: string): ImportLine[] {
   for (const statement of file.statements) {
     if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
     const bindings = statement.importClause?.namedBindings;
-    const names = bindings && ts.isNamedImports(bindings) ? bindings.elements.map((element) => element.name.text) : [];
-    lines.push({ module: statement.moduleSpecifier.text, names, text: code.slice(statement.getStart(file), statement.end), end: statement.end });
+    const elements = bindings && ts.isNamedImports(bindings) ? bindings.elements : [];
+    lines.push({
+      module: statement.moduleSpecifier.text,
+      names: elements.map((element) => element.name.text),
+      specifiers: elements.map((element) => code.slice(element.getStart(file), element.end)),
+      text: code.slice(statement.getStart(file), statement.end),
+      end: statement.end,
+    });
   }
   return lines;
 }

--- a/ui/src/httpMethod.test.ts
+++ b/ui/src/httpMethod.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "bun:test";
+import { Method, Service } from "./apps";
+import { isRestService, methodLabel, parseHttpRequest, pathParameters, pathParts, restOperations, verbMember } from "./httpMethod";
+
+function method(name: string, http?: string): Method {
+  return { name, http };
+}
+
+function service(name: string, methods: Method[]): Service {
+  return { name, packageName: "", sourcePath: "", clientStubModuleId: "", methods };
+}
+
+describe("parseHttpRequest", () => {
+  it("splits the verb from the path", () => {
+    expect(parseHttpRequest("GET /shows")).toEqual({ verb: "GET", path: "/shows" });
+    expect(parseHttpRequest("DELETE /shows/{showId}")).toEqual({ verb: "DELETE", path: "/shows/{showId}" });
+  });
+
+  it("normalizes the verb, so a document shouting or whispering reads the same", () => {
+    expect(parseHttpRequest("get /shows")).toEqual({ verb: "GET", path: "/shows" });
+  });
+
+  it("is nothing where the method carries no request", () => {
+    expect(parseHttpRequest(undefined)).toBeUndefined();
+    expect(parseHttpRequest("")).toBeUndefined();
+  });
+
+  // A verb with no door would generate a member nothing can call, and a path that is
+  // not a path is not an address.
+  it("refuses what the door could not offer", () => {
+    expect(parseHttpRequest("TRACE /shows")).toBeUndefined();
+    expect(parseHttpRequest("GET shows")).toBeUndefined();
+    expect(parseHttpRequest("/shows")).toBeUndefined();
+  });
+});
+
+describe("verbMember", () => {
+  it("is the lowercase verb the script writes", () => {
+    expect(verbMember({ verb: "GET", path: "/shows" })).toBe("get");
+    expect(verbMember({ verb: "DELETE", path: "/shows" })).toBe("delete");
+  });
+});
+
+describe("pathParameters", () => {
+  it("reads the templated names in the order the path names them", () => {
+    expect(pathParameters("/shows/{showId}/cast/{castId}")).toEqual(["showId", "castId"]);
+  });
+
+  it("is empty for a path that templates nothing", () => {
+    expect(pathParameters("/shows")).toEqual([]);
+  });
+});
+
+describe("pathParts", () => {
+  it("splits the address from what is filled in", () => {
+    expect(pathParts("/shows/{showId}/cast")).toEqual([
+      { text: "/shows/", parameter: false },
+      { text: "{showId}", parameter: true },
+      { text: "/cast", parameter: false },
+    ]);
+  });
+
+  it("keeps a path with nothing templated in one part", () => {
+    expect(pathParts("/shows")).toEqual([{ text: "/shows", parameter: false }]);
+  });
+
+  it("puts a trailing parameter last rather than inventing an empty part after it", () => {
+    expect(pathParts("/shows/{showId}")).toEqual([
+      { text: "/shows/", parameter: false },
+      { text: "{showId}", parameter: true },
+    ]);
+  });
+});
+
+describe("methodLabel", () => {
+  it("names a REST method by the request it stands for", () => {
+    expect(methodLabel(method("GetShow", "GET /shows/{showId}"))).toBe("GET /shows/{showId}");
+  });
+
+  it("leaves a method with no request under its own name", () => {
+    expect(methodLabel(method("ListShows"))).toBe("ListShows");
+  });
+});
+
+describe("isRestService and restOperations", () => {
+  it("finds the operations across every service of an app", () => {
+    const services = [
+      service("Shows", [method("ListShows", "GET /shows"), method("GetShow", "GET /shows/{showId}")]),
+      service("Venues", [method("ListVenues", "GET /venues")]),
+    ];
+    expect(restOperations(services).map((operation) => `${operation.request.verb} ${operation.request.path}`)).toEqual([
+      "GET /shows",
+      "GET /shows/{showId}",
+      "GET /venues",
+    ]);
+  });
+
+  it("says a service with nothing to route is not one", () => {
+    expect(isRestService(service("Shows", [method("ListShows")]))).toBe(false);
+    expect(restOperations([service("Shows", [method("ListShows")])])).toEqual([]);
+  });
+});

--- a/ui/src/httpMethod.ts
+++ b/ui/src/httpMethod.ts
@@ -1,4 +1,6 @@
-import { Method, Service } from "./apps";
+// Types only, so this module adds no runtime edge to apps — which is what lets
+// kaja.ts read it without a cycle.
+import type { Method, Service } from "./apps";
 
 // A method's HTTP request, as the app wrote it onto the method: `GET /shows/{showId}`.
 // See server/pkg/apps/openapi/http.proto.

--- a/ui/src/httpMethod.ts
+++ b/ui/src/httpMethod.ts
@@ -1,0 +1,85 @@
+import { Method, Service } from "./apps";
+
+// A method's HTTP request, as the app wrote it onto the method: `GET /shows/{showId}`.
+// See server/pkg/apps/openapi/http.proto.
+//
+// The pair is the API's own identity for an operation — an OpenAPI document is a map
+// of paths to verbs — so it is unique where a generated method name only is because
+// protogen went to trouble to make it so. That is what lets it be the address a script
+// writes and the label the tree shows.
+export interface HttpRequest {
+  verb: string;
+  path: string;
+}
+
+// The verbs the REST door offers. A document declaring anything else keeps its methods
+// and is reached by name alone: a door has to be a member the editor can check.
+const VERBS = ["get", "post", "put", "patch", "delete", "head", "options"];
+
+export function parseHttpRequest(request: string | undefined): HttpRequest | undefined {
+  if (!request) return undefined;
+  const space = request.indexOf(" ");
+  if (space <= 0) return undefined;
+  const verb = request.slice(0, space).trim();
+  const path = request.slice(space + 1).trim();
+  if (!path.startsWith("/") || !VERBS.includes(verb.toLowerCase())) return undefined;
+  return { verb: verb.toUpperCase(), path };
+}
+
+export function httpRequestOf(method: Method): HttpRequest | undefined {
+  return parseHttpRequest(method.http);
+}
+
+// The member of the REST door a method is reached through — `get`, `post`. Lowercase
+// because it is written in a script; `delete` is a member name rather than a binding,
+// so the reserved word costs nothing.
+export function verbMember(request: HttpRequest): string {
+  return request.verb.toLowerCase();
+}
+
+// Whether the app has a REST surface at all: one method carrying an HTTP request is
+// enough, and an app where none does never grows a door.
+export function isRestService(service: Service): boolean {
+  return service.methods.some((method) => httpRequestOf(method) !== undefined);
+}
+
+export function restOperations(services: Service[]): Array<{ service: Service; method: Method; request: HttpRequest }> {
+  const operations: Array<{ service: Service; method: Method; request: HttpRequest }> = [];
+  for (const service of services) {
+    for (const method of service.methods) {
+      const request = httpRequestOf(method);
+      if (request) operations.push({ service, method, request });
+    }
+  }
+  return operations;
+}
+
+// The parameters a path templates, in the order it names them: `/shows/{showId}/cast`
+// gives ["showId"]. Read off the path rather than off the request, because the path is
+// what a person is looking at when they wonder what a call still needs.
+export function pathParameters(path: string): string[] {
+  return [...path.matchAll(/\{([^{}]+)\}/g)].map((match) => match[1]);
+}
+
+// A path split around its templated parameters, so a row can draw `{showId}` quieter
+// than the segments that are literally the address. Always starts with a literal part,
+// which is empty when the path opens with a parameter.
+export function pathParts(path: string): Array<{ text: string; parameter: boolean }> {
+  const parts: Array<{ text: string; parameter: boolean }> = [];
+  let index = 0;
+  for (const match of path.matchAll(/\{[^{}]+\}/g)) {
+    if (match.index! > index) parts.push({ text: path.slice(index, match.index), parameter: false });
+    parts.push({ text: match[0], parameter: true });
+    index = match.index! + match[0].length;
+  }
+  if (index < path.length) parts.push({ text: path.slice(index), parameter: false });
+  return parts;
+}
+
+// What the method is called in every list that names one. A REST method is named by
+// the request it stands for, because that is the name its own API gives it; anything
+// else keeps the name the proto surface gave it.
+export function methodLabel(method: Method): string {
+  const request = httpRequestOf(method);
+  return request ? `${request.verb} ${request.path}` : method.name;
+}

--- a/ui/src/kaja.ts
+++ b/ui/src/kaja.ts
@@ -31,6 +31,7 @@ import {
   rateLimitHost,
   readResponseHeaders,
 } from "./fetchCall";
+import { httpRequestOf } from "./httpMethod";
 import { loopKey } from "./loopKey";
 import { describeSchedule, PerfBody, PerfPlan, PerfReport, perfReport, PerfSchedule, PerfTestOptions, runPerfTest } from "./perfTest";
 import { RunMetrics } from "./runStats";
@@ -1191,12 +1192,19 @@ export interface MethodCall {
 
 /**
  * What a call is called, wherever one is named — the log's rows, the strip, the
- * stats table, a failure notice, the report an agent reads. A service method is its
- * service and its name; a fetch has neither, so it is the verb and the host it went
- * to, and the path that tells two hundred of them apart is the row's key.
+ * stats table, a failure notice, the report an agent reads.
+ *
+ * Three kinds, and each is named the way its own world names it. A fetch has no
+ * service and no method, so it is the verb and the host it went to, and the path
+ * that tells two hundred of them apart is the row's key. A method the API gives a
+ * path is that path, because the document named the operation and Kaja's generated
+ * name was standing in front of one that already existed. Everything else is its
+ * service and its name.
  */
 export function callLabel(methodCall: MethodCall): string {
   if (methodCall.http) return fetchLabel(methodCall.http.method, methodCall.http.url);
+  const request = httpRequestOf(methodCall.method);
+  if (request) return `${request.verb} ${request.path}`;
   return `${methodCall.service.name}.${methodCall.method.name}`;
 }
 

--- a/ui/src/kajaModule.ts
+++ b/ui/src/kajaModule.ts
@@ -101,6 +101,16 @@ export type Input<T> = T extends Uint8Array
       ? { [K in keyof T]?: Input<T[K]> }
       : T;
 
+/**
+ * The request a REST path takes: an \`Input\` whose path parameters are insisted on.
+ *
+ * A path templates the values it cannot be addressed without —
+ * \`GET /shows/{showId}\` is not an address until \`showId\` has one — so those fields
+ * are the exception to everything else being optional. Every other field stays as
+ * \`Input\` leaves it, marked \`[required]\` in its declaration where the API insists.
+ */
+export type WithPath<T, K extends keyof Input<T>> = Input<T> & Required<Pick<Input<T>, K>>;
+
 /** A plain JSON value, as accepted by kaja.value and friends. */
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 

--- a/ui/src/mcpCatalog.test.ts
+++ b/ui/src/mcpCatalog.test.ts
@@ -190,16 +190,31 @@ describe("buildMcpCatalog", () => {
     const built = await catalog();
     const [listShows, getShow] = built.apps[0].services[0].methods;
 
-    expect(listShows.example).toContain('import { Shows } from "theatre"');
-    expect(listShows.example).toContain("Shows.ListShows({})");
+    // These methods stand for HTTP requests, so the call is written the way the API
+    // addresses them — the same code clicking the path in the tree writes.
+    expect(listShows.example).toContain('import { api as theatre } from "theatre"');
+    expect(listShows.example).toContain('theatre.get("/shows", {})');
     // Nothing in this request is required, so nothing is written out — including the
     // enum, whose import goes with it.
     expect(listShows.example).not.toContain("pageSize");
     expect(listShows.example).not.toContain("Sort");
 
-    expect(getShow.example).toContain("Shows.GetShow(");
+    expect(getShow.example).toContain('theatre.get("/shows/{showId}", {');
     expect(getShow.example).toContain('showId: ""');
     expect(getShow.example).not.toContain("fields");
+  });
+
+  // An agent is shown one spelling: the signature its example is an instance of.
+  it("carries the door's own declaration beside the example it writes", async () => {
+    const built = await catalog();
+    const [listShows, getShow] = built.apps[0].services[0].methods;
+
+    expect(built.apps[0].restBinding).toBe("theatre");
+    expect(listShows.restSignature).toContain('get(path: "/shows"');
+    expect(getShow.restSignature).toContain('get(path: "/shows/{showId}"');
+    // The declaration ends at the response type, not at the semicolon of the line it
+    // was read off.
+    expect(getShow.restSignature?.endsWith(";")).toBe(false);
   });
 
   it("leaves out an app that has not compiled", async () => {

--- a/ui/src/mcpCatalog.ts
+++ b/ui/src/mcpCatalog.ts
@@ -1,6 +1,8 @@
 import { generateMethodEditorCode } from "./appLoader";
 import { moduleSpecifier } from "./appImports";
 import { App, Method, Service } from "./apps";
+import { httpRequestOf, verbMember } from "./httpMethod";
+import { doorBinding } from "./restDoor";
 import { appType } from "./appTypes";
 import { Declaration } from "./declarations";
 import { kajaModuleDeclaration } from "./kajaModule";
@@ -23,6 +25,10 @@ export interface McpCatalog {
 export interface McpApp {
   name: string;
   type: string;
+  // What the app's REST door is read under, where it has one — `theatre` for
+  // `import { api as theatre }`. Absent for an app whose methods stand for no
+  // HTTP request, which is every app that isn't built from a REST document.
+  restBinding?: string;
   services: McpService[];
   // Every type the app's services name, by its TypeScript name. An answer closes
   // over this to reach everything a request or response mentions.
@@ -49,6 +55,11 @@ export interface McpMethod {
   // The HTTP request the method stands for, when the app said so. It is the only
   // thing that states whether calling the method reads or writes.
   http?: string;
+  // The method as the REST door declares it, where the app has one:
+  // `get(path: "/shows/{showId}", request: WithPath<GetShowRequest, "showId">, options?: CallOptions): Call<Show>`.
+  // It is what the generated call is written against, so an agent is shown the
+  // signature its example is an instance of rather than a second spelling of it.
+  restSignature?: string;
   // Which way the method streams. Two of the three are directions Kaja does not
   // carry, which is what the note beside the signature says.
   streaming?: StreamingKind;
@@ -77,9 +88,12 @@ export function buildMcpCatalog(apps: App[], variableNames: string[] = []): McpC
       Object.assign(declarations, source.declarations);
     }
 
+    const restBinding = app.sources.some((source) => source.restDoor) ? doorBinding(app.configuration.name) : undefined;
+
     catalog.apps.push({
       name: app.configuration.name,
       type: appType(app.configuration),
+      ...(restBinding ? { restBinding } : {}),
       declarations,
       services: app.services.map((service) => ({
         name: service.name,
@@ -104,9 +118,27 @@ function describeMethod(app: App, service: Service, method: Method): McpMethod {
   };
   if (method.doc) described.doc = method.doc;
   if (method.http) described.http = method.http;
+  const restSignature = doorSignature(app, service, method);
+  if (restSignature) described.restSignature = restSignature;
   const streaming = streamingKind(method);
   if (streaming) described.streaming = streaming;
   return described;
+}
+
+// The door's own declaration for this method, read back out of the generated module
+// rather than rebuilt: the overload is written once, in appLoader, and a second
+// rendering of it here is a thing that can disagree with what the editor checks.
+function doorSignature(app: App, service: Service, method: Method): string | undefined {
+  const request = httpRequestOf(method);
+  const source = app.sources.find((s) => s.importPath === service.sourcePath);
+  if (!request || !source?.restDoor) return undefined;
+
+  const declared = new RegExp(`^\\s*(${verbMember(request)}\\(path: ${escapeForRegExp(JSON.stringify(request.path))},.*)$`, "m").exec(source.file.text);
+  return declared ? declared[1].replace(/;$/, "") : undefined;
+}
+
+function escapeForRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // importSpecifierFor is what a script writes to import the service — the app's

--- a/ui/src/openapi/app.ts
+++ b/ui/src/openapi/app.ts
@@ -1,0 +1,228 @@
+import ts from "typescript";
+import { App, AppRef, Client, Clients, Method, Methods, Service, createAppRef, serviceId } from "../apps";
+import { Call, CallOptions, Kaja, MethodCall, callResponseHeaders } from "../kaja";
+import { APP_OF } from "../rateLimit";
+import { ConfigurationApp } from "../server/api";
+import { Sources } from "../sources";
+import { appHeaders, mergeHeaders } from "../appTypes";
+import { Document, ResolvedOperation } from "./document";
+import { buildModule, RestModule, RestOperation } from "./module";
+import { buildRequest, requestTarget } from "./request";
+import { sendRest } from "./restCall";
+
+/**
+ * A REST app, built in the browser from the document itself.
+ *
+ * Nothing here compiles: there is no proto to generate, no descriptor to load and
+ * no stub to evaluate. The document is read into the surface a script writes
+ * against, and a call is an HTTP request the browser builds and kaja forwards.
+ *
+ * What it produces is an ordinary `App`, so everything downstream is untouched —
+ * the tree, the finder, the console, the run log, approvals, the rate limiter and
+ * the stats all read a `MethodCall`, and a REST call makes one exactly as an RPC
+ * call does. That is what makes this a change of how an app is read rather than a
+ * second kind of app.
+ */
+
+// The module every REST app's surface lives in. One, because a document is one
+// document: there is nothing here for a path to tell apart, which is what a path
+// after the app's name is for.
+const MODULE = "service";
+
+export function loadRestApp(documentJson: string, configuration: ConfigurationApp, target: string): App {
+  const document = JSON.parse(documentJson) as Document;
+  const module = buildModule(document);
+  const appRef = createAppRef(configuration, target);
+
+  const services = servicesOf(module, configuration.name);
+  const sources = sourcesOf(module, configuration.name);
+  const clients: Clients = {};
+  for (const service of services) {
+    clients[serviceId(service)] = createRestClient(service, module, appRef);
+  }
+
+  return {
+    configuration,
+    rest: module,
+    appRef,
+    compilation: { status: "success", logs: [] },
+    services,
+    clients,
+    sources,
+    stub: {},
+    target,
+    protocol: appRef.protocol,
+  };
+}
+
+// Operations are grouped by their tag, which is the document's own way of saying
+// which of them belong together — the same grouping the tree used to get from a
+// generated service, arrived at without inventing one.
+function servicesOf(module: RestModule, appName: string): Service[] {
+  const byTag = new Map<string, Method[]>();
+
+  for (const entry of module.operations) {
+    const methods = byTag.get(entry.service) ?? byTag.set(entry.service, []).get(entry.service)!;
+    methods.push({
+      name: entry.name,
+      input: entry.requestType,
+      output: entry.responseType,
+      doc: entry.operation.summary,
+      // What names the method everywhere one is named. It is the API's own
+      // address for the operation, and here it is read off the document rather
+      // than written onto a generated method as an option.
+      http: `${entry.operation.verb} ${entry.operation.path}`,
+    });
+  }
+
+  return [...byTag.entries()].map(([name, methods]) => ({
+    name,
+    packageName: "",
+    sourcePath: `${appName}/${MODULE}`,
+    clientStubModuleId: "",
+    methods,
+  }));
+}
+
+function sourcesOf(module: RestModule, appName: string): Sources {
+  const importPath = `${appName}/${MODULE}`;
+  const header = `import type { Call, CallOptions } from "kaja";\n\n`;
+  const text = header + module.text + "\n";
+
+  return [
+    {
+      path: `${importPath}.ts`,
+      importPath,
+      stubModuleId: "",
+      file: ts.createSourceFile(`${importPath}.ts`, text, ts.ScriptTarget.Latest),
+      serviceNames: [],
+      restDoor: true,
+      interfaces: {},
+      enums: {},
+      declarations: module.declarations,
+    },
+  ];
+}
+
+/**
+ * The client. A method is a function that builds the request, hands it to the
+ * tunnel and records what happened — the same three things `client.ts` does for a
+ * compiled app, with the encoding step gone.
+ */
+function createRestClient(service: Service, module: RestModule, appRef: AppRef): Client {
+  const byName = new Map<string, RestOperation>();
+  for (const entry of module.operations) byName.set(entry.name, entry);
+
+  const bound = new WeakMap<Kaja, Methods>();
+
+  const bind = (kaja: Kaja): Methods => {
+    const methods: Methods = {};
+    Object.defineProperty(methods, APP_OF, { get: () => appRef.configuration.name });
+
+    for (const method of service.methods) {
+      const entry = byName.get(method.name);
+      if (!entry) continue;
+
+      const send = async (input: any, callOptions: CallOptions | undefined, hold: (methodCall: MethodCall) => void) => {
+        await kaja._internal.acquireRateLimit(appRef.configuration.name);
+
+        const requestHeaders = mergeHeaders(appHeaders(appRef.configuration), callOptions?.headers);
+        const request = buildRequest(entry.operation, input);
+        const headers = { ...requestHeaders, ...request.headers };
+
+        const methodCall: MethodCall = {
+          id: crypto.randomUUID(),
+          appName: appRef.configuration.name,
+          service,
+          method,
+          input,
+          requestHeaders: headers,
+          timestamp: Date.now(),
+        };
+        hold(methodCall);
+        kaja._internal.methodCallUpdate(methodCall);
+
+        const startedAt = performance.now();
+        try {
+          const response = await sendRest(appRef, request, headers, kaja._internal.abortSignal);
+          methodCall.durationMs = Math.round(performance.now() - startedAt);
+          methodCall.upstreamDurationMs = response.durationMs;
+          methodCall.responseHeaders = response.headers;
+          methodCall.upstreamRequestHeaders = response.requestHeaders;
+          methodCall.upstreamResponseHeaders = response.headers;
+
+          const body = readBody(response.body);
+          if (response.status >= 400) {
+            // An HTTP failure is reported as one: the status labels the call and
+            // the body is what the API said about it, which for a REST API is
+            // where the reason lives.
+            methodCall.error = {
+              message: failureMessage(body, response.status),
+              status: response.status,
+              statusText: "",
+              request: `${request.method} ${requestTarget(request)}`,
+              body,
+            } as any;
+          } else {
+            methodCall.output = body;
+          }
+        } catch (error: any) {
+          methodCall.durationMs = Math.round(performance.now() - startedAt);
+          methodCall.error = { message: error?.message ?? String(error) } as any;
+        }
+
+        kaja._internal.methodCallUpdate(methodCall);
+        return methodCall.output;
+      };
+
+      methods[method.name] = (input: any, callOptions?: CallOptions) => {
+        let methodCall: MethodCall | undefined;
+        return new Call(
+          `${service.name}.${method.name}`,
+          input,
+          () => send(input, callOptions, (made) => (methodCall = made)),
+          () => callResponseHeaders(methodCall),
+        );
+      };
+    }
+    return methods;
+  };
+
+  return {
+    methodsFor(kaja: Kaja): Methods {
+      const existing = bound.get(kaja);
+      if (existing) return existing;
+      const methods = bind(kaja);
+      bound.set(kaja, methods);
+      return methods;
+    },
+  };
+}
+
+// A body is JSON where it parses as JSON and text where it does not — which is
+// what the document said it would be, and what an API that answers with plain
+// text on an error path actually sends.
+function readBody(body: string): unknown {
+  const trimmed = body.trim();
+  if (trimmed === "") return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return body;
+  }
+}
+
+// The sentence a failure is labelled with, taken from where APIs actually put it.
+function failureMessage(body: unknown, status: number): string {
+  if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    for (const key of ["detail", "title", "message", "error"]) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+  if (typeof body === "string" && body.trim()) return body.trim().slice(0, 200);
+  return `HTTP ${status}`;
+}
+
+export type { ResolvedOperation };

--- a/ui/src/openapi/document.ts
+++ b/ui/src/openapi/document.ts
@@ -1,0 +1,322 @@
+/**
+ * An OpenAPI 3.x document, as a browser reads it.
+ *
+ * Kaja used to convert a document into a proto file on the server and invoke the
+ * result as if it were gRPC. Everything a REST API says that protobuf has no shape
+ * for had to be carried around it — an envelope field for a body that is an array,
+ * a `kaja.http_in` mark for where a field travels, a `json_name` on every property
+ * so proto3-JSON would spell it the way the API does. The wire was protobuf and the
+ * API was HTTP, so the marks were the translation between them.
+ *
+ * Read here instead, none of that is needed: a schema becomes TypeScript, an
+ * operation becomes an HTTP request, and what the document says is what the script
+ * is checked against. What the API cannot express in protobuf — a union, a nullable
+ * scalar, a free-form object, a literal enum — it can express in TypeScript.
+ *
+ * The model is the document's own shape. Nothing is normalized on the way in, so a
+ * reader can always ask what was written.
+ */
+
+export interface Document {
+  openapi?: string;
+  swagger?: string;
+  info?: Info;
+  servers?: Server[];
+  paths?: { [path: string]: PathItem };
+  components?: Components;
+  security?: SecurityRequirement[];
+}
+
+export interface Info {
+  title?: string;
+  version?: string;
+  description?: string;
+}
+
+export interface Server {
+  url?: string;
+  description?: string;
+  variables?: { [name: string]: ServerVariable };
+}
+
+export interface ServerVariable {
+  default?: string;
+  enum?: string[];
+  description?: string;
+}
+
+export interface PathItem {
+  parameters?: Parameter[];
+  get?: Operation;
+  put?: Operation;
+  post?: Operation;
+  patch?: Operation;
+  delete?: Operation;
+  head?: Operation;
+  options?: Operation;
+}
+
+export interface Operation {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  deprecated?: boolean;
+  tags?: string[];
+  parameters?: Parameter[];
+  requestBody?: RequestBody;
+  responses?: { [status: string]: Response };
+  security?: SecurityRequirement[];
+}
+
+export interface Parameter {
+  $ref?: string;
+  name?: string;
+  in?: "path" | "query" | "header" | "cookie";
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  schema?: Schema;
+  // How an array or object parameter is spelled in the URL. Only `form` (the
+  // default) and `deepObject` differ in a way a caller can observe.
+  style?: string;
+  explode?: boolean;
+  example?: unknown;
+  content?: { [contentType: string]: MediaType };
+}
+
+export interface RequestBody {
+  description?: string;
+  required?: boolean;
+  content?: { [contentType: string]: MediaType };
+}
+
+export interface Response {
+  description?: string;
+  content?: { [contentType: string]: MediaType };
+}
+
+export interface MediaType {
+  schema?: Schema;
+  example?: unknown;
+}
+
+export interface Components {
+  schemas?: { [name: string]: Schema };
+  parameters?: { [name: string]: Parameter };
+  requestBodies?: { [name: string]: RequestBody };
+  responses?: { [name: string]: Response };
+  securitySchemes?: { [name: string]: SecurityScheme };
+}
+
+export interface SecurityScheme {
+  type?: string;
+  scheme?: string;
+  in?: string;
+  name?: string;
+  bearerFormat?: string;
+  description?: string;
+}
+
+export type SecurityRequirement = { [scheme: string]: string[] };
+
+export interface Schema {
+  $ref?: string;
+  // 3.0 writes one string; 3.1 (JSON Schema) allows ["string", "null"]. Kept as
+  // written, because in TypeScript a nullable type is a union and can be said.
+  type?: string | string[];
+  format?: string;
+  title?: string;
+  description?: string;
+  // 3.0's way of saying what 3.1 says with a "null" in `type`.
+  nullable?: boolean;
+  deprecated?: boolean;
+  items?: Schema;
+  properties?: { [name: string]: Schema };
+  additionalProperties?: boolean | Schema;
+  allOf?: Schema[];
+  oneOf?: Schema[];
+  anyOf?: Schema[];
+  required?: string[];
+  enum?: unknown[];
+  default?: unknown;
+  example?: unknown;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+}
+
+// The verbs a path item may declare, in the order an index reads best: what an
+// operation does to the resource, safest first.
+export const VERBS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
+
+export type Verb = (typeof VERBS)[number];
+
+/** One operation, with everything that addresses it resolved onto it. */
+export interface ResolvedOperation {
+  verb: string;
+  path: string;
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  deprecated: boolean;
+  tag: string;
+  // Path-item parameters merged with the operation's own, the operation winning
+  // where both name the same parameter in the same place — which is what the
+  // specification says an operation-level parameter does.
+  parameters: Parameter[];
+  requestBody?: RequestBody;
+  // The response body a call hands back: the first 2xx that declares JSON.
+  response?: { status: string; contentType: string; schema?: Schema };
+  requestContentType?: string;
+  requestSchema?: Schema;
+}
+
+// The tag an operation is filed under. The first, because that is the one a
+// document orders its own navigation by; unfiled operations go in one place rather
+// than each in a group of its own.
+const UNTAGGED = "Default";
+
+export function documentTitle(document: Document): string {
+  return document.info?.title?.trim() || "";
+}
+
+/**
+ * Every operation the document declares, in document order.
+ *
+ * A `$ref` in a parameter is followed here because a parameter is addressed by
+ * name and place rather than by a type — unlike a schema, where the reference is
+ * the type's name and is what makes the emitted TypeScript readable.
+ */
+export function operations(document: Document): ResolvedOperation[] {
+  const found: ResolvedOperation[] = [];
+
+  for (const [path, item] of Object.entries(document.paths ?? {})) {
+    if (!item) continue;
+    for (const verb of VERBS) {
+      const operation = item[verb];
+      if (!operation) continue;
+      found.push(resolveOperation(document, verb.toUpperCase(), path, item, operation));
+    }
+  }
+  return found;
+}
+
+function resolveOperation(document: Document, verb: string, path: string, item: PathItem, operation: Operation): ResolvedOperation {
+  const parameters = mergeParameters(
+    (item.parameters ?? []).map((parameter) => resolveParameter(document, parameter)),
+    (operation.parameters ?? []).map((parameter) => resolveParameter(document, parameter)),
+  );
+
+  const request = jsonContent(operation.requestBody?.content);
+  const response = responseBody(document, operation);
+
+  return {
+    verb,
+    path,
+    operationId: operation.operationId,
+    summary: operation.summary?.trim(),
+    description: operation.description?.trim(),
+    deprecated: operation.deprecated === true,
+    tag: operation.tags?.[0]?.trim() || UNTAGGED,
+    parameters,
+    requestBody: operation.requestBody,
+    requestContentType: request?.contentType,
+    requestSchema: request?.schema,
+    response,
+  };
+}
+
+// An operation's own parameter replaces a path item's when both name the same
+// parameter in the same place; anything else is added.
+function mergeParameters(fromPath: Parameter[], fromOperation: Parameter[]): Parameter[] {
+  const merged = [...fromPath];
+  for (const parameter of fromOperation) {
+    const at = merged.findIndex((other) => other.name === parameter.name && other.in === parameter.in);
+    if (at === -1) merged.push(parameter);
+    else merged[at] = parameter;
+  }
+  return merged;
+}
+
+export function resolveParameter(document: Document, parameter: Parameter): Parameter {
+  if (!parameter.$ref) return parameter;
+  const resolved = followRef(document, parameter.$ref) as Parameter | undefined;
+  return resolved ? { ...resolved, ...withoutRef(parameter) } : parameter;
+}
+
+function withoutRef(parameter: Parameter): Parameter {
+  const { $ref, ...rest } = parameter;
+  return rest;
+}
+
+// The response a call hands back. The first 2xx with a body, because that is the
+// one a script is written against; a document that declares several says so with
+// several status codes and the earliest is the ordinary answer. `default` is the
+// last resort, being what the document says about everything it did not enumerate.
+function responseBody(document: Document, operation: Operation): ResolvedOperation["response"] | undefined {
+  const responses = operation.responses ?? {};
+  const codes = Object.keys(responses)
+    .filter((code) => /^2\d\d$/.test(code))
+    .sort();
+
+  for (const code of [...codes, "2XX", "default"]) {
+    const response = responses[code];
+    if (!response) continue;
+    const content = jsonContent(response.content);
+    if (content) return { status: code, contentType: content.contentType, schema: content.schema };
+    // A 2xx that declares no content at all is a call that answers with nothing,
+    // which is a real answer and stops the search.
+    if (code !== "default" && !response.content) return { status: code, contentType: "" };
+  }
+  return undefined;
+}
+
+/**
+ * The JSON media type to read, preferring plain `application/json`, then a
+ * charset-suffixed variant, then a structured `+json` type — the order the server
+ * used, kept because an API that declares both means the plain one.
+ */
+export function jsonContent(content: { [contentType: string]: MediaType } | undefined): { contentType: string; schema?: Schema } | undefined {
+  if (!content) return undefined;
+  const types = Object.keys(content);
+
+  const exact = types.find((type) => type === "application/json");
+  const prefixed = types.find((type) => type.startsWith("application/json;"));
+  const structured = types.find((type) => /\+json($|;)/.test(type));
+  const chosen = exact ?? prefixed ?? structured;
+  if (chosen) return { contentType: chosen, schema: content[chosen]?.schema };
+
+  // Not JSON, but still a body: text/plain and friends are handed over as they are.
+  const text = types.find((type) => type.startsWith("text/"));
+  if (text) return { contentType: text, schema: content[text]?.schema };
+  return undefined;
+}
+
+/**
+ * Follow a local `$ref` (`#/components/schemas/Show`). Only local references are
+ * followed: a document that points at another file has not been fetched, and a
+ * reference kaja cannot resolve is left as it was rather than guessed at.
+ */
+export function followRef(document: Document, ref: string): unknown {
+  if (!ref.startsWith("#/")) return undefined;
+  let node: unknown = document;
+  for (const rawSegment of ref.slice(2).split("/")) {
+    const segment = rawSegment.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (node === null || typeof node !== "object") return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return node;
+}
+
+/** The name a schema reference names, or nothing where it is not one. */
+export function refName(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  const match = /^#\/components\/schemas\/(.+)$/.exec(ref);
+  return match ? decodeURIComponent(match[1].replace(/~1/g, "/").replace(/~0/g, "~")) : undefined;
+}
+
+/** The declared types of a schema, with 3.0's `nullable` folded into 3.1's spelling. */
+export function schemaTypes(schema: Schema): string[] {
+  const declared = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
+  if (schema.nullable === true && !declared.includes("null")) return [...declared, "null"];
+  return declared;
+}

--- a/ui/src/openapi/kitchensink.test.ts
+++ b/ui/src/openapi/kitchensink.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "bun:test";
+import ts from "typescript";
+import kitchensink from "./testdata/kitchensink.json";
+import { Document, operations } from "./document";
+import { declarations } from "./types";
+
+// The same document server/pkg/apps/openapi is held to, read the other way round.
+// It exercises the schema features an API actually uses, and the point of reading
+// it here is that what comes out is TypeScript the editor will accept — so the
+// test compiles it rather than matching it against a golden file.
+const document = kitchensink as Document;
+
+function compile(source: string): ts.Diagnostic[] {
+  const file = ts.createSourceFile("emitted.ts", source, ts.ScriptTarget.ESNext, true);
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) => (name === "emitted.ts" ? file : undefined),
+    writeFile: () => {},
+    getDefaultLibFileName: () => "lib.d.ts",
+    getCurrentDirectory: () => "",
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => name === "emitted.ts",
+    readFile: () => undefined,
+  };
+  const program = ts.createProgram(["emitted.ts"], { strict: true, noEmit: true, noLib: true, target: ts.ScriptTarget.ESNext }, host);
+  return [...program.getSyntacticDiagnostics(file), ...program.getSemanticDiagnostics(file)];
+}
+
+describe("the kitchen sink, read in the browser", () => {
+  const declared = declarations(document);
+  const source = declared.map((declaration) => declaration.text).join("\n\n");
+
+  it("emits TypeScript the compiler accepts", () => {
+    const errors = compile(source).map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, " "));
+    expect(errors).toEqual([]);
+  });
+
+  it("declares every schema the document does", () => {
+    expect(declared.length).toBe(Object.keys(document.components?.schemas ?? {}).length);
+  });
+
+  it("finds every operation", () => {
+    const found = operations(document).map((operation) => `${operation.verb} ${operation.path}`);
+    expect(found.length).toBeGreaterThan(0);
+    expect(found).toContain("GET /signals");
+  });
+
+  // Each of these is a shape the proto path had to flatten, and the reason the
+  // reading moved: a script was being checked against protobuf's idea of the API.
+  it("keeps a union a union instead of merging its variants", () => {
+    expect(source).toContain("export type Gauge = GaugeFlat | GaugeTiered;");
+  });
+
+  it("keeps a body that is an array, with no envelope around it", () => {
+    expect(source).toContain("export type IngestSignalsBody = Signal | Signal[];");
+  });
+
+  it("keeps a discriminant as the literal the document declared", () => {
+    expect(source).toContain('kind: "flat";');
+  });
+
+  it("keeps a nullable scalar nullable", () => {
+    expect(source).toContain("at?: string | null;");
+  });
+
+  it("keeps an enum's values, which proto3 could only put in a comment", () => {
+    expect(source).toContain('export type IntervalEnum = "MINUTE" | "HOUR" | "DAY";');
+  });
+
+  it("keeps a free-form object as one rather than as a builder", () => {
+    expect(source).toContain("data?: unknown;");
+    expect(source).toContain("labels?: { [key: string]: string };");
+  });
+
+  it("says which fields the API insists on", () => {
+    expect(source).toContain("id: string;");
+    expect(source).toContain("reading?: number;");
+  });
+});

--- a/ui/src/openapi/module.ts
+++ b/ui/src/openapi/module.ts
@@ -1,0 +1,248 @@
+import { Document, ResolvedOperation, Schema, operations } from "./document";
+import { declarations, identifier, propertyName, typeText, TypeDeclaration } from "./types";
+
+/**
+ * The TypeScript a script writes against a REST app.
+ *
+ * One module: the document's own schemas as declarations, a request type per
+ * operation, and the door that addresses them by verb and path.
+ *
+ * There is no `Input<T>` here, and its absence is the point. Through protobuf
+ * nothing was ever required — proto3 has no such thing — so every generated
+ * request had to be a deep partial and the fields the API insists on were a
+ * `[required]` note in a comment. The document says which fields are required, so
+ * the request type says it too, and leaving one out is an error where the API
+ * would have refused the call anyway.
+ */
+
+export interface RestModule {
+  // The whole module, ready to be an editor model.
+  text: string;
+  // Every declaration by name, for the MCP catalog and go-to-definition.
+  declarations: { [name: string]: TypeDeclaration };
+  // One entry per operation, in the order the door declares them.
+  operations: RestOperation[];
+}
+
+/** An operation, with the names its TypeScript goes by. */
+export interface RestOperation {
+  operation: ResolvedOperation;
+  // What identifies the call: the document's operationId where it has one, since
+  // that is the name the API itself gave the operation.
+  name: string;
+  service: string;
+  requestType: string;
+  responseType: string;
+  // Whether a call must pass a request at all.
+  required: boolean;
+}
+
+export function buildModule(document: Document): RestModule {
+  const declared = declarations(document);
+  const byName: { [name: string]: TypeDeclaration } = {};
+  for (const declaration of declared) byName[declaration.name] = declaration;
+
+  const found = operations(document);
+  const taken = new Set(declared.map((declaration) => declaration.name));
+  const built: RestOperation[] = [];
+  const requestTypes: string[] = [];
+
+  for (const operation of found) {
+    const name = operationName(operation, taken);
+    const request = requestInterface(document, operation, `${name}Request`);
+    const responseType = typeText(document, operation.response?.schema) || "unknown";
+
+    requestTypes.push(request.text);
+    byName[request.name] = { name: request.name, text: request.text, references: request.references };
+    built.push({
+      operation,
+      name,
+      service: identifier(operation.tag),
+      requestType: request.name,
+      responseType: operation.response && operation.response.contentType === "" ? "void" : responseType,
+      required: request.required,
+    });
+  }
+
+  const text = [declared.map((declaration) => declaration.text).join("\n\n"), requestTypes.join("\n\n"), doorText(built)].filter(Boolean).join("\n\n");
+
+  return { text, declarations: byName, operations: built };
+}
+
+/**
+ * The door, one overload per operation. Same shape as the door over a compiled
+ * app, because it is the same door: what changed is where the declarations it is
+ * written in terms of came from.
+ */
+function doorText(built: RestOperation[]): string {
+  const byVerb = new Map<string, RestOperation[]>();
+  for (const entry of built) {
+    const verb = entry.operation.verb.toLowerCase();
+    (byVerb.get(verb) ?? byVerb.set(verb, []).get(verb)!).push(entry);
+  }
+
+  const lines: string[] = ["export const api: {"];
+  for (const [verb, entries] of byVerb) {
+    for (const entry of [...entries].sort((a, b) => a.operation.path.localeCompare(b.operation.path))) {
+      const doc = overloadDoc(entry.operation);
+      if (doc) lines.push(`    /** ${doc} */`);
+      const request = `request${entry.required ? "" : "?"}: ${entry.requestType}`;
+      lines.push(`    ${verb}(path: ${JSON.stringify(entry.operation.path)}, ${request}, options?: CallOptions): Call<${entry.responseType}>;`);
+    }
+  }
+  lines.push("} = {} as never;");
+  return lines.join("\n");
+}
+
+function overloadDoc(operation: ResolvedOperation): string {
+  const parts: string[] = [];
+  if (operation.summary) parts.push(operation.summary.replace(/\s+/g, " "));
+  if (operation.deprecated) parts.push("[deprecated]");
+  const text = parts.join(" ");
+  return text.length > 200 ? text.slice(0, 199) + "…" : text;
+}
+
+/**
+ * The request an operation takes: its parameters and its body, in one object.
+ *
+ * A script writes one flat object and the pieces are routed to the path, the
+ * query, a header or the body — which is what an OpenAPI operation is. Where the
+ * body is not an object there is nothing to spread, so it arrives under `body`.
+ */
+function requestInterface(
+  document: Document,
+  operation: ResolvedOperation,
+  name: string,
+): { name: string; text: string; references: string[]; required: boolean } {
+  const references = new Set<string>();
+  const lines: string[] = [];
+  let required = false;
+
+  for (const parameter of operation.parameters) {
+    if (!parameter.name) continue;
+    const doc = parameterDoc(parameter);
+    if (doc) lines.push(`  /** ${doc} */`);
+    // A path parameter is always required: without it the path is not an address,
+    // whatever the document says about it.
+    const insisted = parameter.required === true || parameter.in === "path";
+    if (insisted) required = true;
+    lines.push(`  ${propertyName(parameter.name)}${insisted ? "" : "?"}: ${typeText(document, parameter.schema, references)};`);
+  }
+
+  const body = operation.requestSchema;
+  if (operation.requestBody) {
+    const insisted = operation.requestBody.required === true;
+    if (insisted) required = true;
+
+    if (body && isSpreadable(body)) {
+      // The body's own members sit beside the parameters, so one object is the
+      // whole call.
+      lines.push(...bodyMembers(document, body, references, insisted));
+    } else {
+      const doc = operation.requestBody.description?.replace(/\s+/g, " ").trim();
+      if (doc) lines.push(`  /** ${doc} */`);
+      lines.push(`  body${insisted ? "" : "?"}: ${typeText(document, body, references)};`);
+    }
+  }
+
+  const text = lines.length === 0 ? `export interface ${name} {}` : `export interface ${name} {\n${lines.join("\n")}\n}`;
+  return { name, text, references: [...references], required };
+}
+
+// A body is spread into the request where it is a plain object declared inline. A
+// $ref is left whole so the request names the API's own type rather than copying
+// its members — `body: Show` reads better and follows a rename of the schema.
+function isSpreadable(schema: Schema | undefined): boolean {
+  if (!schema || schema.$ref) return false;
+  return schema.properties !== undefined;
+}
+
+function bodyMembers(document: Document, schema: Schema, references: Set<string>, bodyRequired: boolean): string[] {
+  const required = new Set(schema.required ?? []);
+  const lines: string[] = [];
+  for (const [name, property] of Object.entries(schema.properties ?? {})) {
+    const doc = property.description?.replace(/\s+/g, " ").trim();
+    if (doc) lines.push(`  /** ${doc} */`);
+    // A member the body requires is required only if the body itself is: an
+    // optional body that is left out entirely requires nothing.
+    const insisted = bodyRequired && required.has(name);
+    lines.push(`  ${propertyName(name)}${insisted ? "" : "?"}: ${typeText(document, property, references)};`);
+  }
+  return lines;
+}
+
+function parameterDoc(parameter: { description?: string; in?: string; deprecated?: boolean; example?: unknown }): string {
+  const parts: string[] = [];
+  if (parameter.description) parts.push(parameter.description.replace(/\s+/g, " ").trim());
+  if (parameter.in && parameter.in !== "path") parts.push(`[${parameter.in} parameter]`);
+  if (parameter.deprecated) parts.push("[deprecated]");
+  if (parameter.example !== undefined) parts.push(`[e.g. ${JSON.stringify(parameter.example)}]`);
+  const text = parts.join(" ");
+  return text.length > 200 ? text.slice(0, 199) + "…" : text;
+}
+
+/**
+ * What the operation is called. The document's own operationId where it has one —
+ * the API named the operation, so kaja does not have to — and otherwise a name
+ * read off the verb and the path.
+ *
+ * Only the request type and the call's identity are spelled with it; nothing a
+ * script writes is, because a script writes the path.
+ */
+export function operationName(operation: ResolvedOperation, taken: Set<string>): string {
+  const base = operation.operationId ? pascal(operation.operationId) : pascal(`${operation.verb} ${operation.path.replace(/[{}]/g, "")}`);
+  let name = base || "Operation";
+  for (let suffix = 2; taken.has(name); suffix++) name = `${base}${suffix}`;
+  taken.add(name);
+  return name;
+}
+
+function pascal(text: string): string {
+  const words = text.split(/[^A-Za-z0-9]+/).filter(Boolean);
+  const joined = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join("");
+  return identifier(joined);
+}
+
+/**
+ * The call clicking an operation writes: the path, and the fields the API insists
+ * on. Everything else is left out — the declarations say what else may be sent,
+ * and a page of empty strings reads as values being sent rather than as fields
+ * being offered.
+ */
+export function restEditorCode(module: RestModule, name: string, binding: string): string | undefined {
+  const entry = module.operations.find((operation) => operation.name === name);
+  if (!entry) return undefined;
+
+  const request = module.declarations[entry.requestType];
+  const fields = request ? requiredFields(request.text) : [];
+  const argument = fields.length ? `, {\n${fields.map((field) => `  ${field.name}: ${field.zero},`).join("\n")}\n}` : entry.required ? ", {}" : "";
+
+  return `${binding}.${entry.operation.verb.toLowerCase()}(${JSON.stringify(entry.operation.path)}${argument});\n`;
+}
+
+// Read off the emitted interface rather than the schema, so what the call writes
+// and what the editor checks it against cannot disagree: a member with no `?` is
+// one the document requires.
+function requiredFields(text: string): Array<{ name: string; zero: string }> {
+  const fields: Array<{ name: string; zero: string }> = [];
+  for (const line of text.split("\n")) {
+    const match = /^\s{2}("[^"]+"|[A-Za-z_$][A-Za-z0-9_$]*):\s*(.+);$/.exec(line);
+    if (!match) continue;
+    fields.push({ name: match[1], zero: zeroFor(match[2]) });
+  }
+  return fields;
+}
+
+// The zero a field of this type takes. A union offers its first member, which for
+// an enum is the first value the document listed — the one place a generated call
+// can be right rather than empty.
+function zeroFor(type: string): string {
+  const first = type.split("|")[0].trim();
+  if (/^".*"$/.test(first)) return first;
+  if (first === "number") return "0";
+  if (first === "boolean") return "false";
+  if (first.endsWith("[]") || first.startsWith("(")) return "[]";
+  if (first === "string") return '""';
+  if (first.startsWith("{")) return "{}";
+  return "{}";
+}

--- a/ui/src/openapi/request.test.ts
+++ b/ui/src/openapi/request.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "bun:test";
+import { Parameter, ResolvedOperation, Schema } from "./document";
+import { buildRequest, requestTarget } from "./request";
+
+function operation(over: Partial<ResolvedOperation> = {}): ResolvedOperation {
+  return { verb: "GET", path: "/shows", deprecated: false, tag: "Shows", parameters: [], ...over };
+}
+
+function parameter(name: string, where: Parameter["in"], over: Partial<Parameter> = {}): Parameter {
+  return { name, in: where, ...over };
+}
+
+describe("buildRequest", () => {
+  it("fills a path parameter in and escapes it", () => {
+    const built = buildRequest(operation({ path: "/shows/{showId}", parameters: [parameter("showId", "path")] }), { showId: "a/b" });
+    expect(built.path).toBe("/shows/a%2Fb");
+  });
+
+  // A hole in the URL would be a call to /shows/undefined, which the API answers
+  // for; the template reaching it is the honest account of what was not written.
+  it("leaves a path parameter that was not written in place", () => {
+    expect(buildRequest(operation({ path: "/shows/{showId}", parameters: [parameter("showId", "path")] }), {}).path).toBe("/shows/{showId}");
+  });
+
+  it("sends a query parameter, and leaves out one nothing was written for", () => {
+    const shows = operation({ parameters: [parameter("city", "query"), parameter("limit", "query")] });
+    expect(buildRequest(shows, { city: "Chicago" }).query).toEqual([["city", "Chicago"]]);
+    expect(buildRequest(shows, {}).query).toEqual([]);
+    // An absent value is absent, which a message could not express.
+    expect(buildRequest(shows, { city: undefined, limit: 0 }).query).toEqual([["limit", "0"]]);
+  });
+
+  it("sends a header parameter as a header", () => {
+    const built = buildRequest(operation({ parameters: [parameter("X-Trace", "header")] }), { "X-Trace": "1" });
+    expect(built.headers).toEqual({ "X-Trace": "1" });
+  });
+
+  describe("the spellings a document may choose for an array", () => {
+    const exploded = operation({ parameters: [parameter("tag", "query")] });
+    const joined = operation({ parameters: [parameter("tag", "query", { explode: false })] });
+
+    it("repeats the name when exploded, which is the default", () => {
+      expect(buildRequest(exploded, { tag: ["a", "b"] }).query).toEqual([
+        ["tag", "a"],
+        ["tag", "b"],
+      ]);
+    });
+
+    it("comma-joins when the document says not to explode", () => {
+      expect(buildRequest(joined, { tag: ["a", "b"] }).query).toEqual([["tag", "a,b"]]);
+    });
+
+    it("sends nothing for an empty array", () => {
+      expect(buildRequest(exploded, { tag: [] }).query).toEqual([]);
+    });
+  });
+
+  it("writes a deepObject as name[key]", () => {
+    const filtered = operation({ parameters: [parameter("filter", "query", { style: "deepObject" })] });
+    expect(buildRequest(filtered, { filter: { model: "gpt-4", tier: "pro" } }).query).toEqual([
+      ["filter[model]", "gpt-4"],
+      ["filter[tier]", "pro"],
+    ]);
+  });
+
+  describe("the body", () => {
+    const objectBody: Schema = { type: "object", properties: { title: { type: "string" } } };
+
+    it("is the input's own members, minus what travels in the URL", () => {
+      const create = operation({
+        verb: "POST",
+        path: "/shows/{showId}",
+        parameters: [parameter("showId", "path"), parameter("dryRun", "query")],
+        requestBody: { content: {} },
+        requestSchema: objectBody,
+      });
+      const built = buildRequest(create, { showId: "vera-lune", dryRun: true, title: "Vera Lune", venueId: "the-foundry" });
+
+      expect(built.path).toBe("/shows/vera-lune");
+      expect(built.query).toEqual([["dryRun", "true"]]);
+      expect(JSON.parse(built.body!)).toEqual({ title: "Vera Lune", venueId: "the-foundry" });
+      expect(built.headers["Content-Type"]).toBe("application/json");
+    });
+
+    // A body that is an array has nothing to spread, so it is named. Under proto
+    // this needed an envelope field that the API never declared.
+    it("is taken from `body` where the document says the body is not an object", () => {
+      const ingest = operation({ verb: "POST", requestBody: { content: {} }, requestSchema: { type: "array", items: { type: "string" } } });
+      expect(JSON.parse(buildRequest(ingest, { body: ["a", "b"] }).body!)).toEqual(["a", "b"]);
+      expect(buildRequest(ingest, {}).body).toBeUndefined();
+    });
+
+    it("lets an explicit `body` win, so an API with its own `body` property is reachable", () => {
+      const create = operation({ verb: "POST", requestBody: { content: {} }, requestSchema: objectBody });
+      expect(JSON.parse(buildRequest(create, { body: { title: "x" } }).body!)).toEqual({ title: "x" });
+    });
+
+    it("is absent where the operation declares none, whatever was written", () => {
+      expect(buildRequest(operation(), { title: "x" }).body).toBeUndefined();
+    });
+
+    it("is sent empty where the API requires one and nothing was written", () => {
+      const create = operation({ verb: "POST", requestBody: { required: true, content: {} }, requestSchema: objectBody });
+      expect(buildRequest(create, {}).body).toBe("{}");
+    });
+
+    it("uses the content type the document declared", () => {
+      const create = operation({ verb: "POST", requestBody: { content: {} }, requestSchema: objectBody, requestContentType: "application/merge-patch+json" });
+      expect(buildRequest(create, { title: "x" }).headers["Content-Type"]).toBe("application/merge-patch+json");
+    });
+  });
+});
+
+describe("requestTarget", () => {
+  it("is the path alone where there is no query", () => {
+    expect(requestTarget({ method: "GET", path: "/shows", query: [], headers: {} })).toBe("/shows");
+  });
+
+  it("escapes both halves of every pair", () => {
+    const target = requestTarget({ method: "GET", path: "/shows", query: [["q", "a b&c"]], headers: {} });
+    expect(target).toBe("/shows?q=a%20b%26c");
+  });
+});

--- a/ui/src/openapi/request.ts
+++ b/ui/src/openapi/request.ts
@@ -1,0 +1,174 @@
+import { Parameter, ResolvedOperation, Schema, schemaTypes } from "./document";
+
+/**
+ * The HTTP request an operation and its input make.
+ *
+ * This is what `transcode` did in Go, and moving it here is what lets the request
+ * be an ordinary object. Going through protobuf, the input was a message: every
+ * value had a declared field, a field left out was indistinguishable from one sent
+ * as its zero, and a body that was not an object needed an envelope field to live
+ * in. Here the input is JSON, so what the script wrote is what goes out —
+ * including, where the API says so, a body that is an array or a bare string.
+ */
+
+export interface HttpRequest {
+  method: string;
+  // Relative to the app's base URL, which the tunnel supplies: the browser never
+  // learns where the API is, and a script cannot address anything else.
+  path: string;
+  query: Array<[string, string]>;
+  headers: { [name: string]: string };
+  // Absent for a request with no body, which is not the same as an empty one.
+  body?: string;
+}
+
+// Where a value in the input travels. A body-less operation takes its whole input
+// from parameters; one with a body takes the rest of it from the body.
+const BODY = "body";
+
+/**
+ * Build the request. `input` is what the script wrote; anything it does not name
+ * is left out rather than sent as a zero — which the proto path could not do,
+ * since a message has no way to say a field is absent.
+ */
+export function buildRequest(operation: ResolvedOperation, input: Record<string, unknown> | undefined): HttpRequest {
+  const values = input ?? {};
+  const query: Array<[string, string]> = [];
+  const headers: { [name: string]: string } = {};
+
+  let path = operation.path;
+  for (const parameter of operation.parameters) {
+    const name = parameter.name;
+    if (!name) continue;
+    const value = values[name];
+
+    switch (parameter.in) {
+      case "path":
+        // A path parameter that is missing leaves its template in the URL rather
+        // than a hole: the request then fails against the API, which is a clearer
+        // account of what went wrong than a call to /shows/undefined.
+        if (value !== undefined && value !== null) {
+          path = path.replace(`{${name}}`, encodeURIComponent(scalar(value)));
+        }
+        break;
+      case "query":
+        if (value !== undefined && value !== null) query.push(...queryValues(parameter, name, value));
+        break;
+      case "header":
+        if (value !== undefined && value !== null) headers[name] = scalar(value);
+        break;
+      case "cookie":
+        // Cookies are the browser's to set and this call is made by a proxy, so a
+        // cookie parameter is sent as the header it would have become.
+        if (value !== undefined && value !== null) headers["Cookie"] = `${name}=${scalar(value)}`;
+        break;
+    }
+  }
+
+  const request: HttpRequest = { method: operation.verb.toUpperCase(), path, query, headers };
+
+  const body = bodyOf(operation, values);
+  if (body !== undefined) {
+    request.body = JSON.stringify(body);
+    headers["Content-Type"] = operation.requestContentType || "application/json";
+  }
+  return request;
+}
+
+/**
+ * What goes in the body.
+ *
+ * An operation whose body is an object takes it from the input's own members,
+ * minus the ones that travel in the path, the query or a header — so a script
+ * writes one flat object and the request is assembled from it. An operation whose
+ * body is not an object (an array, a scalar) takes it from a `body` member,
+ * because there is nothing to spread.
+ */
+function bodyOf(operation: ResolvedOperation, values: Record<string, unknown>): unknown {
+  if (!operation.requestBody) return undefined;
+
+  if (!isObjectBody(operation.requestSchema)) {
+    return BODY in values ? values[BODY] : undefined;
+  }
+
+  // An explicit `body` wins, so an API with a property genuinely called `body` is
+  // still reachable and a caller who prefers to be explicit may be.
+  if (BODY in values) return values[BODY];
+
+  const travelling = new Set(operation.parameters.map((parameter) => parameter.name).filter((name): name is string => !!name));
+  const body: Record<string, unknown> = {};
+  let found = false;
+  for (const [name, value] of Object.entries(values)) {
+    if (travelling.has(name)) continue;
+    body[name] = value;
+    found = true;
+  }
+  // A body the API requires is sent even when it is empty; one it does not is
+  // left out entirely, which is not the same as sending `{}`.
+  if (!found && !operation.requestBody.required) return undefined;
+  return body;
+}
+
+function isObjectBody(schema: Schema | undefined): boolean {
+  if (!schema) return false;
+  if (schema.$ref || schema.properties || schema.allOf?.length) return true;
+  const types = schemaTypes(schema).filter((type) => type !== "null");
+  if (types.includes("array")) return false;
+  return types.length === 0 || types.includes("object");
+}
+
+/**
+ * A query parameter, spelled the way the document says.
+ *
+ * `style` and `explode` are the only part of a URL an API gets to choose, and
+ * getting it wrong is a request that silently returns the wrong rows — so the
+ * default (form, exploded) is applied by absence rather than assumed.
+ */
+function queryValues(parameter: Parameter, name: string, value: unknown): Array<[string, string]> {
+  const explode = parameter.explode ?? parameter.style !== "deepObject";
+
+  if (parameter.style === "deepObject" && isRecord(value)) {
+    return Object.entries(value)
+      .filter(([, member]) => member !== undefined && member !== null)
+      .map(([key, member]): [string, string] => [`${name}[${key}]`, scalar(member)]);
+  }
+
+  if (Array.isArray(value)) {
+    const members = value.filter((member) => member !== undefined && member !== null).map(scalar);
+    if (members.length === 0) return [];
+    // form with explode=false is one comma-joined value; exploded is one entry
+    // per member, which is what an API means by `?tag=a&tag=b`.
+    return explode ? members.map((member): [string, string] => [name, member]) : [[name, members.join(",")]];
+  }
+
+  if (isRecord(value)) {
+    // An object in a form-style parameter is its members, flattened — the
+    // specification's own reading of `explode: true` for an object.
+    const members = Object.entries(value).filter(([, member]) => member !== undefined && member !== null);
+    if (explode) return members.map(([key, member]): [string, string] => [key, scalar(member)]);
+    return [[name, members.map(([key, member]) => `${key},${scalar(member)}`).join(",")]];
+  }
+
+  return [[name, scalar(value)]];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// A value in a URL is text. An object or array that reaches here is one the
+// document did not describe as one, so it travels as its JSON rather than as
+// "[object Object]".
+function scalar(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value);
+}
+
+/** The request's path with its query on the end, which is what the tunnel sends. */
+export function requestTarget(request: HttpRequest): string {
+  if (request.query.length === 0) return request.path;
+  const query = request.query.map(([name, value]) => `${encodeURIComponent(name)}=${encodeURIComponent(value)}`).join("&");
+  return `${request.path}?${query}`;
+}

--- a/ui/src/openapi/restCall.ts
+++ b/ui/src/openapi/restCall.ts
@@ -1,0 +1,93 @@
+import { AppRef } from "../apps";
+import { getBaseUrlForRest } from "../server/connection";
+import { isWailsEnvironment } from "../wails";
+import { HttpRequest, requestTarget } from "./request";
+
+/**
+ * One HTTP call, carried to the API through kaja.
+ *
+ * The browser never calls the API directly: it does not know where the API is and
+ * must not hold the credential that opens it, and CORS would refuse most of the
+ * calls it could make anyway. So the request crosses as a method, a path and a
+ * body, and the process on the other side supplies the rest.
+ *
+ * Both builds answer the same shape. The web posts to /rest; the desktop calls
+ * the bound Rest method, reached through the same dynamic import everything else
+ * about Wails is, so a browser never loads the runtime.
+ */
+
+export interface RestResponse {
+  status: number;
+  headers: { [name: string]: string };
+  // The body as text. Parsing is the caller's, because what a body is depends on
+  // what the document said it would be.
+  body: string;
+  requestHeaders: { [name: string]: string };
+  // What the upstream exchange took, as the one process in the path measured it —
+  // the same number every other transport reports under kaja-upstream-*.
+  durationMs?: number;
+}
+
+// The reserved names this hop answers under. The response's own headers travel as
+// data rather than as headers, so nothing of kaja's shows up in the Headers view.
+const STATUS = "kaja-upstream-status";
+const DURATION = "kaja-upstream-duration-ms";
+const RESPONSE_HEADERS = "kaja-upstream-response-headers";
+const REQUEST_HEADERS = "kaja-upstream-request-headers";
+
+export async function sendRest(appRef: AppRef, request: HttpRequest, headers: { [name: string]: string }, signal?: AbortSignal): Promise<RestResponse> {
+  if (isWailsEnvironment()) {
+    // The Go side of this lane exists (App.Rest), but reaching it needs the
+    // generated bindings, and those are written by the Wails CLI — which is why
+    // this says so rather than guessing at the call. Regenerating them is
+    // `scripts/desktop-build`, and until that has been run the desktop reads a
+    // REST app the compiled way.
+    throw new Error("Reading a REST app from its document is not on the desktop yet — regenerate the Wails bindings to enable it.");
+  }
+
+  // The headers keep the X-Header- prefix the other lane uses, so their ${NAME}
+  // references cross unexpanded and are resolved where the values live.
+  const sent: { [name: string]: string } = {
+    "X-Target": appRef.target,
+    "X-Kaja-Method": request.method,
+    "X-Kaja-Path": requestTarget(request),
+  };
+  for (const [name, value] of Object.entries(headers)) sent["X-Header-" + name] = value;
+
+  const response = await fetch(getBaseUrlForRest(), {
+    method: "POST",
+    headers: sent,
+    body: request.body ?? "",
+    signal,
+  });
+
+  if (response.status === 502) {
+    // This hop failed, which is not something the API said. It is reported as
+    // what it is rather than passed off as an answer with an empty body.
+    throw new Error((await response.text()) || "The call could not be made.");
+  }
+
+  return {
+    status: Number(response.headers.get(STATUS) ?? response.status),
+    headers: parseHeaders(response.headers.get(RESPONSE_HEADERS)),
+    body: await response.text(),
+    requestHeaders: parseHeaders(response.headers.get(REQUEST_HEADERS)),
+    durationMs: numberOf(response.headers.get(DURATION)),
+  };
+}
+
+function parseHeaders(value: string | null): { [name: string]: string } {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? (parsed as { [name: string]: string }) : {};
+  } catch {
+    return {};
+  }
+}
+
+function numberOf(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/ui/src/openapi/testdata/kitchensink.json
+++ b/ui/src/openapi/testdata/kitchensink.json
@@ -1,0 +1,710 @@
+{
+ "openapi": "3.0.0",
+ "info": {
+  "title": "Kaja Kitchen Sink",
+  "version": "1.0.0"
+ },
+ "servers": [
+  {
+   "url": "https://kitchensink.kaja.tools"
+  }
+ ],
+ "security": [
+  {
+   "TokenAuth": []
+  }
+ ],
+ "paths": {
+  "/signals": {
+   "post": {
+    "operationId": "ingestSignals",
+    "tags": [
+     "Signals"
+    ],
+    "summary": "Ingest signals",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/IngestSignalsBody"
+       }
+      },
+      "application/vnd.kaja.signals+json": {
+       "schema": {
+        "$ref": "#/components/schemas/Signal"
+       }
+      }
+     }
+    },
+    "responses": {
+     "204": {
+      "description": "accepted"
+     },
+     "default": {
+      "description": "error"
+     }
+    }
+   },
+   "get": {
+    "operationId": "listSignals",
+    "tags": [
+     "Signals"
+    ],
+    "summary": "List signals",
+    "parameters": [
+     {
+      "$ref": "#/components/parameters/page"
+     },
+     {
+      "$ref": "#/components/parameters/order"
+     },
+     {
+      "name": "expand",
+      "in": "query",
+      "style": "form",
+      "explode": false,
+      "schema": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      }
+     },
+     {
+      "name": "filterLabels",
+      "in": "query",
+      "style": "deepObject",
+      "schema": {
+       "type": "object",
+       "additionalProperties": {
+        "type": "string"
+       }
+      }
+     },
+     {
+      "name": "advancedFilter",
+      "in": "query",
+      "content": {
+       "application/json": {
+        "schema": {
+         "type": "object",
+         "additionalProperties": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "ok",
+      "content": {
+       "application/json": {
+        "schema": {
+         "type": "array",
+         "items": {
+          "$ref": "#/components/schemas/Signal"
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/gauges": {
+   "post": {
+    "operationId": "createGauge",
+    "tags": [
+     "Gauges"
+    ],
+    "summary": "Create a gauge",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/Gauge"
+       }
+      }
+     }
+    },
+    "responses": {
+     "201": {
+      "description": "created",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/Gauge"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/gauges/{gaugeKey}": {
+   "parameters": [
+    {
+     "name": "gaugeKey",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "string"
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getGauge",
+    "tags": [
+     "Gauges"
+    ],
+    "summary": "Get a gauge",
+    "responses": {
+     "200": {
+      "description": "ok",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/Gauge"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/probes": {
+   "post": {
+    "operationId": "createProbe",
+    "tags": [
+     "Probes"
+    ],
+    "summary": "Create a probe",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/CreateProbeRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "201": {
+      "description": "created",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/Probe"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/reports": {
+   "get": {
+    "operationId": "listReports",
+    "tags": [
+     "Reports"
+    ],
+    "summary": "List reports",
+    "parameters": [
+     {
+      "$ref": "#/components/parameters/page"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "ok",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ListReportsResult"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/reports/batch": {
+   "post": {
+    "operationId": "createReports",
+    "tags": [
+     "Reports"
+    ],
+    "summary": "Create reports in bulk",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/Report"
+        }
+       }
+      }
+     }
+    },
+    "responses": {
+     "204": {
+      "description": "created"
+     }
+    }
+   }
+  },
+  "/status": {
+   "get": {
+    "operationId": "getStatus",
+    "summary": "Plain-text service status",
+    "responses": {
+     "200": {
+      "description": "ok",
+      "content": {
+       "text/plain": {
+        "schema": {
+         "type": "string"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/widgets/{widgetId}": {
+   "get": {
+    "operationId": "getWidget",
+    "tags": [
+     "Widgets"
+    ],
+    "summary": "Get a widget",
+    "parameters": [
+     {
+      "name": "widgetId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "format": "uuid"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "ok",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/Widget"
+        }
+       }
+      }
+     }
+    }
+   },
+   "put": {
+    "operationId": "updateWidget",
+    "tags": [
+     "Widgets"
+    ],
+    "summary": "Update a widget",
+    "parameters": [
+     {
+      "name": "widgetId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "format": "uuid"
+      }
+     },
+     {
+      "$ref": "#/components/parameters/traceId"
+     },
+     {
+      "name": "If-Match",
+      "in": "header",
+      "schema": {
+       "type": "string"
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/WidgetBase"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "ok",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/Widget"
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ },
+ "components": {
+  "parameters": {
+   "traceId": {
+    "name": "X-Trace-Id",
+    "in": "header",
+    "schema": {
+     "type": "string"
+    }
+   },
+   "page": {
+    "name": "page",
+    "in": "query",
+    "style": "form",
+    "explode": false,
+    "schema": {
+     "type": "integer"
+    }
+   },
+   "order": {
+    "name": "order",
+    "in": "query",
+    "schema": {
+     "allOf": [
+      {
+       "$ref": "#/components/schemas/SortOrder"
+      }
+     ],
+     "default": "ASC"
+    }
+   }
+  },
+  "securitySchemes": {
+   "TokenAuth": {
+    "type": "http",
+    "scheme": "Bearer"
+   }
+  },
+  "schemas": {
+   "SortOrder": {
+    "type": "string",
+    "enum": [
+     "ASC",
+     "DESC"
+    ]
+   },
+   "IngestSignalsBody": {
+    "anyOf": [
+     {
+      "$ref": "#/components/schemas/Signal"
+     },
+     {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/Signal"
+      }
+     }
+    ],
+    "description": "A single signal or a batch of signals."
+   },
+   "Signal": {
+    "type": "object",
+    "required": [
+     "id",
+     "source",
+     "kind"
+    ],
+    "properties": {
+     "id": {
+      "type": "string"
+     },
+     "source": {
+      "type": "string"
+     },
+     "kind": {
+      "type": "string"
+     },
+     "reading": {
+      "type": "number",
+      "format": "double"
+     },
+     "total": {
+      "type": "integer",
+      "format": "uint64"
+     },
+     "count": {
+      "type": "integer",
+      "format": "uint32"
+     },
+     "at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+     },
+     "labels": {
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "payload": {
+      "type": "object",
+      "additionalProperties": {},
+      "nullable": true
+     },
+     "value": {
+      "oneOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "boolean"
+       },
+       {
+        "type": "number"
+       }
+      ]
+     },
+     "data": {
+      "description": "Arbitrary JSON payload with no declared type."
+     },
+     "interval": {
+      "$ref": "#/components/schemas/Interval"
+     }
+    }
+   },
+   "Interval": {
+    "anyOf": [
+     {
+      "type": "string",
+      "format": "duration"
+     },
+     {
+      "$ref": "#/components/schemas/IntervalEnum"
+     }
+    ]
+   },
+   "IntervalEnum": {
+    "type": "string",
+    "enum": [
+     "MINUTE",
+     "HOUR",
+     "DAY"
+    ]
+   },
+   "Gauge": {
+    "oneOf": [
+     {
+      "$ref": "#/components/schemas/GaugeFlat"
+     },
+     {
+      "$ref": "#/components/schemas/GaugeTiered"
+     }
+    ],
+    "discriminator": {
+     "propertyName": "kind"
+    }
+   },
+   "GaugeFlat": {
+    "type": "object",
+    "required": [
+     "kind",
+     "key"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "enum": [
+       "flat"
+      ]
+     },
+     "key": {
+      "type": "string"
+     },
+     "name": {
+      "type": "string"
+     },
+     "scale": {
+      "allOf": [
+       {
+        "$ref": "#/components/schemas/FlatScale"
+       }
+      ],
+      "nullable": true
+     }
+    }
+   },
+   "GaugeTiered": {
+    "type": "object",
+    "required": [
+     "kind",
+     "key"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "enum": [
+       "tiered"
+      ]
+     },
+     "key": {
+      "type": "string"
+     },
+     "name": {
+      "type": "string"
+     },
+     "scale": {
+      "$ref": "#/components/schemas/TieredScale"
+     }
+    }
+   },
+   "FlatScale": {
+    "type": "object",
+    "properties": {
+     "factor": {
+      "type": "string"
+     }
+    }
+   },
+   "TieredScale": {
+    "type": "object",
+    "properties": {
+     "tiers": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ScaleTier"
+      }
+     }
+    }
+   },
+   "ScaleTier": {
+    "type": "object",
+    "properties": {
+     "upTo": {
+      "type": "integer",
+      "format": "int64"
+     },
+     "factor": {
+      "type": "string"
+     }
+    }
+   },
+   "CreateProbeRequest": {
+    "type": "object",
+    "required": [
+     "target"
+    ],
+    "properties": {
+     "target": {
+      "type": "string"
+     },
+     "timeoutSeconds": {
+      "type": "integer"
+     }
+    }
+   },
+   "Probe": {
+    "allOf": [
+     {
+      "$ref": "#/components/schemas/Resource"
+     },
+     {
+      "$ref": "#/components/schemas/CreateProbeRequest"
+     }
+    ]
+   },
+   "Resource": {
+    "type": "object",
+    "properties": {
+     "id": {
+      "type": "string",
+      "readOnly": true
+     },
+     "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "readOnly": true
+     }
+    }
+   },
+   "Widget": {
+    "allOf": [
+     {
+      "$ref": "#/components/schemas/Resource"
+     },
+     {
+      "$ref": "#/components/schemas/WidgetBase"
+     }
+    ],
+    "properties": {
+     "deprecatedName": {
+      "type": "string",
+      "deprecated": true
+     }
+    }
+   },
+   "WidgetBase": {
+    "type": "object",
+    "properties": {
+     "name": {
+      "type": "string"
+     },
+     "kind": {
+      "type": "string"
+     }
+    }
+   },
+   "Report": {
+    "type": "object",
+    "properties": {
+     "title": {
+      "type": "string"
+     },
+     "parent": {
+      "$ref": "#/components/schemas/Report"
+     }
+    }
+   },
+   "ListReportsResult": {
+    "oneOf": [
+     {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/Report"
+      }
+     },
+     {
+      "$ref": "#/components/schemas/PaginatedReports"
+     }
+    ]
+   },
+   "PaginatedReports": {
+    "type": "object",
+    "properties": {
+     "totalCount": {
+      "type": "integer"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/Report"
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/ui/src/openapi/types.test.ts
+++ b/ui/src/openapi/types.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "bun:test";
+import { Document, Schema } from "./document";
+import { declarations, typeText } from "./types";
+
+function doc(schemas: { [name: string]: Schema }): Document {
+  return { openapi: "3.1.0", components: { schemas } };
+}
+
+const empty: Document = { openapi: "3.1.0" };
+
+describe("typeText", () => {
+  it("writes the scalars", () => {
+    expect(typeText(empty, { type: "string" })).toBe("string");
+    expect(typeText(empty, { type: "integer" })).toBe("number");
+    expect(typeText(empty, { type: "number" })).toBe("number");
+    expect(typeText(empty, { type: "boolean" })).toBe("boolean");
+  });
+
+  it("says nothing about a schema that says nothing", () => {
+    expect(typeText(empty, {})).toBe("unknown");
+    expect(typeText(empty, undefined)).toBe("unknown");
+  });
+
+  // The whole point: a reference is the name, not the shape. It is what keeps a
+  // self-referential schema from recursing forever.
+  it("writes a reference as the name it refers to", () => {
+    expect(typeText(empty, { $ref: "#/components/schemas/Show" })).toBe("Show");
+  });
+
+  it("collects the names a type reaches", () => {
+    const references = new Set<string>();
+    typeText(empty, { type: "array", items: { $ref: "#/components/schemas/Show" } }, references);
+    expect([...references]).toEqual(["Show"]);
+  });
+
+  it("writes an array, parenthesising a union element", () => {
+    expect(typeText(empty, { type: "array", items: { type: "string" } })).toBe("string[]");
+    expect(typeText(empty, { type: "array", items: { type: ["string", "number"] } })).toBe("(string | number)[]");
+  });
+
+  // Everything below is a shape proto3 had no way to carry, so the server-side
+  // path flattened it. TypeScript says it, so it is said.
+  it("writes a nullable type as a union, in both spellings", () => {
+    expect(typeText(empty, { type: ["string", "null"] })).toBe("string | null");
+    expect(typeText(empty, { type: "string", nullable: true })).toBe("string | null");
+  });
+
+  it("writes oneOf and anyOf as a union", () => {
+    const union = { oneOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }] };
+    expect(typeText(empty, union)).toBe("Cat | Dog");
+    expect(typeText(empty, { anyOf: [{ type: "string" }, { type: "number" }] })).toBe("string | number");
+  });
+
+  it("folds a null member of a union in rather than making it a type of its own", () => {
+    expect(typeText(empty, { oneOf: [{ type: "string" }, { type: "null" }] })).toBe("string | null");
+  });
+
+  it("writes allOf as an intersection", () => {
+    const composed = { allOf: [{ $ref: "#/components/schemas/Base" }, { $ref: "#/components/schemas/Extra" }] };
+    expect(typeText(empty, composed)).toBe("Base & Extra");
+  });
+
+  it("writes an enum as the values, which is what the document said", () => {
+    expect(typeText(empty, { type: "string", enum: ["draft", "live"] })).toBe('"draft" | "live"');
+    expect(typeText(empty, { type: "integer", enum: [1, 2] })).toBe("1 | 2");
+    expect(typeText(empty, { type: ["string", "null"], enum: ["a", null] })).toBe('"a" | null');
+  });
+
+  it("writes additionalProperties as an index signature", () => {
+    expect(typeText(empty, { type: "object", additionalProperties: { type: "string" } })).toBe("{ [key: string]: string }");
+    expect(typeText(empty, { type: "object", additionalProperties: true })).toBe("{ [key: string]: unknown }");
+    expect(typeText(empty, { type: "object" })).toBe("{ [key: string]: unknown }");
+  });
+
+  it("reads shape keywords where the document forgot the type", () => {
+    expect(typeText(empty, { properties: { id: { type: "string" } } })).toContain("id?: string");
+    expect(typeText(empty, { items: { type: "string" } })).toBe("string[]");
+  });
+
+  it("marks a property optional unless the document requires it", () => {
+    const object: Schema = { type: "object", properties: { id: { type: "string" }, name: { type: "string" } }, required: ["id"] };
+    const text = typeText(empty, object);
+    expect(text).toContain("id: string;");
+    expect(text).toContain("name?: string;");
+  });
+
+  it("quotes a property name that is not an identifier", () => {
+    expect(typeText(empty, { type: "object", properties: { "x-rate-limit": { type: "number" } } })).toContain('"x-rate-limit"?: number');
+  });
+});
+
+describe("declarations", () => {
+  it("writes a plain object as an interface", () => {
+    const [show] = declarations(doc({ Show: { type: "object", properties: { id: { type: "string" } }, required: ["id"] } }));
+    expect(show.name).toBe("Show");
+    expect(show.text).toBe("export interface Show {\n  id: string;\n}");
+  });
+
+  // A union has no member list to write, and forcing one into an interface is
+  // exactly what the proto path did when it merged the variants.
+  it("writes anything that is not a plain object as a type alias", () => {
+    const [pet] = declarations(doc({ Pet: { oneOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }] } }));
+    expect(pet.text).toBe("export type Pet = Cat | Dog;");
+
+    const [status] = declarations(doc({ Status: { type: "string", enum: ["draft", "live"] } }));
+    expect(status.text).toBe('export type Status = "draft" | "live";');
+  });
+
+  it("carries the API's own description onto the declaration and its members", () => {
+    const declared = declarations(
+      doc({ Show: { type: "object", description: "One screening.", properties: { id: { type: "string", description: "The id.", example: "vera-lune" } } } }),
+    );
+    expect(declared[0].text).toContain("/** One screening. */");
+    expect(declared[0].text).toContain('/** The id. [e.g. "vera-lune"] */');
+  });
+
+  it("reports what a declaration reaches, without counting itself", () => {
+    const declared = declarations(
+      doc({
+        Node: { type: "object", properties: { child: { $ref: "#/components/schemas/Node" }, leaf: { $ref: "#/components/schemas/Leaf" } } },
+      }),
+    );
+    expect(declared[0].references).toEqual(["Leaf"]);
+    // A schema that refers to itself terminates, because a reference is a name.
+    expect(declared[0].text).toContain("child?: Node;");
+  });
+
+  it("makes a name that is not an identifier into one, in both places", () => {
+    const declared = declarations(doc({ "order-item": { type: "object", properties: { of: { $ref: "#/components/schemas/order-item" } } } }));
+    expect(declared[0].name).toBe("order_item");
+    expect(declared[0].text).toContain("export interface order_item");
+    expect(declared[0].text).toContain("of?: order_item;");
+  });
+});

--- a/ui/src/openapi/types.ts
+++ b/ui/src/openapi/types.ts
@@ -1,0 +1,261 @@
+import { Document, Schema, refName, schemaTypes } from "./document";
+
+/**
+ * A schema, as TypeScript.
+ *
+ * This is the whole reason the parsing moved into the browser. Going through
+ * protobuf, everything a REST API says that proto3 has no shape for had to be
+ * flattened on the way in: a union of two objects became one message holding the
+ * superset of their fields, a nullable string became a string, a free-form object
+ * became `google.protobuf.Value`, an enum became a comment because proto3 has
+ * nowhere to put the values. What came back out was a shape the API never
+ * declared, and a script was checked against that shape rather than against the
+ * API.
+ *
+ * TypeScript can say all of it, so it does:
+ *
+ *   oneOf                 →  A | B
+ *   ["string", "null"]    →  string | null
+ *   enum: ["a", "b"]      →  "a" | "b"
+ *   additionalProperties  →  { [key: string]: T }
+ *   allOf                 →  A & B
+ *
+ * A `$ref` becomes the name it refers to rather than the schema it refers to,
+ * which is what keeps the output readable and what makes a self-referential
+ * schema terminate.
+ */
+
+// A schema with none of type, properties, items or a composition keyword says
+// nothing about its value — which in TypeScript is `unknown`, the type that makes
+// a reader narrow before using it.
+const UNKNOWN = "unknown";
+
+export interface TypeDeclaration {
+  name: string;
+  // The declaration, ready to show and ready to compile.
+  text: string;
+  // The names this declaration mentions, so a reader can close over what a type
+  // reaches without walking the schema again.
+  references: string[];
+}
+
+/** The TypeScript for one schema, inline — a reference becomes a name. */
+export function typeText(document: Document, schema: Schema | undefined, references?: Set<string>): string {
+  if (!schema) return UNKNOWN;
+
+  const referenced = refName(schema.$ref);
+  if (referenced) {
+    references?.add(referenced);
+    return identifier(referenced);
+  }
+
+  const parts: string[] = [];
+  const types = schemaTypes(schema);
+  const nullable = types.includes("null");
+
+  // allOf is an intersection, which is what "all of these at once" means. A
+  // member that says nothing is left out rather than intersected with `unknown`,
+  // which would erase the rest.
+  if (schema.allOf?.length) {
+    const members = schema.allOf.map((member) => typeText(document, member, references)).filter((text) => text !== UNKNOWN);
+    parts.push(members.length ? members.join(" & ") : UNKNOWN);
+  }
+
+  // oneOf and anyOf are both unions here. The difference between them is whether
+  // more than one member may match, which is a validation rule rather than a
+  // shape, and TypeScript has no way to say it.
+  const union = schema.oneOf ?? schema.anyOf;
+  if (union?.length) {
+    const members = union
+      .filter((member) => !isNullSchema(member))
+      .map((member) => typeText(document, member, references))
+      .filter((text, index, all) => all.indexOf(text) === index);
+    // The null member joins the union rather than sitting beside it: a variant
+    // that may be null is `A | null`, and `A & null` is a type nothing inhabits.
+    if (union.some(isNullSchema)) members.push("null");
+    if (members.length) parts.push(members.length === 1 ? members[0] : members.join(" | "));
+  }
+
+  if (parts.length === 0) {
+    parts.push(bareType(document, schema, types, references));
+  }
+
+  const text = parts.length === 1 ? parts[0] : parts.join(" & ");
+  return nullable && !text.split(" | ").includes("null") ? `${text} | null` : text;
+}
+
+function isNullSchema(schema: Schema): boolean {
+  return schemaTypes(schema).length === 1 && schemaTypes(schema)[0] === "null";
+}
+
+function bareType(document: Document, schema: Schema, types: string[], references?: Set<string>): string {
+  // The values are the type. A document that declares an enum has said exactly
+  // what may be sent, and a literal union is the one place the editor can offer
+  // it back — which the proto path could only write in a comment.
+  if (schema.enum?.length) {
+    const literals = schema.enum.filter((value) => value !== null).map((value) => JSON.stringify(value));
+    if (literals.length) {
+      const text = literals.filter((value, index, all) => all.indexOf(value) === index).join(" | ");
+      return schema.enum.includes(null) ? `${text} | null` : text;
+    }
+  }
+
+  const concrete = types.filter((type) => type !== "null");
+  if (concrete.length > 1) {
+    return concrete.map((type) => scalarType(document, schema, type, references)).join(" | ");
+  }
+  return scalarType(document, schema, concrete[0], references);
+}
+
+function scalarType(document: Document, schema: Schema, type: string | undefined, references?: Set<string>): string {
+  switch (type) {
+    case "string":
+      return "string";
+    case "integer":
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "array":
+      return arrayType(document, schema, references);
+    case "object":
+      return objectType(document, schema, references);
+    default:
+      // No type keyword, but shape keywords that imply one. A document that
+      // declares properties and forgets `type: object` is common enough that
+      // reading it as an object is right, and reading it as `unknown` is useless.
+      if (schema.properties || schema.additionalProperties !== undefined) return objectType(document, schema, references);
+      if (schema.items) return arrayType(document, schema, references);
+      return UNKNOWN;
+  }
+}
+
+function arrayType(document: Document, schema: Schema, references?: Set<string>): string {
+  const element = typeText(document, schema.items, references);
+  // A union element needs the parentheses, or `A | B[]` reads as `A | (B[])`.
+  return /[|&]/.test(element) ? `(${element})[]` : `${element}[]`;
+}
+
+function objectType(document: Document, schema: Schema, references?: Set<string>): string {
+  const members = objectMembers(document, schema, references, "  ");
+  const index = indexSignature(document, schema, references);
+
+  if (members.length === 0) {
+    // A free-form object: what the document said, rather than the `Value` builder
+    // the proto path needed for the same thing.
+    return index ?? "{ [key: string]: unknown }";
+  }
+  const lines = [...members, ...(index ? [`  ${index.slice(2, -2).trim()};`] : [])];
+  return `{\n${lines.join("\n")}\n}`;
+}
+
+function indexSignature(document: Document, schema: Schema, references?: Set<string>): string | undefined {
+  const additional = schema.additionalProperties;
+  if (additional === undefined || additional === false) return undefined;
+  if (additional === true) return "{ [key: string]: unknown }";
+  return `{ [key: string]: ${typeText(document, additional, references)} }`;
+}
+
+function objectMembers(document: Document, schema: Schema, references: Set<string> | undefined, indent: string): string[] {
+  const required = new Set(schema.required ?? []);
+  const lines: string[] = [];
+
+  for (const [name, property] of Object.entries(schema.properties ?? {})) {
+    const doc = propertyDoc(property);
+    if (doc) lines.push(`${indent}/** ${doc} */`);
+    // A property the document does not require is optional, which is the one
+    // thing proto3 could not say at all: everything was optional there, so a
+    // required field looked exactly like one the API never needed.
+    lines.push(`${indent}${propertyName(name)}${required.has(name) ? "" : "?"}: ${typeText(document, property, references)};`);
+  }
+  return lines;
+}
+
+// A description, and the facts a reader would otherwise have to open the document
+// for. Kept to one line: this is the hover, not the reference.
+function propertyDoc(schema: Schema): string {
+  const parts: string[] = [];
+  if (schema.description) parts.push(schema.description.replace(/\s+/g, " ").trim());
+  if (schema.deprecated) parts.push("[deprecated]");
+  if (schema.readOnly) parts.push("[read-only]");
+  if (schema.writeOnly) parts.push("[write-only]");
+  if (schema.format) parts.push(`[${schema.format}]`);
+  if (schema.default !== undefined) parts.push(`[default ${JSON.stringify(schema.default)}]`);
+  if (schema.example !== undefined) parts.push(`[e.g. ${JSON.stringify(schema.example)}]`);
+
+  const text = parts.join(" ");
+  return text.length > 240 ? text.slice(0, 239) + "…" : text;
+}
+
+// A property name is quoted unless it is an identifier — an API is free to use
+// `x-rate-limit` or `2fa` as a property name, and a quoted key is how TypeScript
+// says one.
+export function propertyName(name: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
+// A schema name is a type name, so it has to be one. A document is free to call a
+// schema `Pet.Detail` or `order-item`; the reference and the declaration are run
+// through the same function, so they cannot disagree.
+export function identifier(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9_$]/g, "_");
+  return /^[0-9]/.test(cleaned) ? `_${cleaned}` : cleaned || "_";
+}
+
+/**
+ * Every named schema in the document, as a TypeScript declaration.
+ *
+ * An object becomes an interface, so a reader gets the members listed and the
+ * editor gets a name it can go to. Anything else — a union, an enum, an alias —
+ * becomes a type alias, because that is what it is.
+ */
+export function declarations(document: Document): TypeDeclaration[] {
+  const schemas = document.components?.schemas ?? {};
+  const declared: TypeDeclaration[] = [];
+
+  for (const [name, schema] of Object.entries(schemas)) {
+    if (!schema) continue;
+    const references = new Set<string>();
+    const doc = schemaDoc(schema);
+    const header = doc ? `/** ${doc} */\n` : "";
+
+    if (isInterface(schema)) {
+      const members = objectMembers(document, schema, references, "  ");
+      const index = indexSignature(document, schema, references);
+      const body = [...members, ...(index ? [`  [key: string]: ${index.slice(index.indexOf(": ") + 2, -2)};`] : [])];
+      declared.push({
+        name: identifier(name),
+        text: `${header}export interface ${identifier(name)} {\n${body.join("\n")}\n}`,
+        references: [...references].map(identifier).filter((reference) => reference !== identifier(name)),
+      });
+      continue;
+    }
+
+    declared.push({
+      name: identifier(name),
+      text: `${header}export type ${identifier(name)} = ${typeText(document, schema, references)};`,
+      references: [...references].map(identifier).filter((reference) => reference !== identifier(name)),
+    });
+  }
+  return declared;
+}
+
+// An interface is the right shape only for a plain object: something with members
+// and no composition around them. A schema that is a union or an intersection has
+// no member list to write, and forcing one is how the proto path lost them.
+function isInterface(schema: Schema): boolean {
+  if (schema.$ref || schema.oneOf?.length || schema.anyOf?.length || schema.allOf?.length || schema.enum?.length) return false;
+  const types = schemaTypes(schema).filter((type) => type !== "null");
+  if (schemaTypes(schema).includes("null")) return false;
+  if (types.length > 1) return false;
+  if (types[0] && types[0] !== "object") return false;
+  return schema.properties !== undefined;
+}
+
+function schemaDoc(schema: Schema): string {
+  const parts: string[] = [];
+  if (schema.description) parts.push(schema.description.replace(/\s+/g, " ").trim());
+  if (schema.deprecated) parts.push("[deprecated]");
+  const text = parts.join(" ");
+  return text.length > 240 ? text.slice(0, 239) + "…" : text;
+}

--- a/ui/src/restCallAt.test.ts
+++ b/ui/src/restCallAt.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test";
+import { restCallAt } from "./restCallAt";
+
+const script = `import { api as theatre } from "theatre";
+import { api as store } from "petstore";
+
+const shows = await theatre.get("/shows", { city: "Chicago" });
+await store.post("/pets", { name: "/shows" });
+`;
+
+// The offset of the nth occurrence of a piece of text, inside it rather than at its edge.
+function inside(code: string, text: string, occurrence = 1): number {
+  let at = -1;
+  for (let i = 0; i < occurrence; i++) at = code.indexOf(text, at + 1);
+  return at + 2;
+}
+
+describe("restCallAt", () => {
+  it("reads the call whose path is under the cursor", () => {
+    const call = restCallAt(script, inside(script, '"/shows"'));
+    expect(call).toEqual({ appSpecifier: "theatre", verb: "GET", path: "/shows", start: expect.any(Number), end: expect.any(Number) });
+  });
+
+  it("keeps each door with the app it was imported from", () => {
+    expect(restCallAt(script, inside(script, '"/pets"'))?.appSpecifier).toBe("petstore");
+    expect(restCallAt(script, inside(script, '"/pets"'))?.verb).toBe("POST");
+  });
+
+  // The path is what is hovered, so a string that happens to look like one is not it.
+  it("says nothing about a string that is not the path argument", () => {
+    expect(restCallAt(script, inside(script, '"/shows"', 2))).toBeUndefined();
+    expect(restCallAt(script, inside(script, '"Chicago"'))).toBeUndefined();
+  });
+
+  it("says nothing where the cursor is not in a string at all", () => {
+    expect(restCallAt(script, script.indexOf("const shows"))).toBeUndefined();
+  });
+
+  // The door is an ordinary local binding, so a receiver that was never imported as
+  // one is not a door however it is spelled.
+  it("says nothing for a receiver that is not a door", () => {
+    const other = `const theatre = { get: (p: string) => p };\ntheatre.get("/shows");\n`;
+    expect(restCallAt(other, inside(other, '"/shows"'))).toBeUndefined();
+  });
+
+  it("follows the door under whatever name it was bound to", () => {
+    const renamed = `import { api } from "theatre";\napi.delete("/shows/{showId}", { showId: "x" });\n`;
+    const call = restCallAt(renamed, inside(renamed, '"/shows/{showId}"'));
+    expect(call?.verb).toBe("DELETE");
+    expect(call?.path).toBe("/shows/{showId}");
+    expect(call?.appSpecifier).toBe("theatre");
+  });
+
+  it("underlines the literal, quotes included", () => {
+    const call = restCallAt(script, inside(script, '"/shows"'))!;
+    expect(script.slice(call.start, call.end)).toBe('"/shows"');
+  });
+
+  it("says nothing in a file that imports no door", () => {
+    const none = `import { Shows } from "theatre";\nShows.GetShow({ showId: "/shows" });\n`;
+    expect(restCallAt(none, inside(none, '"/shows"'))).toBeUndefined();
+  });
+});

--- a/ui/src/restCallAt.ts
+++ b/ui/src/restCallAt.ts
@@ -1,0 +1,65 @@
+import ts from "typescript";
+import { REST_DOOR } from "./restDoor";
+
+/**
+ * The REST call whose path string is under the cursor:
+ * `theatre.get("/shows/{showId}", …)`.
+ *
+ * Read at the language level rather than by pattern, for the reason `scriptInputs`
+ * is: the door is an ordinary local binding, so which receiver is the door is settled
+ * by what the file imported and under what alias, and a `"/shows"` in a comment, in a
+ * string, or in an argument to something else is not a call.
+ *
+ * The path is what is being hovered, so it is the string literal the position sits
+ * inside — not the call the position sits anywhere in. That is what keeps the answer
+ * to a hover over `{ showId: "/shows" }` empty.
+ */
+export interface RestCallAt {
+  // The app the door was imported from, which is what the call is routed by.
+  appSpecifier: string;
+  verb: string;
+  path: string;
+  // Where the path literal sits, quotes included, so a hover can underline exactly it.
+  start: number;
+  end: number;
+}
+
+export function restCallAt(code: string, offset: number): RestCallAt | undefined {
+  const file = ts.createSourceFile("hover.ts", code, ts.ScriptTarget.Latest, true);
+
+  // A door is imported as `api`, usually under the app's own name. One file may hold
+  // several, so the specifier is kept per binding rather than looked up again.
+  const doors = new Map<string, string>();
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      const exported = element.propertyName?.text ?? element.name.text;
+      if (exported === REST_DOOR) doors.set(element.name.text, statement.moduleSpecifier.text);
+    }
+  }
+  if (doors.size === 0) return undefined;
+
+  let found: RestCallAt | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.expression)) {
+      const specifier = doors.get(node.expression.expression.text);
+      const argument = node.arguments[0];
+      if (specifier && argument && ts.isStringLiteral(argument) && offset >= argument.getStart(file) && offset <= argument.getEnd()) {
+        found = {
+          appSpecifier: specifier,
+          verb: node.expression.name.text.toUpperCase(),
+          path: argument.text,
+          start: argument.getStart(file),
+          end: argument.getEnd(),
+        };
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return found;
+}

--- a/ui/src/restDoor.ts
+++ b/ui/src/restDoor.ts
@@ -1,0 +1,80 @@
+import { App, Client, Methods, serviceId } from "./apps";
+import { restOperations } from "./httpMethod";
+import { Call, CallOptions, Kaja } from "./kaja";
+import { APP_OF } from "./rateLimit";
+
+// The name the REST door is exported and imported under. Fixed rather than the app's
+// own name, which may be no identifier at all (`grpcb.in`, a name with a space) and
+// which two apps in one script would collide on — the generated code aliases it back
+// to the app (`import { api as theatre }`), so what is read is still the app's name.
+export const REST_DOOR = "api";
+
+// What the door is called in a script. The export is always `api`, so the generated
+// code aliases it to the app — `import { api as theatre }` — which is what makes two
+// REST apps in one script readable and keeps the app's own name in front of the call.
+// An app whose name is no identifier keeps the plain `api`.
+export function doorBinding(appName: string): string {
+  return appName !== REST_DOOR && /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(appName) ? appName : REST_DOOR;
+}
+
+// A method addressed the way its own API addresses it. The verbs are the members
+// httpMethod's VERBS lists; a path that is not one of the app's is a type error before
+// it is a lookup that fails.
+export interface RestDoor {
+  [verb: string]: (path: string, request?: unknown, options?: CallOptions) => Call<unknown>;
+}
+
+// The door is a second address for the methods that already exist, not a second way of
+// calling them: it hands the call to the same bound `Methods`, so the log row, the
+// approvals, the rate limiter, the console and the run's stats cannot tell which door
+// the call came through — and a script may use both in one file.
+//
+// Bound per run for the same reason `Client.methodsFor` is: the methods it routes to
+// belong to one run, and two scripts running at once must not reach into each other's.
+const doors = new WeakMap<App, WeakMap<Kaja, RestDoor>>();
+
+export function restDoorFor(app: App, kaja: Kaja): RestDoor {
+  let perRun = doors.get(app);
+  if (!perRun) {
+    perRun = new WeakMap();
+    doors.set(app, perRun);
+  }
+  const existing = perRun.get(kaja);
+  if (existing) return existing;
+
+  const door = buildDoor(app, kaja);
+  perRun.set(kaja, door);
+  return door;
+}
+
+function buildDoor(app: App, kaja: Kaja): RestDoor {
+  // Resolved once per run: which service's methods answer a given verb and path.
+  const routes = new Map<string, { client: Client; methodName: string }>();
+  for (const { service, method, request } of restOperations(app.services)) {
+    const client = app.clients[serviceId(service)];
+    if (client) routes.set(routeKey(request.verb, request.path), { client, methodName: method.name });
+  }
+
+  const door: RestDoor = {};
+  Object.defineProperty(door, APP_OF, { get: () => app.configuration.name });
+
+  // Bound methods are asked for per call rather than up front, so the door costs a run
+  // that never uses it nothing, and memoization inside methodsFor keeps it to one
+  // lookup per service.
+  const verbs = new Set([...routes.keys()].map((key) => key.slice(0, key.indexOf(" ")).toLowerCase()));
+  for (const verb of verbs) {
+    door[verb] = (path: string, request?: unknown, options?: CallOptions) => {
+      const route = routes.get(routeKey(verb, path));
+      if (!route) {
+        throw new Error(`App "${app.configuration.name}" has no ${verb.toUpperCase()} ${path}.`);
+      }
+      const methods: Methods = route.client.methodsFor(kaja);
+      return methods[route.methodName](request ?? {}, options);
+    };
+  }
+  return door;
+}
+
+function routeKey(verb: string, path: string): string {
+  return `${verb.toUpperCase()} ${path}`;
+}

--- a/ui/src/restHover.ts
+++ b/ui/src/restHover.ts
@@ -1,0 +1,130 @@
+import * as monaco from "monaco-editor";
+import { App } from "./apps";
+import { appFor } from "./appImports";
+import { restCallAt } from "./restCallAt";
+import { getApiClient } from "./server/connection";
+
+/**
+ * What an API says about the operation under the cursor, shown over the path in the
+ * script that calls it.
+ *
+ * The generated declarations carry what could be modelled — the request, the
+ * response, which fields travel in the path — and the overload carries the API's own
+ * summary. What is left is most of what a person reads before writing a call: the
+ * prose under each parameter, the examples, the response codes that are never values,
+ * the vendor extensions. That is served from the document itself.
+ *
+ * It sits over the path string because the TypeScript worker has nothing to say
+ * there — it reports no hover at all inside a string literal argument — so this is an
+ * empty slot rather than a second opinion. Where the worker does speak, on the
+ * receiver and on the request, hovers from every provider are shown stacked, so
+ * nothing here is in front of anything.
+ *
+ * Fetched when hovered rather than carried with the app: a document with nine hundred
+ * operations would otherwise ride along with every compile to answer for the one under
+ * the cursor. That is what an async provider buys, and why the fragment is nowhere in
+ * the generated module or in the MCP catalog, both of which are read whole.
+ */
+
+// A document's own prose is the API's, and can run to paragraphs. It is not repeated
+// in the fragment below, so this is the only place it is shown and the bound is
+// generous — but a hover three screens tall is not a hover.
+const MAX_DESCRIPTION = 600;
+
+// Bounded for the same reason a payload pane is: one operation of a large document can
+// be hundreds of lines, and a hover taller than the window is not one.
+const MAX_DOCUMENT_LINES = 60;
+
+let hoverApps: App[] = [];
+
+export function setHoverApps(apps: App[]): void {
+  hoverApps = apps;
+}
+
+// Keyed on the app's target as well as the operation, so a recompile that replaces the
+// instance is a different question rather than a stale answer. A miss is remembered
+// too: an app that documents nothing must not be asked once per hover.
+const answers = new Map<string, Promise<monaco.IMarkdownString[] | undefined>>();
+
+export function registerRestHover(): monaco.IDisposable {
+  return monaco.languages.registerHoverProvider("typescript", {
+    async provideHover(model, position) {
+      const call = restCallAt(model.getValue(), model.getOffsetAt(position));
+      if (!call) return null;
+
+      const app = appFor(hoverApps, call.appSpecifier);
+      if (!app?.target) return null;
+
+      const contents = await documentationFor(app, `${call.verb} ${call.path}`);
+      if (!contents) return null;
+
+      const start = model.getPositionAt(call.start);
+      const end = model.getPositionAt(call.end);
+      return { range: new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column), contents };
+    },
+  });
+}
+
+function documentationFor(app: App, operation: string): Promise<monaco.IMarkdownString[] | undefined> {
+  const key = `${app.target}\n${operation}`;
+  const held = answers.get(key);
+  if (held) return held;
+
+  const asked = getApiClient()
+    .getMethodDocumentation({ target: app.target, method: operation })
+    .response.then(({ documentation }) => (documentation ? card(operation, documentation) : undefined))
+    // A hover that could not ask says nothing, and asks again next time rather than
+    // remembering that it failed.
+    .catch(() => {
+      answers.delete(key);
+      return undefined;
+    });
+
+  answers.set(key, asked);
+  return asked;
+}
+
+interface Documentation {
+  summary: string;
+  description: string;
+  deprecated: boolean;
+  document: string;
+  language: string;
+}
+
+// The card is three things in the order they are wanted: what the operation is, what
+// the API says about it, and the declaration itself.
+function card(operation: string, documentation: Documentation): monaco.IMarkdownString[] {
+  const headline = [`**\`${operation}\`**`];
+  if (documentation.deprecated) headline.push("· _deprecated_");
+  if (documentation.summary) headline.push(`\n\n${documentation.summary}`);
+
+  const contents: monaco.IMarkdownString[] = [{ value: headline.join(" ") }];
+
+  // The summary is already the headline, and a description that only repeats it is a
+  // second copy rather than more to read. The fragment below carries neither, so this
+  // is the one place the API's prose is stated.
+  const description = clamp(documentation.description, MAX_DESCRIPTION);
+  if (description && description !== documentation.summary) {
+    contents.push({ value: description });
+  }
+
+  const document = clampLines(documentation.document, MAX_DOCUMENT_LINES);
+  if (document) {
+    contents.push({ value: "```" + (documentation.language || "yaml") + "\n" + document + "\n```" });
+  }
+  return contents;
+}
+
+function clamp(text: string, limit: number): string {
+  const trimmed = text.trim();
+  return trimmed.length > limit ? trimmed.slice(0, limit).trimEnd() + "…" : trimmed;
+}
+
+// A cut says how much it left, because a fragment that stops without saying so reads
+// as an operation that declares less than it does.
+function clampLines(text: string, limit: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= limit) return text.trimEnd();
+  return lines.slice(0, limit).join("\n") + `\n# … ${lines.length - limit} more lines`;
+}

--- a/ui/src/scriptBindings.ts
+++ b/ui/src/scriptBindings.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { REST_DOOR } from "./restDoor";
 
 /**
  * What a script's imports bound, which is the only thing that says what a name
@@ -6,6 +7,24 @@ import ts from "typescript";
  * a receiver is identified by what brought it into the file rather than by how
  * it is spelled.
  */
+
+/**
+ * Whatever the REST door was bound to in this file — `api`, and whatever each import
+ * renamed it to. Matched on what was exported rather than on how it is spelled, since
+ * the generated code reads it under the app's own name.
+ */
+export function doorNames(file: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      if ((element.propertyName?.text ?? element.name.text) === REST_DOOR) names.add(element.name.text);
+    }
+  }
+  return names;
+}
 
 /** Every name the file imported, whatever it imported it from. */
 export function importedNames(file: ts.SourceFile): Set<string> {

--- a/ui/src/scriptRunner.ts
+++ b/ui/src/scriptRunner.ts
@@ -3,6 +3,7 @@ import { ApprovalRejectedError, AskCancelledError, Kaja } from "./kaja";
 import { Client, App, serviceId } from "./apps";
 import { appFor, resolve as resolveImport } from "./appImports";
 import { printStatements } from "./appLoader";
+import { REST_DOOR, restDoorFor } from "./restDoor";
 import { scriptConsole } from "./scriptConsole";
 import { deviceConsole } from "./uiLog";
 
@@ -124,6 +125,13 @@ function prepareTask(code: string, kaja: Kaja, apps: App[]): { args: { [key: str
           // An interface a script imports for its type has nothing to bind at run time.
           if ("absent" in resolution) return;
           const source = resolution.source;
+          // The door is the app's, not a service's — a path is addressed across every
+          // service the app has — so it is bound from the app rather than looked up in
+          // one. It routes to the same bound methods, so a script may use both doors.
+          if (name === REST_DOOR && source.restDoor) {
+            args[alias] = restDoorFor(app, kaja);
+            return;
+          }
           // Matched on source path too, to handle duplicate service names.
           const service = app.services.find((s) => s.name === name && s.sourcePath === source.importPath);
           if (service) {

--- a/ui/src/server/api.client.ts
+++ b/ui/src/server/api.client.ts
@@ -4,6 +4,8 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Api } from "./api";
+import type { GetMethodDocumentationResponse } from "./api";
+import type { GetMethodDocumentationRequest } from "./api";
 import type { ReadScriptResponse } from "./api";
 import type { ReadScriptRequest } from "./api";
 import type { ListScriptsResponse } from "./api";
@@ -76,6 +78,10 @@ export interface IApiClient {
      * @generated from protobuf rpc: ReadScript
      */
     readScript(input: ReadScriptRequest, options?: RpcOptions): UnaryCall<ReadScriptRequest, ReadScriptResponse>;
+    /**
+     * @generated from protobuf rpc: GetMethodDocumentation
+     */
+    getMethodDocumentation(input: GetMethodDocumentationRequest, options?: RpcOptions): UnaryCall<GetMethodDocumentationRequest, GetMethodDocumentationResponse>;
 }
 /**
  * @generated from protobuf service Api
@@ -162,5 +168,12 @@ export class ApiClient implements IApiClient, ServiceInfo {
     readScript(input: ReadScriptRequest, options?: RpcOptions): UnaryCall<ReadScriptRequest, ReadScriptResponse> {
         const method = this.methods[10], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReadScriptRequest, ReadScriptResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * @generated from protobuf rpc: GetMethodDocumentation
+     */
+    getMethodDocumentation(input: GetMethodDocumentationRequest, options?: RpcOptions): UnaryCall<GetMethodDocumentationRequest, GetMethodDocumentationResponse> {
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        return stackIntercept<GetMethodDocumentationRequest, GetMethodDocumentationResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/ui/src/server/api.ts
+++ b/ui/src/server/api.ts
@@ -145,6 +145,15 @@ export interface OpenAppResponse {
      * @generated from protobuf field: string protocol = 5
      */
     protocol: string;
+    /**
+     * The app's own description, as JSON, for an app the client drives as HTTP.
+     * A REST document is read in the browser — a schema becomes TypeScript there,
+     * and an operation becomes an HTTP request — so an app that has one compiles no
+     * proto and `proto_dir` is empty for it.
+     *
+     * @generated from protobuf field: string document = 6
+     */
+    document: string;
 }
 /**
  * InspectGrpc reads the service surface a grpc app *would* be opened with -
@@ -1842,7 +1851,8 @@ class OpenAppResponse$Type extends MessageType<OpenAppResponse> {
             { no: 2, name: "logs", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Log },
             { no: 3, name: "proto_dir", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "target", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 5, name: "protocol", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 5, name: "protocol", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 6, name: "document", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<OpenAppResponse>): OpenAppResponse {
@@ -1852,6 +1862,7 @@ class OpenAppResponse$Type extends MessageType<OpenAppResponse> {
         message.protoDir = "";
         message.target = "";
         message.protocol = "";
+        message.document = "";
         if (value !== undefined)
             reflectionMergePartial<OpenAppResponse>(this, message, value);
         return message;
@@ -1875,6 +1886,9 @@ class OpenAppResponse$Type extends MessageType<OpenAppResponse> {
                     break;
                 case /* string protocol */ 5:
                     message.protocol = reader.string();
+                    break;
+                case /* string document */ 6:
+                    message.document = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1903,6 +1917,9 @@ class OpenAppResponse$Type extends MessageType<OpenAppResponse> {
         /* string protocol = 5; */
         if (message.protocol !== "")
             writer.tag(5, WireType.LengthDelimited).string(message.protocol);
+        /* string document = 6; */
+        if (message.document !== "")
+            writer.tag(6, WireType.LengthDelimited).string(message.document);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/ui/src/server/api.ts
+++ b/ui/src/server/api.ts
@@ -12,6 +12,73 @@ import type { PartialMessage } from "@protobuf-ts/runtime";
 import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
 /**
+ * GetMethodDocumentation reads one of a live app's methods back out of the document
+ * its surface was generated from. The generated proto carries what kaja could model;
+ * this is the rest — the prose, the examples, the response codes — which is most of
+ * what a person reads before writing the call.
+ *
+ * One operation at a time, because a document with nine hundred of them would
+ * otherwise ride along with every compile to answer for the one under the cursor.
+ *
+ * @generated from protobuf message GetMethodDocumentationRequest
+ */
+export interface GetMethodDocumentationRequest {
+    /**
+     * The opened app, as OpenApp reported it: "kaja-app://<id>".
+     *
+     * @generated from protobuf field: string target = 1
+     */
+    target: string;
+    /**
+     * The method, named the way the app's methods name theirs — "GET /shows/{showId}"
+     * for an app built from a REST document.
+     *
+     * @generated from protobuf field: string method = 2
+     */
+    method: string;
+}
+/**
+ * @generated from protobuf message GetMethodDocumentationResponse
+ */
+export interface GetMethodDocumentationResponse {
+    /**
+     * Unset where the app documents nothing, or the method is one it does not declare.
+     * Not an error: the caller is a hover, and a hover with nothing to say says nothing.
+     *
+     * @generated from protobuf field: MethodDocumentation documentation = 1
+     */
+    documentation?: MethodDocumentation;
+}
+/**
+ * @generated from protobuf message MethodDocumentation
+ */
+export interface MethodDocumentation {
+    /**
+     * @generated from protobuf field: string summary = 1
+     */
+    summary: string;
+    /**
+     * @generated from protobuf field: string description = 2
+     */
+    description: string;
+    /**
+     * @generated from protobuf field: bool deprecated = 3
+     */
+    deprecated: boolean;
+    /**
+     * The declaration as it was written, ready to show.
+     *
+     * @generated from protobuf field: string document = 4
+     */
+    document: string;
+    /**
+     * What `document` is written in, so an editor can colour it: "yaml", "json".
+     *
+     * @generated from protobuf field: string language = 5
+     */
+    language: string;
+}
+/**
  * @generated from protobuf message CompileRequest
  */
 export interface CompileRequest {
@@ -1478,6 +1545,186 @@ export enum VariableSource {
      */
     ENVIRONMENT = 3
 }
+// @generated message type with reflection information, may provide speed optimized methods
+class GetMethodDocumentationRequest$Type extends MessageType<GetMethodDocumentationRequest> {
+    constructor() {
+        super("GetMethodDocumentationRequest", [
+            { no: 1, name: "target", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "method", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<GetMethodDocumentationRequest>): GetMethodDocumentationRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.target = "";
+        message.method = "";
+        if (value !== undefined)
+            reflectionMergePartial<GetMethodDocumentationRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetMethodDocumentationRequest): GetMethodDocumentationRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string target */ 1:
+                    message.target = reader.string();
+                    break;
+                case /* string method */ 2:
+                    message.method = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: GetMethodDocumentationRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string target = 1; */
+        if (message.target !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.target);
+        /* string method = 2; */
+        if (message.method !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.method);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message GetMethodDocumentationRequest
+ */
+export const GetMethodDocumentationRequest = new GetMethodDocumentationRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class GetMethodDocumentationResponse$Type extends MessageType<GetMethodDocumentationResponse> {
+    constructor() {
+        super("GetMethodDocumentationResponse", [
+            { no: 1, name: "documentation", kind: "message", T: () => MethodDocumentation }
+        ]);
+    }
+    create(value?: PartialMessage<GetMethodDocumentationResponse>): GetMethodDocumentationResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<GetMethodDocumentationResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetMethodDocumentationResponse): GetMethodDocumentationResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* MethodDocumentation documentation */ 1:
+                    message.documentation = MethodDocumentation.internalBinaryRead(reader, reader.uint32(), options, message.documentation);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: GetMethodDocumentationResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* MethodDocumentation documentation = 1; */
+        if (message.documentation)
+            MethodDocumentation.internalBinaryWrite(message.documentation, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message GetMethodDocumentationResponse
+ */
+export const GetMethodDocumentationResponse = new GetMethodDocumentationResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class MethodDocumentation$Type extends MessageType<MethodDocumentation> {
+    constructor() {
+        super("MethodDocumentation", [
+            { no: 1, name: "summary", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "deprecated", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "document", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "language", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<MethodDocumentation>): MethodDocumentation {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.summary = "";
+        message.description = "";
+        message.deprecated = false;
+        message.document = "";
+        message.language = "";
+        if (value !== undefined)
+            reflectionMergePartial<MethodDocumentation>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MethodDocumentation): MethodDocumentation {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string summary */ 1:
+                    message.summary = reader.string();
+                    break;
+                case /* string description */ 2:
+                    message.description = reader.string();
+                    break;
+                case /* bool deprecated */ 3:
+                    message.deprecated = reader.bool();
+                    break;
+                case /* string document */ 4:
+                    message.document = reader.string();
+                    break;
+                case /* string language */ 5:
+                    message.language = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: MethodDocumentation, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string summary = 1; */
+        if (message.summary !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.summary);
+        /* string description = 2; */
+        if (message.description !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.description);
+        /* bool deprecated = 3; */
+        if (message.deprecated !== false)
+            writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* string document = 4; */
+        if (message.document !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.document);
+        /* string language = 5; */
+        if (message.language !== "")
+            writer.tag(5, WireType.LengthDelimited).string(message.language);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MethodDocumentation
+ */
+export const MethodDocumentation = new MethodDocumentation$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class CompileRequest$Type extends MessageType<CompileRequest> {
     constructor() {
@@ -4635,5 +4882,6 @@ export const Api = new ServiceType("Api", [
     { name: "SetStoredValue", options: {}, I: SetStoredValueRequest, O: StoredValueResponse },
     { name: "ClearStoredValue", options: {}, I: ClearStoredValueRequest, O: StoredValueResponse },
     { name: "ListScripts", options: {}, I: ListScriptsRequest, O: ListScriptsResponse },
-    { name: "ReadScript", options: {}, I: ReadScriptRequest, O: ReadScriptResponse }
+    { name: "ReadScript", options: {}, I: ReadScriptRequest, O: ReadScriptResponse },
+    { name: "GetMethodDocumentation", options: {}, I: GetMethodDocumentationRequest, O: GetMethodDocumentationResponse }
 ]);

--- a/ui/src/server/connection.ts
+++ b/ui/src/server/connection.ts
@@ -27,6 +27,12 @@ export function getBaseUrlForTarget(): string {
   return `${servedFrom()}/target`;
 }
 
+// Where a REST app's calls go. Its own door rather than /target's, because what
+// crosses is an HTTP request the browser built rather than an encoded message.
+export function getBaseUrlForRest(): string {
+  return `${servedFrom()}/rest`;
+}
+
 export function getBaseUrlForAi(): string {
   return `${servedFrom()}/ai`;
 }

--- a/ui/src/sources.ts
+++ b/ui/src/sources.ts
@@ -8,6 +8,9 @@ export interface Source {
   stubModuleId: string;
   file: ts.SourceFile;
   serviceNames: string[];
+  // Whether this module declares the REST door (restDoor.ts). It is a member the module
+  // exports rather than a service, so nothing else about the module says it is there.
+  restDoor?: boolean;
   interfaces: { [key: string]: ts.InterfaceDeclaration };
   enums: { [key: string]: { object: any } };
   // The generated types this source declares, as a script reads them. Built

--- a/ui/src/useCompilation.ts
+++ b/ui/src/useCompilation.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { createAppRef, App, Transport, transportFromProtocol, updateAppRef } from "./apps";
 import { loadApp } from "./appLoader";
+import { loadRestApp } from "./openapi/app";
+import { isWailsEnvironment } from "./wails";
 import { CompileStatus as ApiCompileStatus, GetConfigurationResponse, OpenStatus } from "./server/api";
 import { getApiClient } from "./server/connection";
 
@@ -109,6 +111,33 @@ export function useCompilation(
       }
 
       if (signal.aborted) return;
+
+      // An app that reported its own document is read here rather than compiled:
+      // the schemas become TypeScript in the browser and a call becomes an HTTP
+      // request, so there is no proto to compile and nothing to poll for.
+      //
+      // Not yet on the desktop. The Go side of that lane exists (App.Rest), but
+      // reaching it needs the generated Wails bindings, and those are written by
+      // the Wails CLI rather than by hand — so until `scripts/desktop-build` has
+      // been run there, the desktop reads a REST app the compiled way. That is
+      // the one thing standing between this and the proto path being deleted.
+      if (openResponse.document && !isWailsEnvironment()) {
+        const app = appsRef.current.find((candidate) => candidate.configuration.name === appName);
+        if (!app) return;
+        const loaded = loadRestApp(openResponse.document, app.configuration, target);
+        const duration = formatDuration(Date.now() - (app?.compilation.startTime || 0));
+
+        onUpdate((prevApps) => {
+          const index = prevApps.findIndex((candidate) => candidate.configuration.name === appName);
+          if (index === -1) return prevApps;
+          const updatedApps = [...prevApps];
+          updatedApps[index] = { ...loaded, compilation: { status: "success", logs: openResponse.logs, duration } };
+          return updatedApps;
+        });
+
+        delete abortControllers.current[appName];
+        return;
+      }
 
       await pollCompilation(appName, compilationId, openResponse.protoDir, target, protocol, signal);
     } catch (error: any) {


### PR DESCRIPTION
An app built from a REST document is now read in the browser and called over HTTP — its schemas become TypeScript directly, so a union stays a union and a field the API requires is required, and the server keeps only what the browser cannot do: fetching the document and forwarding each call with the base URL and credential it must not hold. The verb-and-path door the app is addressed through, and the hover showing an operation as its own document declares it, came with it.