### PR TITLE
Escaped the fetch lane's failure, logged a stream that failed upstream, and ran the traces per app family

### DIFF
--- a/desktop/fetch.go
+++ b/desktop/fetch.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -154,6 +155,26 @@ func copyUpstreamHeaders(destination, source http.Header) {
 // A failure of the lane rather than a status the API answered with. The header is what
 // tells the two apart, so an API's own 502 stays a response.
 func fetchFailed(w http.ResponseWriter, status int, message string) {
-	w.Header().Set(fetchErrorHeader, strings.ReplaceAll(strings.ReplaceAll(message, "\r", " "), "\n", " "))
+	w.Header().Set(fetchErrorHeader, escapeHeaderValue(message))
 	w.WriteHeader(status)
+}
+
+// escapeHeaderValue percent-encodes everything a header value cannot carry verbatim,
+// the same rule and the same reason as a gRPC-Web trailer's: a header is a byte string
+// the Fetch API reads as Latin-1, so the UTF-8 of a message naming a host, a
+// certificate or an OS error in a language that has accents arrives mangled, and a
+// newline in one would be a second header. Encoding the bytes outside printable ASCII
+// - and "%" itself, so the escape is reversible - is what the reader undoes with
+// decodeURIComponent.
+func escapeHeaderValue(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c > 0x7e || c == '%' {
+			fmt.Fprintf(&b, "%%%02X", c)
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }

--- a/desktop/fetch_test.go
+++ b/desktop/fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -135,6 +136,31 @@ func TestFetchReportsARequestThatNeverCompleted(t *testing.T) {
 	}
 	if strings.ContainsAny(failure, "\r\n") {
 		t.Fatalf("a header value with a newline in it: %q", failure)
+	}
+}
+
+// The message rides as a header, and a header value is a byte string the Fetch API
+// reads as Latin-1: the UTF-8 of a host, a certificate or an OS error with an accent
+// in it arrives mangled, and a newline in one would be a second header. So it is
+// percent-encoded, and the reader undoes it.
+func TestFetchEscapesWhatAHeaderValueCannotCarry(t *testing.T) {
+	message := "dial tcp: lookup café.example.com:\r\nno such host (100%)"
+
+	response := httptest.NewRecorder()
+	fetchFailed(response, http.StatusBadGateway, message)
+
+	failure := response.Header().Get(fetchErrorHeader)
+	for i := 0; i < len(failure); i++ {
+		if failure[i] < 0x20 || failure[i] > 0x7e {
+			t.Fatalf("byte %d of %q is not one a header value carries", i, failure)
+		}
+	}
+	decoded, err := url.PathUnescape(failure)
+	if err != nil {
+		t.Fatalf("the reader cannot undo it: %v", err)
+	}
+	if decoded != message {
+		t.Fatalf("decoded = %q, want the message as it was written", decoded)
 	}
 }
 

--- a/docs/network-stack.md
+++ b/docs/network-stack.md
@@ -195,7 +195,11 @@ the lane whole — `router.Mount` → `grpc.Serve` → `InvokeApp` → a real ap
 upstream that records what it was sent — and asserts one bullet per case. A
 layer's own test can only say what that layer did with what it was handed;
 which values reach the wire is a property of the lane as a whole, so a line
-here that stops being true fails there instead of rotting quietly.
+here that stops being true fails there instead of rotting quietly. The bullets
+run on the app that forwards the bytes the client framed, and then once more
+per family — an app that transcodes a document, one that speaks a protocol of
+its own, and one that answers here with no upstream at all — because they are
+the door's rules rather than any app's.
 
 ## Seven traces
 

--- a/server/pkg/api/api.go
+++ b/server/pkg/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	fmt "fmt"
+	"io"
 	"log/slog"
 	"sort"
 	"sync"
@@ -182,9 +183,19 @@ type timedStream struct {
 	resolver *Resolver
 	sent     map[string]string
 	log      callLog
+	// failure is what ended the stream, held for the line: a call that fails after it
+	// has started answering fails at Recv, and the report the line is written from
+	// says nothing about it.
+	failure error
 }
 
-func (s *timedStream) Recv() ([]byte, error) { return s.stream.Recv() }
+func (s *timedStream) Recv() ([]byte, error) {
+	message, err := s.stream.Recv()
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.failure = err
+	}
+	return message, err
+}
 
 func (s *timedStream) Report() *apps.Report {
 	report := s.stream.Report()
@@ -193,7 +204,7 @@ func (s *timedStream) Report() *apps.Report {
 	}
 	report.DurationMs = time.Since(s.started).Milliseconds()
 	report.RequestHeaders = s.resolver.Redact(report.RequestHeaders, s.sent)
-	s.log.write(report.DurationMs, nil)
+	s.log.write(report.DurationMs, s.failure)
 	return report
 }
 

--- a/server/pkg/api/api_test.go
+++ b/server/pkg/api/api_test.go
@@ -1,3 +1,84 @@
 package api
 
-// Tests for the API service are located in configuration_test.go
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wham/kaja/v2/pkg/apps"
+)
+
+// failingStream answers with one message and then the failure that ended it, which is
+// what a call that has already started answering fails as.
+type failingStream struct {
+	sent bool
+	err  error
+}
+
+func (s *failingStream) Recv() ([]byte, error) {
+	if s.sent {
+		return nil, s.err
+	}
+	s.sent = true
+	return []byte("first"), nil
+}
+
+func (s *failingStream) Report() *apps.Report { return &apps.Report{} }
+
+// The door writes one line per call, and a stream that failed halfway through is a
+// call whose outcome is settled at its report: the status the upstream refused it with
+// has to be on that line, or a headless deployment has nothing saying the call failed
+// at all.
+func TestTheDoorLogsTheStatusOfAFailureThatSurfacedMidStream(t *testing.T) {
+	lines := &bytes.Buffer{}
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(lines, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	failure := apps.NewUpstreamError(http.MethodGet, "https://api.example.com/orders", http.StatusTooManyRequests, []byte(`{"msg":"slow down"}`))
+	stream := &timedStream{
+		stream:   &failingStream{err: failure},
+		started:  time.Now(),
+		resolver: NewResolver(nil, nil),
+		log:      callLog{method: "orders.v1.Orders/List", app: "orders"},
+	}
+
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("first Recv: %v", err)
+	}
+	if _, err := stream.Recv(); err == nil {
+		t.Fatal("second Recv answered, want the failure that ended the stream")
+	}
+	stream.Report()
+
+	if !strings.Contains(lines.String(), "upstreamStatus=429") {
+		t.Errorf("the line says nothing of what refused the call: %q", lines.String())
+	}
+}
+
+// A stream that ran out is not a stream that failed.
+func TestTheDoorLogsNoStatusForAStreamThatEnded(t *testing.T) {
+	lines := &bytes.Buffer{}
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(lines, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	stream := &timedStream{
+		stream:   &failingStream{err: io.EOF},
+		started:  time.Now(),
+		resolver: NewResolver(nil, nil),
+		log:      callLog{method: "orders.v1.Orders/List", app: "orders"},
+	}
+
+	stream.Recv()
+	stream.Recv()
+	stream.Report()
+
+	if strings.Contains(lines.String(), "upstreamStatus") {
+		t.Errorf("a stream that ran out was logged as a failure: %q", lines.String())
+	}
+}

--- a/server/pkg/router/traces_test.go
+++ b/server/pkg/router/traces_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -46,12 +48,22 @@ const (
 // mount — the web server's and the desktop webview's are this one.
 func workspace(t *testing.T, upstreamURL string) *http.ServeMux {
 	t.Helper()
+	entry := fmt.Sprintf(`{"name": %q, "twirp": {"url": %q, "proto_dir": "proto"}}`, appName, upstreamURL)
+	return workspaceWith(t, entry, appName, "twirp", map[string]string{"url": upstreamURL, "proto_dir": "proto"})
+}
+
+// workspaceWith is that workspace for any one app: the entry as kaja.json carries it,
+// and the parameters the door will invoke it with. The TOKEN variable's value lives
+// outside the file whatever the app is, which is the whole reason the browser may
+// never be told it.
+func workspaceWith(t *testing.T, entry string, name string, appType string, parameters map[string]string) *http.ServeMux {
+	t.Helper()
 	t.Setenv("KAJA_TOKEN", tokenValue)
 
 	configuration := fmt.Sprintf(`{
 		"variables": {"TOKEN": "${secret}"},
-		"apps": [{"name": %q, "twirp": {"url": %q, "proto_dir": "proto"}}]
-	}`, appName, upstreamURL)
+		"apps": [%s]
+	}`, entry)
 	path := t.TempDir() + "/kaja.json"
 	if err := os.WriteFile(path, []byte(configuration), 0o600); err != nil {
 		t.Fatalf("write configuration: %v", err)
@@ -60,7 +72,7 @@ func workspace(t *testing.T, upstreamURL string) *http.ServeMux {
 	service := api.NewApiService(path, false, "", "", nil)
 	// What OpenApp does once it has flattened the app's typed parameters. Compiling
 	// the proto surface is the other half of that RPC and no part of a call.
-	if _, err := service.Apps().Open(appName, "twirp", map[string]string{"url": upstreamURL, "proto_dir": "proto"}, t.TempDir(), func(string) {}); err != nil {
+	if _, err := service.Apps().Open(name, appType, parameters, t.TempDir(), func(string) {}); err != nil {
 		t.Fatalf("open app: %v", err)
 	}
 
@@ -83,9 +95,16 @@ type exchange struct {
 // name among them.
 func call(t *testing.T, mux *http.ServeMux, headers map[string]string) exchange {
 	t.Helper()
-	request := httptest.NewRequest(http.MethodPost, "/app/"+method, bytes.NewReader(frame(0, []byte("request"))))
+	return callApp(t, mux, appName, method, []byte("request"), headers)
+}
+
+// callApp is that call against any app: the one the client names in the reserved
+// header, the method it names in the path, and the request bytes it framed.
+func callApp(t *testing.T, mux *http.ServeMux, app string, method string, message []byte, headers map[string]string) exchange {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/app/"+method, bytes.NewReader(frame(0, message)))
 	request.Header.Set("Content-Type", "application/grpc-web+proto")
-	request.Header.Set("X-Header-X-Kaja-App", appName)
+	request.Header.Set("X-Header-X-Kaja-App", app)
 	for name, value := range headers {
 		request.Header.Set("X-Header-"+name, value)
 	}
@@ -366,4 +385,166 @@ func parseFrames(t *testing.T, body []byte) (messages [][]byte, trailers string)
 		body = body[5+n:]
 	}
 	return messages, trailers
+}
+
+// The traces above run on the app that forwards the bytes the client framed. The three
+// tests below are the same lane with something else at the end of it — an app that
+// builds its own HTTP request out of a document, one that speaks a protocol of its
+// own, and one that answers in this process without an upstream at all — because the
+// door's rules are the door's rather than any app's.
+
+const ordersSpec = `
+openapi: 3.0.0
+info:
+  title: Orders
+  version: "1.0"
+paths:
+  /orders:
+    get:
+      operationId: listOrders
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+`
+
+// A transcoded call is a request kaja builds rather than one it passes on, so nothing
+// the client framed reaches the wire by simply being left alone: the reserved header
+// has to be gone because the door took it out, and the resolved credential has to be
+// there because the door put it there.
+func TestATranscodedCallCarriesTheDoorsRules(t *testing.T) {
+	var seen *http.Request
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"total":2}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	parameters := map[string]string{"spec_content": ordersSpec, "base_url": upstream.URL}
+	entry := fmt.Sprintf(`{"name": "orders", "openapi": {"spec_content": %s, "base_url": %q}}`, strconv.Quote(ordersSpec), upstream.URL)
+	mux := workspaceWith(t, entry, "orders", "openapi", parameters)
+
+	e := callApp(t, mux, "orders", "orders.Orders/ListOrders", nil, map[string]string{"Authorization": "Bearer ${TOKEN}"})
+
+	if seen == nil {
+		t.Fatalf("the upstream was never called\nresponse = %q", e.body)
+	}
+	if seen.URL.Path != "/orders" {
+		t.Errorf("upstream path = %q, want the one the document binds the method to", seen.URL.Path)
+	}
+	for name := range seen.Header {
+		if strings.Contains(strings.ToLower(name), "kaja") {
+			t.Errorf("upstream was sent %q, and the app's name is the browser's whole address", name)
+		}
+	}
+	if got := seen.Header.Get("Authorization"); got != "Bearer "+tokenValue {
+		t.Errorf("upstream Authorization = %q, want the resolved value", got)
+	}
+	if bytes.Contains(e.body, []byte(tokenValue)) {
+		t.Errorf("the resolved value reached the client: %q", e.body)
+	}
+	if request := headersOf(t, e.upstreamOf(t), "requestHeaders"); request["Authorization"] != "Bearer ${TOKEN}" {
+		t.Errorf("reported Authorization = %#v, want the reference the client sent", request["Authorization"])
+	}
+	if len(e.messages) != 1 {
+		t.Errorf("messages = %q, want the one the API answered with", e.messages)
+	}
+}
+
+// An app that speaks a protocol of its own is the same call to the door: the headers
+// it carries are the door's to expand and redact, whatever the app wraps them around.
+func TestAnAppSpeakingItsOwnProtocolCarriesTheDoorsRules(t *testing.T) {
+	var invoked *http.Request
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var message struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		json.Unmarshal(body, &message)
+		if len(message.ID) == 0 {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if message.Method == "tools/call" {
+			invoked = r
+		}
+		result, ok := mcpResults[message.Method]
+		w.Header().Set("Content-Type", "application/json")
+		if !ok {
+			// What a server that doesn't know the method says, which for the modern
+			// era's probe is what settles the client on the handshake instead.
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"Method not found"}}`, message.ID)
+			return
+		}
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%s}`, message.ID, result)
+	}))
+	t.Cleanup(upstream.Close)
+
+	entry := fmt.Sprintf(`{"name": "orders", "mcp": {"url": %q}}`, upstream.URL)
+	mux := workspaceWith(t, entry, "orders", "mcp", map[string]string{"url": upstream.URL})
+
+	e := callApp(t, mux, "orders", "mcp.Tools/ListOrders", nil, map[string]string{"Authorization": "Bearer ${TOKEN}"})
+
+	if invoked == nil {
+		t.Fatalf("the tool was never called\nresponse = %q", e.body)
+	}
+	for name := range invoked.Header {
+		if strings.Contains(strings.ToLower(name), "kaja") {
+			t.Errorf("upstream was sent %q, and the app's name is the browser's whole address", name)
+		}
+	}
+	if got := invoked.Header.Get("Authorization"); got != "Bearer "+tokenValue {
+		t.Errorf("upstream Authorization = %q, want the resolved value", got)
+	}
+	if bytes.Contains(e.body, []byte(tokenValue)) {
+		t.Errorf("the resolved value reached the client: %q", e.body)
+	}
+	if request := headersOf(t, e.upstreamOf(t), "requestHeaders"); request["Authorization"] != "Bearer ${TOKEN}" {
+		t.Errorf("reported Authorization = %#v, want the reference the client sent", request["Authorization"])
+	}
+}
+
+// What a server answers the calls an mcp app opens with, and the one tool it exposes.
+var mcpResults = map[string]string{
+	"initialize": `{"protocolVersion":"2025-06-18","serverInfo":{"name":"orders","version":"1"},"capabilities":{"tools":{}}}`,
+	"tools/list": `{"tools":[{"name":"list_orders","description":"Lists orders","inputSchema":{"type":"object","properties":{}}}]}`,
+	"tools/call": `{"content":[{"type":"text","text":"two"}]}`,
+}
+
+// A local app makes no upstream call at all, and the lane says so: the door still
+// times what it carried, and the exchange it reports is empty rather than invented.
+func TestALocalAppReportsNoHop(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "notes.md"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	entry := fmt.Sprintf(`{"name": "files", "folder": {"path": %q}}`, directory)
+	mux := workspaceWith(t, entry, "files", "folder", map[string]string{"path": directory})
+
+	e := callApp(t, mux, "files", "folder.Folder/ListFolder", nil, map[string]string{"Authorization": "Bearer ${TOKEN}"})
+
+	if len(e.messages) != 1 || !bytes.Contains(e.messages[0], []byte("notes.md")) {
+		t.Fatalf("messages = %q, want the folder it listed", e.messages)
+	}
+	if bytes.Contains(e.body, []byte(tokenValue)) {
+		t.Errorf("the resolved value reached the client: %q", e.body)
+	}
+	envelope := e.upstreamOf(t)
+	if _, ok := envelope["durationMs"].(float64); !ok {
+		t.Errorf("durationMs missing: %q", e.trailers)
+	}
+	for _, key := range []string{"requestHeaders", "responseHeaders", "error"} {
+		if value, ok := envelope[key]; ok {
+			t.Errorf("%s = %#v, want nothing: a call that never left this process made no exchange", key, value)
+		}
+	}
 }

--- a/ui/src/fetchTransport.test.ts
+++ b/ui/src/fetchTransport.test.ts
@@ -80,6 +80,19 @@ describe("the desktop's fetch lane", () => {
     expect(send("https://api.example.com/orders")).rejects.toThrow("connection refused");
   });
 
+  it("reads the lane's sentence as it was written", async () => {
+    const escaped = "dial tcp: lookup caf%C3%A9.example.com: no such host";
+    lane(() => new Response("", { status: 502, headers: { "X-Kaja-Fetch-Error": escaped } }));
+
+    expect(send("https://xn--caf-dma.example.com/orders")).rejects.toThrow("café.example.com");
+  });
+
+  it("shows a sentence it cannot decode as it came", async () => {
+    lane(() => new Response("", { status: 502, headers: { "X-Kaja-Fetch-Error": "100% of the time" } }));
+
+    expect(send("https://api.example.com/orders")).rejects.toThrow("100% of the time");
+  });
+
   it("hands back a status the API answered with rather than throwing", async () => {
     lane(() => new Response('{"error":"nope"}', { status: 404, statusText: "Not Found" }));
 

--- a/ui/src/fetchTransport.ts
+++ b/ui/src/fetchTransport.ts
@@ -64,9 +64,21 @@ export async function sendThroughDesktop(request: FetchRequest, input: RequestIn
   const failure = answer.headers.get(ERROR_HEADER);
   // A request that never completed, which is what fetch throws for. A TypeError
   // because that is what fetch throws, and the message is the lane's own.
-  if (failure) throw new TypeError(failure);
+  if (failure) throw new TypeError(laneMessage(failure));
 
   return apiResponse(answer, request.url);
+}
+
+// The lane's own sentence, as it was written. A header value is a byte string the
+// Fetch API reads as Latin-1, so the lane percent-encodes it on the way out - the
+// rule a gRPC-Web trailer is written under, for the same reason. A value that does
+// not decode is shown as it came rather than lost.
+function laneMessage(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 // The API's answer as the script sees it: the lane's status, the API's own headers,


### PR DESCRIPTION
Percent-encoded `X-Kaja-Fetch-Error` under the rule a gRPC-Web trailer is written by, since a header value is read as Latin-1 and a message with an accent or a newline in it arrived mangled or split; held on the timed stream what ended it, so a call an upstream refused halfway through puts its status on the door's line rather than reading like one that ran out; and ran the lane's invariants once per family of app, because the traces asserted them only against the app that forwards the bytes the client framed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxKifHh647kLs8zXVLtQWC)_