### PR TITLE
Kept the variables table's order when a save echoes back

### DIFF
--- a/ui/src/Variables.test.ts
+++ b/ui/src/Variables.test.ts
@@ -13,4 +13,14 @@ describe("shouldAdoptIncomingVariables", () => {
   it("adopts the acknowledged save when nothing was edited after it started", () => {
     expect(shouldAdoptIncomingVariables({ A: "saved" }, { A: "old" }, { A: "saved" }, { A: "saved" }, false)).toBe(false);
   });
+
+  // The watcher sends the file back after every save, so the table is told its own
+  // content a moment after writing it. Adopting that re-sorts the rows.
+  it("keeps the table's order when the push carries what it already holds", () => {
+    expect(shouldAdoptIncomingVariables({ A: "1", B: "2" }, { A: "1", B: "2" }, { A: "1", B: "2" }, undefined, false)).toBe(false);
+  });
+
+  it("keeps a row being added when the push carries what the table already holds", () => {
+    expect(shouldAdoptIncomingVariables({ A: "1" }, { A: "1" }, { A: "1" }, undefined, false)).toBe(false);
+  });
 });

--- a/ui/src/Variables.tsx
+++ b/ui/src/Variables.tsx
@@ -92,6 +92,12 @@ export function shouldAdoptIncomingVariables(
   submitted: { [key: string]: string } | undefined,
   editedSinceSubmission: boolean,
 ): boolean {
+  // A push carrying what the table already holds is not a change to adopt. Writing
+  // the file is what makes the watcher send one, so every save comes back as an echo
+  // a moment later - and adopting it re-sorts the rows under whoever is typing in
+  // one, which is the row you just added swapping places with the one it now sorts
+  // before, taking your cursor with it.
+  if (sameVariables(current, incoming)) return false;
   const acknowledgingSubmission = submitted !== undefined && sameVariables(incoming, submitted);
   return sameVariables(current, previous) && !(editedSinceSubmission && acknowledgingSubmission);
 }


### PR DESCRIPTION
Every autosave writes kaja.json, which makes the watcher push the same configuration straight back, and the table read that echo as an external change and re-sorted its rows from the file, so a row you had just added jumped under your cursor and the next keystrokes landed on the variable it swapped with. A push carrying what the table already holds is no longer adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZfRKoHxgQPh2VwNkRHGYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZfRKoHxgQPh2VwNkRHGYq)_