### PR TITLE
Gave each MCP client its own draft

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ server/proto/api.proto
 3. **Naming a draft moves it into Files.** The naming sheet asks for a name and a folder, nothing else.
 4. **Discarding is safe.** Untouched drafts are cleared without asking; edited ones need a confirm that names them.
 
-One word throughout — a **draft** (`drafts.ts`, `Draft`, `draftTitle.ts`, IndexedDB, unlimited, web and desktop alike). The old "scratch" keys (`drafts`, `agentDraftId`, view `type: "draft"`) are still read once for migration.
+One word throughout — a **draft** (`drafts.ts`, `Draft`, `draftTitle.ts`, IndexedDB, unlimited, web and desktop alike). The old "scratch" key (`drafts`) is still read once for migration.
 
 - **Five verbs, one object each.** You **name** a draft, **save** a file, **clear** drafts, **delete** a file, **revert** a file to saved. Nothing says "unsaved", because nothing is at risk.
 - **Clicking a method never asks what to do with it** (`onMethodSelect`). `findUntouched` first looks for an untouched draft holding exactly this call from this app and **reopens** it (`reopen` only bumps `updatedAt`, so it sits at the top and out of the sweep's reach). Otherwise an **untouched** draft — byte-identical to its generated code and never run (`isUntouched`) — is **taken over**, and a worked-in one is left alone while the call starts a new draft. The agent's draft is never taken over. Appending is deliberate: **⌥click or the row's `+`**; `appendCall` merges import lines and edits the text rather than reprinting it, so the author's formatting survives. Generated code is run through prettier **before it reaches the model** — format-on-open only fires when a model is created, and a takeover writes into one that already exists. The editor wraps rather than scrolling sideways.
@@ -170,12 +170,13 @@ One word throughout — a **draft** (`drafts.ts`, `Draft`, `draftTitle.ts`, Inde
 
 ### The agent's draft
 
-A snippet run over MCP is run in **one** draft, the same one every time, so its runs appear in the sidebar and the run history.
+A snippet run over MCP is run in **one** draft per client, the same one every time that client runs, so its runs appear in the sidebar and the run history.
 
-- **One row, pinned above your own, wearing the last client's name** — `clientInfo.title`, else `clientInfo.name`, else `Agent`, captured in `server/pkg/mcp/server.go` and carried into the run. `agentClient` on the `Draft` is the whole of it; `isAgentDraft` pins the row, excludes it from the count and spares it from the sweep. The icon is `Plug`, which already means MCP in the sidebar's band.
+- **One row per client, pinned above your own and wearing its name** — `clientInfo.title`, else `clientInfo.name`, else `Agent`, read in `server/pkg/mcp/server.go` and carried into the run. `agentClient` on the `Draft` is the whole of it, the **slot included**: `agentDraft` finds the client's buffer by that name rather than by an id held beside the list, so nothing can drift from it and a draft written when there was one slot belongs to whoever last wrote it. `isAgentDraft` pins the rows, excludes them from the count and spares them from the sweep; among themselves they order by recency. The icon is `Plug`, which already means MCP in the sidebar's band.
+- **One endpoint serves every client, so a run says who made it** (`identify`). Three ways, newest first: the revision that dropped the handshake carries `clientInfo` in `params._meta` on every request; an older one announces it at `initialize` and echoes the `Mcp-Session-Id` pinned in the answer; a client doing neither is whoever handshook last, which is what a single-agent endpoint was already read as. A name is pinned a session **once**, so a client that handshakes on every start is one entry and the map is bounded by how many agents there are rather than by how often they connect.
 - **The emerald dot is the only live indicator in the sidebar.** It goes out when the call finishes; the row and its name persist with no client connected.
-- **It can be cleared like any draft** — the next snippet makes another.
-- **Naming it works the same way.** `create_script` also consumes it when what was saved is exactly what was last run (`consumeAgentDraft`), so the buffer becomes the file rather than lingering as a copy, and its console follows it to the path.
+- **It can be cleared like any draft** — the next snippet from that client makes another.
+- **Naming it works the same way.** `create_script` also consumes it when what was saved is exactly what was last run (`consumeAgentDraft`, matching the code rather than a remembered id), so the buffer becomes the file rather than lingering as a copy, and its console follows it to the path.
 
 ## Deeplinks
 

--- a/server/pkg/mcp/server.go
+++ b/server/pkg/mcp/server.go
@@ -11,7 +11,9 @@ package mcp
 
 import (
 	"context"
+	"crypto/rand"
 	_ "embed"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -134,6 +136,15 @@ const defaultClientName = "Agent"
 // indistinguishable from one that failed.
 const streamKeepalive = 15 * time.Second
 
+// sessionHeader is what a handshake pins and every request after it echoes, which
+// is what tells two agents on one endpoint apart. Streamable HTTP makes echoing it
+// the client's job once a server has issued one.
+const sessionHeader = "Mcp-Session-Id"
+
+// metaClientInfo is where the revision that dropped the handshake carries the
+// client's identity: on every request, in params._meta.
+const metaClientInfo = "io.modelcontextprotocol/clientInfo"
+
 // Server is the MCP HTTP handler.
 type Server struct {
 	bridge   Bridge
@@ -142,15 +153,21 @@ type Server struct {
 
 	mu       sync.Mutex
 	inFlight int
-	// What the last client to handshake called itself. One buffer is shared by every
-	// client, so this is whichever touched it last.
+	// What the last client to handshake called itself, which is what a request
+	// carrying neither a session nor an identity of its own is read as.
 	client string
+	// The name each pinned session belongs to, and the session pinned for each name.
+	// A name is minted a session once, so a client that handshakes on every start is
+	// one entry rather than a hundred, and the map is bounded by how many agents
+	// there are rather than by how often they connect.
+	sessions map[string]string
+	pinned   map[string]string
 }
 
 // NewServer builds a server. token guards every request via a bearer header;
 // it must be non-empty.
 func NewServer(bridge Bridge, token string) *Server {
-	return &Server{bridge: bridge, token: token}
+	return &Server{bridge: bridge, token: token, sessions: map[string]string{}, pinned: map[string]string{}}
 }
 
 // Streamed answers over SSE whenever the client says it accepts one, so a slow
@@ -208,6 +225,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	caller := s.identify(w, r, req)
+
 	// An agent's calls arrive in bursts, so the request is marked from the moment it
 	// lands until it is answered and the UI holds the mark a little longer.
 	if req.Method != "ping" {
@@ -222,11 +241,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.streamed && acceptsEventStream(r) {
-		s.respondStreamed(w, r, req)
+		s.respondStreamed(w, r, req, caller)
 		return
 	}
 
-	result, rerr := s.dispatch(r.Context(), req.Method, req.Params)
+	result, rerr := s.dispatch(r.Context(), req.Method, req.Params, caller)
 	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
 	if rerr != nil {
 		resp.Error = rerr
@@ -243,11 +262,11 @@ func acceptsEventStream(r *http.Request) bool {
 // respondStreamed answers over SSE, which Streamable HTTP allows for any request.
 // The answer is the same JSON-RPC response in one event; what it buys is the comment
 // line sent while it is still being produced.
-func (s *Server) respondStreamed(w http.ResponseWriter, r *http.Request, req rpcRequest) {
+func (s *Server) respondStreamed(w http.ResponseWriter, r *http.Request, req rpcRequest, caller string) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		// Nothing can be flushed, so a stream would be buffered into a single write anyway.
-		result, rerr := s.dispatch(r.Context(), req.Method, req.Params)
+		result, rerr := s.dispatch(r.Context(), req.Method, req.Params, caller)
 		resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
 		if rerr != nil {
 			resp.Error = rerr
@@ -269,7 +288,7 @@ func (s *Server) respondStreamed(w http.ResponseWriter, r *http.Request, req rpc
 	}
 	done := make(chan answer, 1)
 	go func() {
-		result, rerr := s.dispatch(r.Context(), req.Method, req.Params)
+		result, rerr := s.dispatch(r.Context(), req.Method, req.Params, caller)
 		done <- answer{result: result, err: rerr}
 	}()
 
@@ -319,7 +338,7 @@ func (s *Server) authorized(r *http.Request) bool {
 	return subtleEqual(strings.TrimPrefix(h, prefix), s.token)
 }
 
-func (s *Server) dispatch(ctx context.Context, method string, params json.RawMessage) (interface{}, *rpcError) {
+func (s *Server) dispatch(ctx context.Context, method string, params json.RawMessage, caller string) (interface{}, *rpcError) {
 	switch method {
 	case "initialize":
 		return s.handleInitialize(params), nil
@@ -328,7 +347,7 @@ func (s *Server) dispatch(ctx context.Context, method string, params json.RawMes
 	case "tools/list":
 		return map[string]interface{}{"tools": toolDefinitions(s.bridge.CanWriteScripts())}, nil
 	case "tools/call":
-		return s.handleToolCall(ctx, params)
+		return s.handleToolCall(ctx, params, caller)
 	case "resources/list":
 		return s.handleResourcesList()
 	case "resources/read":
@@ -338,29 +357,7 @@ func (s *Server) dispatch(ctx context.Context, method string, params json.RawMes
 	}
 }
 
-// handleInitialize also learns what the client calls itself. The name is only ever
-// read back onto the draft an inline run lands in.
 func (s *Server) handleInitialize(params json.RawMessage) interface{} {
-	var announced struct {
-		ClientInfo struct {
-			Title string `json:"title"`
-			Name  string `json:"name"`
-		} `json:"clientInfo"`
-	}
-	if err := json.Unmarshal(params, &announced); err == nil {
-		// A title is written to be read; a name is an identifier ("claude-code"). Prefer the
-		// one meant for a person, since that is where this ends up.
-		name := strings.TrimSpace(announced.ClientInfo.Title)
-		if name == "" {
-			name = strings.TrimSpace(announced.ClientInfo.Name)
-		}
-		if name != "" {
-			s.mu.Lock()
-			s.client = name
-			s.mu.Unlock()
-		}
-	}
-
 	return map[string]interface{}{
 		"protocolVersion": protocolVersion,
 		"capabilities": map[string]interface{}{
@@ -375,8 +372,92 @@ func (s *Server) handleInitialize(params json.RawMessage) interface{} {
 	}
 }
 
-// clientName is what the last handshake announced, or the fallback.
-func (s *Server) clientName() string {
+// identify is who this request is from, which is the whole of what gives an agent a
+// draft of its own. Three ways of saying it, newest first: the revision that dropped
+// the handshake carries the identity on every request, an older one announces it once
+// and echoes the session pinned for it, and a client that does neither is whoever
+// handshook last — which is what a single-agent endpoint was already read as.
+//
+// A handshake also pins the session, so the answer to `initialize` is where the
+// header is set.
+func (s *Server) identify(w http.ResponseWriter, r *http.Request, req rpcRequest) string {
+	if name := announcedName(req.Params, metaClientInfo); name != "" {
+		return name
+	}
+	if req.Method == "initialize" {
+		name := announcedName(req.Params, "clientInfo")
+		if name == "" {
+			return s.lastClient()
+		}
+		w.Header().Set(sessionHeader, s.pin(name))
+		return name
+	}
+	if id := r.Header.Get(sessionHeader); id != "" {
+		s.mu.Lock()
+		name := s.sessions[id]
+		s.mu.Unlock()
+		if name != "" {
+			return name
+		}
+	}
+	return s.lastClient()
+}
+
+// announcedName reads a clientInfo out of the params, either at the top level (the
+// handshake) or under `_meta` (every request of the modern revision). A title is
+// written to be read; a name is an identifier ("claude-code"). Prefer the one meant
+// for a person, since a draft's row is where this ends up.
+func announcedName(params json.RawMessage, key string) string {
+	fields := map[string]json.RawMessage{}
+	if json.Unmarshal(params, &fields) != nil {
+		return ""
+	}
+	if key == metaClientInfo {
+		meta := map[string]json.RawMessage{}
+		if json.Unmarshal(fields["_meta"], &meta) != nil {
+			return ""
+		}
+		fields = meta
+	}
+	var announced struct {
+		Title string `json:"title"`
+		Name  string `json:"name"`
+	}
+	if json.Unmarshal(fields[key], &announced) != nil {
+		return ""
+	}
+	if title := strings.TrimSpace(announced.Title); title != "" {
+		return title
+	}
+	return strings.TrimSpace(announced.Name)
+}
+
+// pin records the handshake and answers with the session this name is known by.
+func (s *Server) pin(name string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.client = name
+	if id, ok := s.pinned[name]; ok {
+		return id
+	}
+	id := newSessionID()
+	s.pinned[name] = id
+	s.sessions[id] = name
+	return id
+}
+
+// newSessionID is the opaque handle a handshake is pinned under. It identifies a
+// client rather than authorizing one — the bearer token does that — so it is short.
+func newSessionID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return hex.EncodeToString([]byte(time.Now().Format(time.RFC3339Nano)))
+	}
+	return hex.EncodeToString(b)
+}
+
+// lastClient is what the last handshake announced, or the fallback.
+func (s *Server) lastClient() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.client == "" {

--- a/server/pkg/mcp/server_test.go
+++ b/server/pkg/mcp/server_test.go
@@ -161,18 +161,12 @@ const token = "secret-token"
 
 func call(t *testing.T, srv *Server, method string, params interface{}) rpcResponse {
 	t.Helper()
-	body := map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": method}
-	if params != nil {
-		body["params"] = params
-	}
-	b, _ := json.Marshal(body)
-	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(b))
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("%s: status = %d, body = %s", method, rec.Code, rec.Body.String())
-	}
+	return request(t, srv, method, params, nil)
+}
+
+func request(t *testing.T, srv *Server, method string, params interface{}, headers map[string]string) rpcResponse {
+	t.Helper()
+	rec := post(t, srv, method, params, headers)
 	var resp rpcResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("%s: decode response: %v (%s)", method, err, rec.Body.String())
@@ -180,14 +174,52 @@ func call(t *testing.T, srv *Server, method string, params interface{}) rpcRespo
 	return resp
 }
 
+func post(t *testing.T, srv *Server, method string, params interface{}, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": method}
+	if params != nil {
+		body["params"] = params
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s: status = %d, body = %s", method, rec.Code, rec.Body.String())
+	}
+	return rec
+}
+
 // tool calls a tool and returns its text content.
 func tool(t *testing.T, srv *Server, name string, args map[string]string) string {
+	t.Helper()
+	return toolAs(t, srv, "", name, args)
+}
+
+// toolAs calls a tool as the client holding a session, which is how one endpoint
+// serving two agents is written in a test.
+func toolAs(t *testing.T, srv *Server, session, name string, args map[string]string) string {
 	t.Helper()
 	params := map[string]interface{}{"name": name}
 	if args != nil {
 		params["arguments"] = args
 	}
-	return toolText(t, call(t, srv, "tools/call", params))
+	headers := map[string]string{}
+	if session != "" {
+		headers[sessionHeader] = session
+	}
+	return toolText(t, request(t, srv, "tools/call", params, headers))
+}
+
+// handshake introduces a client and answers with the session it was pinned.
+func handshake(t *testing.T, srv *Server, info map[string]string) string {
+	t.Helper()
+	rec := post(t, srv, "initialize", map[string]interface{}{"clientInfo": info}, nil)
+	return rec.Header().Get(sessionHeader)
 }
 
 func contains(t *testing.T, text string, fragments ...string) {
@@ -514,7 +546,7 @@ func TestCallTool_CRUD(t *testing.T) {
 }
 
 // The draft an inline run lands in is labelled with the agent that ran it, so
-// the name it announced at the handshake has to reach the run.
+// the name it announced has to reach the run.
 func TestRunScriptCarriesTheClientName(t *testing.T) {
 	bridge := newFakeBridge()
 	srv := NewServer(bridge, token)
@@ -526,16 +558,78 @@ func TestRunScriptCarriesTheClientName(t *testing.T) {
 	}
 
 	// A title is what a person reads; the identifier is the fallback.
-	call(t, srv, "initialize", map[string]interface{}{"clientInfo": map[string]string{"name": "claude-code", "title": "Claude Code"}})
+	handshake(t, srv, map[string]string{"name": "claude-code", "title": "Claude Code"})
 	tool(t, srv, "run_script", map[string]string{"code": "1"})
 	if bridge.lastClient != "Claude Code" {
 		t.Errorf("client = %q, want Claude Code", bridge.lastClient)
 	}
 
-	call(t, srv, "initialize", map[string]interface{}{"clientInfo": map[string]string{"name": "cursor-vscode"}})
+	handshake(t, srv, map[string]string{"name": "cursor-vscode"})
 	tool(t, srv, "run_script", map[string]string{"code": "1"})
 	if bridge.lastClient != "cursor-vscode" {
 		t.Errorf("client = %q, want cursor-vscode", bridge.lastClient)
+	}
+}
+
+// Two agents on one endpoint each get their own draft, so a run has to be read as
+// the client that made it rather than as whoever handshook last.
+func TestTwoClientsAreToldApartByTheirSession(t *testing.T) {
+	bridge := newFakeBridge()
+	srv := NewServer(bridge, token)
+
+	code := handshake(t, srv, map[string]string{"name": "claude-code", "title": "Claude Code"})
+	codex := handshake(t, srv, map[string]string{"name": "codex"})
+	if code == "" || codex == "" {
+		t.Fatalf("handshakes pinned no session (%q, %q)", code, codex)
+	}
+	if code == codex {
+		t.Fatalf("both clients were pinned the same session %q", code)
+	}
+
+	// Interleaved, and the later handshake is the one the fallback would have named.
+	toolAs(t, srv, code, "run_script", map[string]string{"code": "1"})
+	if bridge.lastClient != "Claude Code" {
+		t.Errorf("client = %q, want Claude Code", bridge.lastClient)
+	}
+	toolAs(t, srv, codex, "run_script", map[string]string{"code": "1"})
+	if bridge.lastClient != "codex" {
+		t.Errorf("client = %q, want codex", bridge.lastClient)
+	}
+
+	// A client that handshakes again is the same client, so it keeps its session and
+	// the map is bounded by how many agents there are.
+	if again := handshake(t, srv, map[string]string{"name": "claude-code", "title": "Claude Code"}); again != code {
+		t.Errorf("session = %q, want the one already pinned (%q)", again, code)
+	}
+}
+
+// The revision that dropped the handshake carries the identity on every request,
+// where it outranks any session at all.
+func TestClientInfoInMetaNamesTheCaller(t *testing.T) {
+	bridge := newFakeBridge()
+	srv := NewServer(bridge, token)
+
+	handshake(t, srv, map[string]string{"name": "claude-code", "title": "Claude Code"})
+	call(t, srv, "tools/call", map[string]interface{}{
+		"name":      "run_script",
+		"arguments": map[string]string{"code": "1"},
+		"_meta":     map[string]interface{}{metaClientInfo: map[string]string{"name": "codex"}},
+	})
+	if bridge.lastClient != "codex" {
+		t.Errorf("client = %q, want codex", bridge.lastClient)
+	}
+}
+
+// A session nothing pinned is a client kaja has never met, which is the one case
+// left for the last handshake to answer.
+func TestUnknownSessionFallsBackToTheLastHandshake(t *testing.T) {
+	bridge := newFakeBridge()
+	srv := NewServer(bridge, token)
+
+	handshake(t, srv, map[string]string{"name": "codex"})
+	toolAs(t, srv, "nothing-pinned-this", "run_script", map[string]string{"code": "1"})
+	if bridge.lastClient != "codex" {
+		t.Errorf("client = %q, want codex", bridge.lastClient)
 	}
 }
 

--- a/server/pkg/mcp/tools.go
+++ b/server/pkg/mcp/tools.go
@@ -185,7 +185,7 @@ type toolCallParams struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func (s *Server) handleToolCall(ctx context.Context, params json.RawMessage) (interface{}, *rpcError) {
+func (s *Server) handleToolCall(ctx context.Context, params json.RawMessage, caller string) (interface{}, *rpcError) {
 	var p toolCallParams
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid params"}
@@ -250,7 +250,7 @@ func (s *Server) handleToolCall(ctx context.Context, params json.RawMessage) (in
 		}
 		return textToolResult("Deleted " + args["path"]), nil
 	case "run_script":
-		return s.runScript(ctx, args["path"], args["code"]), nil
+		return s.runScript(ctx, args["path"], args["code"], caller), nil
 	default:
 		return nil, &rpcError{Code: codeInvalidParams, Message: fmt.Sprintf("unknown tool %q", p.Name)}
 	}
@@ -316,11 +316,11 @@ func (s *Server) describeType(name, appName string) map[string]interface{} {
 	return errorToolResult(fmt.Errorf("%q is declared by more than one app (%s); pass app to choose", name, strings.Join(names, ", ")))
 }
 
-func (s *Server) runScript(ctx context.Context, path, code string) map[string]interface{} {
+func (s *Server) runScript(ctx context.Context, path, code, caller string) map[string]interface{} {
 	if path == "" && code == "" {
 		return errorToolResult(fmt.Errorf("provide either path or code"))
 	}
-	result, err := s.bridge.RunScript(ctx, path, code, s.clientName())
+	result, err := s.bridge.RunScript(ctx, path, code, caller)
 	if err != nil {
 		return errorToolResult(err)
 	}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1114,14 +1114,17 @@ export function App() {
   const onNewDraftRef = useRef(onNewDraft);
   onNewDraftRef.current = onNewDraft;
 
-  const agentDraftIdRef = useRef<string | undefined>(getPersistedValue<string>("agentDraftId") ?? getPersistedValue<string>("agentScratchId"));
+  /**
+   * The slot is the client's, not the endpoint's: Claude Code and Codex each write into
+   * a draft of their own rather than over each other's. It is found by the name the
+   * draft is already labelled with, so there is nothing beside the list to keep in step
+   * with it and a draft written before there was more than one client is that client's.
+   */
   const agentDraft = useCallback(
     (code: string, client: string): Draft => {
       const now = Date.now();
-      const held = draftsRef.current.find((draft) => draft.id === agentDraftIdRef.current);
+      const held = draftsRef.current.find((draft) => draft.agentClient === client);
       const draft = { ...markRun(held ?? createDraft(code, undefined, now), code, now), agentClient: client };
-      agentDraftIdRef.current = draft.id;
-      setPersistedValue("agentDraftId", draft.id);
       applyDrafts((list) => (held ? list.map((candidate) => (candidate.id === draft.id ? draft : candidate)) : [draft, ...list]));
       const view = viewsRef.current.find((candidate) => candidate.type === "draft" && candidate.draftId === draft.id);
       if (view?.type === "draft" && view.model.getValue() !== code) view.model.setValue(code);
@@ -1136,11 +1139,9 @@ export function App() {
   // from what it ran is a new one, and the buffer stays where it is.
   const consumeAgentDraft = useCallback(
     (script: Script, content: string) => {
-      const id = agentDraftIdRef.current;
-      const draft = id ? draftsRef.current.find((candidate) => candidate.id === id) : undefined;
-      if (!id || !draft || draft.code !== content) return;
-      agentDraftIdRef.current = undefined;
-      setPersistedValue("agentDraftId", undefined);
+      const draft = draftsRef.current.find((candidate) => isAgentDraft(candidate) && candidate.code === content);
+      if (!draft) return;
+      const id = draft.id;
       const shown = viewsRef.current.find((view) => view.type === "draft" && view.draftId === id);
       applyViews((views) => (shown ? dropView(showScript(views, script, content), shown.id) : views));
       applyDrafts((list) => list.filter((candidate) => candidate.id !== id));
@@ -1498,10 +1499,6 @@ export function App() {
       if (sheet.draftId) {
         const id = sheet.draftId;
         applyDrafts((list) => list.filter((candidate) => candidate.id !== id));
-        if (id === agentDraftIdRef.current) {
-          agentDraftIdRef.current = undefined;
-          setPersistedValue("agentDraftId", undefined);
-        }
         consoles.renameFile(id, script.path);
         renameStoredFile(id, script.path);
         moveRunInput(id, script.path);

--- a/ui/src/ScriptsRegion.tsx
+++ b/ui/src/ScriptsRegion.tsx
@@ -103,8 +103,9 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
   const touch = useMediaQuery("(hover: none)");
 
   const ordered = useMemo(() => orderDrafts(drafts), [drafts]);
-  const agentDraft = ordered.find(isAgentDraft);
-  // The agent's row is pinned above your own and outside the count.
+  // One row per agent that has run something here, pinned above your own and outside
+  // the count. Two agents on one endpoint are two rows, most recently run first.
+  const agentDrafts = useMemo(() => ordered.filter(isAgentDraft), [ordered]);
   const ownDrafts = useMemo(() => ordered.filter((draft) => !isAgentDraft(draft)), [ordered]);
 
   const tree = useMemo(() => buildScriptTree(scripts, folders), [scripts, folders]);
@@ -223,7 +224,7 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
     >
       {/* Zero drafts hides the group rather than showing an empty label: there
           is nothing there and nothing to say about it. */}
-      {(agentDraft !== undefined || ownDrafts.length > 0) && (
+      {(agentDrafts.length > 0 || ownDrafts.length > 0) && (
         <>
           <GroupHeader
             label="Drafts"
@@ -238,20 +239,21 @@ export function ScriptsRegion(props: ScriptsRegionProps) {
           />
           {draftsOpen && (
             <ul role="tree" aria-label="Drafts" className="select-none">
-              {agentDraft && (
+              {agentDrafts.map((draft) => (
                 <AgentRow
-                  draft={agentDraft}
-                  current={props.currentDraftId === agentDraft.id}
-                  running={props.runningFileIds?.has(agentDraft.id)}
-                  waiting={props.waitingFileIds?.has(agentDraft.id)}
-                  active={active(`draft:${agentDraft.id}`)}
+                  key={draft.id}
+                  draft={draft}
+                  current={props.currentDraftId === draft.id}
+                  running={props.runningFileIds?.has(draft.id)}
+                  waiting={props.waitingFileIds?.has(draft.id)}
+                  active={active(`draft:${draft.id}`)}
                   canWrite={canWrite}
-                  onHover={(on) => setHovered(on ? `draft:${agentDraft.id}` : null)}
-                  onSelect={() => props.onDraftSelect(agentDraft)}
-                  onName={() => props.onNameDraft(agentDraft)}
-                  onDiscard={() => props.onDiscardDraft(agentDraft)}
+                  onHover={(on) => setHovered(on ? `draft:${draft.id}` : null)}
+                  onSelect={() => props.onDraftSelect(draft)}
+                  onName={() => props.onNameDraft(draft)}
+                  onDiscard={() => props.onDiscardDraft(draft)}
                 />
-              )}
+              ))}
               {draftsShown.map((draft) => (
                 <DraftRow
                   key={draft.id}

--- a/ui/src/drafts.test.ts
+++ b/ui/src/drafts.test.ts
@@ -157,6 +157,17 @@ describe("the Drafts group", () => {
     expect(ordered.map((draft) => draft.id)).toEqual(["agent", "ran", "edited", "browsed-new", "browsed-old"]);
   });
 
+  // A slot per client, so the rows read as who is writing where.
+  it("pins a row per agent, most recently run first", () => {
+    const ordered = orderDrafts([
+      draft("mine", NOW),
+      draft("codex", NOW - 2 * DAY, { agentClient: "Codex" }),
+      draft("claude", NOW - DAY, { agentClient: "Claude Code" }),
+    ]);
+
+    expect(ordered.map((draft) => draft.id)).toEqual(["claude", "codex", "mine"]);
+  });
+
   // Clearing untouched drafts must not reach the agent's row or your work.
   it("counts untouched and edited without the agent's row", () => {
     const list = [draft("browsed", NOW), draft("edited", NOW, { code: listShows + "// mine" }), draft("agent", NOW, { agentClient: "Claude" })];

--- a/ui/src/drafts.ts
+++ b/ui/src/drafts.ts
@@ -109,7 +109,7 @@ export function isAgentDraft(draft: Draft): boolean {
 }
 
 /**
- * The order the Drafts group reads in: the agent's row first, then edited drafts —
+ * The order the Drafts group reads in: the agents' rows first, then edited drafts —
  * work never hides behind generated calls — then the browsing buffers, each half most
  * recently opened first.
  */


### PR DESCRIPTION
Every agent on the MCP endpoint wrote into one draft and took it over from each other, so the slot is now keyed by the client's own name and the sidebar draws a row per agent; the server reads that name per request (`_meta` clientInfo, then a pinned `Mcp-Session-Id`, then the last handshake) so two clients running at once are told apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPhUjsjCeZKF7x5ws6AyZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPhUjsjCeZKF7x5ws6AyZA)_