### PR TITLE
Made the resize handle a hairline that tints

### DIFF
--- a/ui/src/Splitter.tsx
+++ b/ui/src/Splitter.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 
 import { cn } from "./cn";
 
+const HIT_AREA = 9;
+const OVERLAP = 4;
+
 interface SplitterProps {
   orientation: "vertical" | "horizontal";
   onResize: (delta: number) => void;
@@ -33,19 +36,24 @@ export function Splitter({ orientation, onResize, hitAreaSize }: SplitterProps) 
     event.preventDefault();
   };
 
-  const hitArea = hitAreaSize ?? 3;
+  const hitArea = hitAreaSize ?? HIT_AREA;
 
   return (
     <div className={cn("relative shrink-0 bg-border", isVertical ? "h-full w-px" : "h-px w-full")}>
       <div
-        className={cn(
-          "absolute z-[1] hover:bg-primary",
-          isVertical ? "-left-px top-0 h-full cursor-col-resize" : "-top-px left-0 w-full cursor-row-resize",
-          isResizing && "bg-primary",
-        )}
-        style={isVertical ? { width: hitArea } : { height: hitArea }}
+        className={cn("group absolute z-[2]", isVertical ? "top-0 h-full cursor-col-resize" : "left-0 w-full cursor-row-resize")}
+        style={isVertical ? { width: hitArea, left: -OVERLAP } : { height: hitArea, top: -OVERLAP }}
         onMouseDown={onMouseDown}
-      />
+      >
+        <div
+          className={cn(
+            "absolute bg-primary transition-opacity delay-100 duration-[120ms]",
+            isVertical ? "top-0 h-full w-px" : "left-0 h-px w-full",
+            isResizing ? "opacity-100" : "opacity-0 group-hover:opacity-70",
+          )}
+          style={isVertical ? { left: OVERLAP } : { top: OVERLAP }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The splitter filled its whole hit area with the accent on hover, so the mark grew as the cursor came near; it is now one hairline that never changes size, fading from border to accent after a 100ms delay, with the hit area grown to 9px centred on the line instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZDpHrH1r9D3XzY9zku6tu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZDpHrH1r9D3XzY9zku6tu)_