### PR TITLE
Reordered the agent list

### DIFF
--- a/ui/src/mcpAgents.test.ts
+++ b/ui/src/mcpAgents.test.ts
@@ -38,7 +38,7 @@ describe("mcpAgents", () => {
   });
 
   test("VS Code's deeplink carries the same, as its own handler wants it", () => {
-    const link = agent("VS Code / Copilot").install!.link(endpoint);
+    const link = agent("VS Code").install!.link(endpoint);
     expect(JSON.parse(decodeURIComponent(link.slice("vscode:mcp/install?".length)))).toEqual({
       name: "kaja",
       type: "http",

--- a/ui/src/mcpAgents.ts
+++ b/ui/src/mcpAgents.ts
@@ -61,23 +61,6 @@ export const mcpAgents: McpAgent[] = [
     snippet: ({ url, token }) => `claude mcp add --transport http kaja \\\n  ${url} \\\n  --header "Authorization: Bearer ${token}"`,
   },
   {
-    name: "VS Code / Copilot",
-    kind: "one-click install",
-    path: "run in a terminal",
-    lead: "Opens VS Code's install prompt through its vscode: handler; VS Code writes the server into its own settings. The command below does the same thing without the handler.",
-    install: { label: "Add to VS Code", link: vsCodeLink },
-    snippet: ({ url, token }) => `code --add-mcp '{"name":"kaja","type":"http",\n  "url":"${url}",\n  "headers":{"Authorization":"Bearer ${token}"}}'`,
-  },
-  {
-    name: "Cursor",
-    kind: "one-click install",
-    path: "~/.cursor/mcp.json",
-    lead: "Opens Cursor through its deeplink handler and prefills the server; Cursor writes mcp.json once you accept. Below is the equivalent hand-edit.",
-    configurationKey: "cursor",
-    install: { label: "Add to Cursor", link: cursorLink },
-    snippet: ({ url, token }) => mcpServers(`      "url": "${url}",\n      "headers": { "Authorization": "Bearer ${token}" }`),
-  },
-  {
     // The connector UI connects from Anthropic's servers, which can't reach localhost,
     // so Desktop goes through the mcp-remote stdio bridge instead. The header is passed
     // via an env var because Claude Desktop splits args on spaces, which would otherwise
@@ -102,6 +85,32 @@ export const mcpAgents: McpAgent[] = [
         null,
         2,
       ),
+  },
+  {
+    name: "Cursor",
+    kind: "one-click install",
+    path: "~/.cursor/mcp.json",
+    lead: "Opens Cursor through its deeplink handler and prefills the server; Cursor writes mcp.json once you accept. Below is the equivalent hand-edit.",
+    configurationKey: "cursor",
+    install: { label: "Add to Cursor", link: cursorLink },
+    snippet: ({ url, token }) => mcpServers(`      "url": "${url}",\n      "headers": { "Authorization": "Bearer ${token}" }`),
+  },
+  {
+    name: "VS Code",
+    kind: "one-click install",
+    path: "run in a terminal",
+    lead: "Opens VS Code's install prompt through its vscode: handler; VS Code writes the server into its own settings. The command below does the same thing without the handler.",
+    install: { label: "Add to VS Code", link: vsCodeLink },
+    snippet: ({ url, token }) => `code --add-mcp '{"name":"kaja","type":"http",\n  "url":"${url}",\n  "headers":{"Authorization":"Bearer ${token}"}}'`,
+  },
+  {
+    name: "OpenAI Codex CLI",
+    kind: "config file",
+    path: "~/.codex/config.toml",
+    lead: "TOML. Append both tables at the end of the file.",
+    foot: "The headers table has to come after its parent table.",
+    configurationKey: "codex",
+    snippet: ({ url, token }) => `[mcp_servers.kaja]\nurl = "${url}"\n\n[mcp_servers.kaja.headers]\nAuthorization = "Bearer ${token}"`,
   },
   {
     name: "Windsurf",
@@ -139,15 +148,6 @@ export const mcpAgents: McpAgent[] = [
     configurationKey: "goose",
     snippet: ({ url, token }) =>
       `extensions:\n  kaja:\n    type: streamable_http\n    uri: ${url}\n    headers:\n      Authorization: "Bearer ${token}"\n    enabled: true`,
-  },
-  {
-    name: "OpenAI Codex CLI",
-    kind: "config file",
-    path: "~/.codex/config.toml",
-    lead: "TOML. Append both tables at the end of the file.",
-    foot: "The headers table has to come after its parent table.",
-    configurationKey: "codex",
-    snippet: ({ url, token }) => `[mcp_servers.kaja]\nurl = "${url}"\n\n[mcp_servers.kaja.headers]\nAuthorization = "Bearer ${token}"`,
   },
   {
     name: "Gemini CLI",


### PR DESCRIPTION
Put Claude Code, Claude Desktop, Cursor, VS Code and OpenAI Codex CLI at the top of the MCP agent list, leaving the rest in the order they had, and renamed "VS Code / Copilot" to "VS Code" since the row registers the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lb3fE4TYb2GqatkJXCqoB

---
_Generated by [Claude Code](https://claude.ai/code/session_018Lb3fE4TYb2GqatkJXCqoB)_