### PR TITLE
Kept a restored file editable

### DIFF
--- a/ui/src/Editor.tsx
+++ b/ui/src/Editor.tsx
@@ -496,5 +496,14 @@ export function Editor({ model, onMount, onGoToDefinition, readOnly = false, for
     };
   }, [model]);
 
+  // The option is read once, when the editor is created, and a view mounts before
+  // the process has said whether it may write the workspace: a window restores its
+  // views synchronously and the answer arrives with the configuration. Without this
+  // the file that was open when the window last closed stays read-only for the
+  // session, and reopening it revisits the same editor.
+  useEffect(() => {
+    editorRef.current?.updateOptions({ readOnly });
+  }, [readOnly]);
+
   return <div ref={containerRef} className="h-full w-full bg-background" />;
 }


### PR DESCRIPTION
The editor's `readOnly` option was only applied when the editor was created, so a file view restored at startup — mounted before the process has said whether it may write the workspace — stayed read-only for the whole session, and reopening the file revisited that same stuck editor; the option is now applied whenever it changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJH4TrKV59wG7PsnY68Ymb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJH4TrKV59wG7PsnY68Ymb)_