### PR TITLE
Fixed the case-only rename and made creating a script atomic

### DIFF
--- a/server/pkg/api/scripts.go
+++ b/server/pkg/api/scripts.go
@@ -156,10 +156,20 @@ func (s *ApiService) CreateScript(ctx context.Context, req *CreateScriptRequest)
 			return nil, err
 		}
 	}
-	if _, err := root.Stat(relative); err == nil {
-		return nil, fmt.Errorf("a script named %q already exists", relative)
+	// O_EXCL is the collision check as well as the create, so there is no window
+	// between asking whether the name is taken and taking it.
+	file, err := root.OpenFile(relative, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("a script named %q already exists", relative)
+		}
+		return nil, err
 	}
-	if err := root.WriteFile(relative, []byte(req.Content), 0644); err != nil {
+	if _, err := file.WriteString(req.Content); err != nil {
+		file.Close()
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
 		return nil, err
 	}
 	return &CreateScriptResponse{Script: scriptAt(dir, relative, req.Content)}, nil
@@ -188,7 +198,7 @@ func (s *ApiService) RenameScript(ctx context.Context, req *RenameScriptRequest)
 				return nil, err
 			}
 		}
-		if _, err := root.Stat(to); err == nil {
+		if takenByAnother(root, from, to) {
 			return nil, fmt.Errorf("a script named %q already exists", to)
 		}
 		if err := root.Rename(from, to); err != nil {
@@ -265,7 +275,7 @@ func (s *ApiService) RenameScriptFolder(ctx context.Context, req *RenameScriptFo
 		to = parent + "/" + base
 	}
 	if to != from {
-		if _, err := root.Stat(to); err == nil {
+		if takenByAnother(root, from, to) {
 			return nil, fmt.Errorf("a folder named %q already exists", to)
 		}
 		if err := root.Rename(from, to); err != nil {
@@ -321,6 +331,22 @@ func (s *ApiService) openScriptsForWriting() (string, *os.Root, error) {
 		return "", nil, fmt.Errorf("failed to open the scripts folder: %w", err)
 	}
 	return dir, root, nil
+}
+
+// takenByAnother reports whether the destination of a rename holds something other
+// than the source itself. A case-only rename - "foo.ts" to "Foo.ts" - is a real rename
+// with one file under both names on a case-insensitive filesystem, where a plain stat
+// of the destination finds the source and reads as a collision.
+func takenByAnother(root *os.Root, from string, to string) bool {
+	destination, err := root.Stat(to)
+	if err != nil {
+		return false
+	}
+	source, err := root.Stat(from)
+	if err != nil {
+		return true
+	}
+	return !os.SameFile(source, destination)
 }
 
 func scriptAt(dir string, relative string, content string) *Script {

--- a/server/pkg/api/scripts_test.go
+++ b/server/pkg/api/scripts_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -344,6 +346,133 @@ func TestRenameScriptMoves(t *testing.T) {
 	}
 	if _, err := service.ReadScript(ctx, &ReadScriptRequest{Name: "other.ts"}); err != nil {
 		t.Fatalf("the source was moved anyway: %v", err)
+	}
+}
+
+// A case-only rename is a rename like any other. On a case-insensitive filesystem the
+// destination stats to the source itself, which is not a name being taken.
+func TestRenameScriptChangesOnlyCase(t *testing.T) {
+	service := writableWorkspace(t)
+	ctx := context.Background()
+	createScript(t, service, "reports/churn.ts", "// body")
+
+	renamed, err := service.RenameScript(ctx, &RenameScriptRequest{Name: "reports/churn.ts", NewName: "reports/Churn.ts"})
+	if err != nil {
+		t.Fatalf("a case-only rename was refused: %v", err)
+	}
+	if renamed.Script.Name != "Churn.ts" || renamed.Script.Folder != "reports" || renamed.Script.Content != "// body" {
+		t.Fatalf("renamed %+v", renamed.Script)
+	}
+	// The listing reads the name off disk, so it says which one the file has now.
+	listed, err := service.ListScripts(ctx, &ListScriptsRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Scripts) != 1 || listed.Scripts[0].Name != "Churn.ts" {
+		t.Fatalf("scripts = %+v", listed.Scripts)
+	}
+
+	// A name another file holds is still taken.
+	createScript(t, service, "reports/other.ts", "")
+	if _, err := service.RenameScript(ctx, &RenameScriptRequest{Name: "reports/other.ts", NewName: "reports/Churn.ts"}); err == nil {
+		t.Fatalf("a move onto an existing file was accepted")
+	}
+}
+
+func TestRenameScriptFolderChangesOnlyCase(t *testing.T) {
+	service := writableWorkspace(t)
+	ctx := context.Background()
+	createScript(t, service, "billing/invoices.ts", "")
+
+	renamed, err := service.RenameScriptFolder(ctx, &RenameScriptFolderRequest{Name: "billing", NewName: "Billing"})
+	if err != nil {
+		t.Fatalf("a case-only rename was refused: %v", err)
+	}
+	if renamed.Folder != "Billing" {
+		t.Fatalf("renamed to %q", renamed.Folder)
+	}
+	folders, err := service.ListScriptFolders(ctx, &ListScriptFoldersRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(folders.Folders) != 1 || folders.Folders[0] != "Billing" {
+		t.Fatalf("folders = %q", folders.Folders)
+	}
+
+	// A folder another folder holds is still taken.
+	if _, err := service.CreateScriptFolder(ctx, &CreateScriptFolderRequest{Name: "archive"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RenameScriptFolder(ctx, &RenameScriptFolderRequest{Name: "archive", NewName: "Billing"}); err == nil {
+		t.Fatalf("a rename onto an existing folder was accepted")
+	}
+}
+
+// The two names a case-insensitive filesystem gives one file are what a hardlink is
+// on any filesystem, so the rule the rename checks is testable where the case-only
+// rename above is a no-op.
+func TestTakenByAnother(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "churn.ts"), []byte("// body"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(filepath.Join(dir, "churn.ts"), filepath.Join(dir, "Churn.ts")); err != nil {
+		t.Skipf("this filesystem has no hardlinks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "other.ts"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if takenByAnother(root, "churn.ts", "Churn.ts") {
+		t.Errorf("the source under a second name was read as a collision")
+	}
+	if !takenByAnother(root, "churn.ts", "other.ts") {
+		t.Errorf("another file was not read as a collision")
+	}
+	if takenByAnother(root, "churn.ts", "nothing.ts") {
+		t.Errorf("a name nothing holds was read as a collision")
+	}
+}
+
+// Creating is one act, so exactly one of a crowd asking for the same name gets it.
+func TestCreateScriptIsAtomic(t *testing.T) {
+	service := writableWorkspace(t)
+	ctx := context.Background()
+
+	const creators = 8
+	var wait sync.WaitGroup
+	created := make(chan string, creators)
+	for i := range creators {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			content := fmt.Sprintf("// %d", i)
+			if _, err := service.CreateScript(ctx, &CreateScriptRequest{Name: "churn.ts", Content: content}); err == nil {
+				created <- content
+			}
+		}()
+	}
+	wait.Wait()
+	close(created)
+
+	winners := []string{}
+	for content := range created {
+		winners = append(winners, content)
+	}
+	if len(winners) != 1 {
+		t.Fatalf("%d creators were told they had made the file: %q", len(winners), winners)
+	}
+	read, err := service.ReadScript(ctx, &ReadScriptRequest{Name: "churn.ts"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Script.Content != winners[0] {
+		t.Fatalf("the file holds %q, but %q was the one that was created", read.Script.Content, winners[0])
 	}
 }
 


### PR DESCRIPTION
Renaming a script or folder to a name differing only in case was refused on macOS, because the stat guarding the destination finds the source itself on a case-insensitive filesystem, so both renames now treat a destination that resolves to the source as free rather than taken; creating a script was stat-then-write and is now one `O_EXCL` create, so two callers asking for one name can no longer both be told they made the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_011zKh6JqQZ9cM8vnL7J3bsX)_