### PR TITLE
Shortened the scripts folder picker message

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -340,7 +340,7 @@ func (a *App) chooseScriptsFolder() {
 		CanChooseDirectories(true).
 		CanCreateDirectories(true).
 		SetTitle("Scripts Folder").
-		SetMessage("Pick the folder to keep your scripts in. Pick one this machine already syncs, such as a folder in iCloud Drive, to share them with another installation. Your apps are unaffected.").
+		SetMessage("Where to keep your scripts.").
 		SetButtonText("Use Folder").
 		PromptForSingleSelection()
 	if err != nil {


### PR DESCRIPTION
The scripts folder picker's message was three sentences about syncing, iCloud Drive and apps; it now says what the folder is for and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4uTjgc3gx6phogDj6T5Z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4uTjgc3gx6phogDj6T5Z3)_