### PR TITLE
Ordered the New app dialog like the empty state's map

### DIFF
--- a/ui/src/KajaMap.tsx
+++ b/ui/src/KajaMap.tsx
@@ -18,7 +18,8 @@ import { GrpcMark, McpMark, OpenApiMark, TwirpMark } from "./protocolMarks";
  * agent's run looks like when it lands.
  */
 
-// The apps down the right-hand side, each with the one word its surface is read from.
+// The apps down the right-hand side, each with the one word its surface is read from,
+// in the order the New dialog offers them in (appTypes.ts).
 const PROTOCOLS = [
   { mark: GrpcMark, name: "gRPC", source: ".proto", y: 40 },
   { mark: OpenApiMark, name: "OpenAPI", source: "schema", y: 100 },

--- a/ui/src/appTypes.ts
+++ b/ui/src/appTypes.ts
@@ -44,8 +44,10 @@ export interface AppTypeDefinition {
   demo?: { label: string; name: string; parameters: Record<string, string> };
 }
 
-// In the order shown in the New grid. Keep in sync with the app types registered on
-// the server (server/pkg/api/api.go).
+// In the order shown in the New grid, which is the order the empty state's map lists
+// the protocols in (KajaMap.tsx): the dialog is opened from that screen, so a reader
+// meets the same four in the same places. Keep in sync with the app types registered
+// on the server (server/pkg/api/api.go).
 export const appTypes: AppTypeDefinition[] = [
   {
     type: "grpc",
@@ -76,28 +78,6 @@ export const appTypes: AppTypeDefinition[] = [
       name: "grpcb.in",
       parameters: { url: "grpcb.in:9000", reflection: "true" },
     },
-  },
-  {
-    type: "twirp",
-    label: "Twirp",
-    description: "Call a Twirp service from its proto files.",
-    icon: TwirpMark,
-    parameters: [
-      {
-        key: "url",
-        label: "URL",
-        type: "url",
-        placeholder: "https://example.com/twirp",
-        caption: "Base URL of the Twirp server.",
-      },
-      {
-        key: "protoDir",
-        label: "Proto directory",
-        type: "folder",
-        placeholder: "path/to/proto",
-        caption: "Directory of .proto files (Twirp has no reflection).",
-      },
-    ],
   },
   {
     type: "openapi",
@@ -145,6 +125,28 @@ export const appTypes: AppTypeDefinition[] = [
       name: "DeepWiki",
       parameters: { url: "https://mcp.deepwiki.com/mcp" },
     },
+  },
+  {
+    type: "twirp",
+    label: "Twirp",
+    description: "Call a Twirp service from its proto files.",
+    icon: TwirpMark,
+    parameters: [
+      {
+        key: "url",
+        label: "URL",
+        type: "url",
+        placeholder: "https://example.com/twirp",
+        caption: "Base URL of the Twirp server.",
+      },
+      {
+        key: "protoDir",
+        label: "Proto directory",
+        type: "folder",
+        placeholder: "path/to/proto",
+        caption: "Directory of .proto files (Twirp has no reflection).",
+      },
+    ],
   },
   {
     preview: true,


### PR DESCRIPTION
The New app dialog listed gRPC, Twirp, OpenAPI, MCP while the empty state's map beside it lists gRPC, OpenAPI, MCP, Twirp, so Twirp moves below MCP in `appTypes.ts` and the two lists now name each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZSQDvn1xiR3W5rB17cEmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZSQDvn1xiR3W5rB17cEmB)_